### PR TITLE
feat(itglue): add Document Sections API tools for editing document content

### DIFF
--- a/msp-claude-plugins/kaseya/it-glue/commands/edit-doc-sections.md
+++ b/msp-claude-plugins/kaseya/it-glue/commands/edit-doc-sections.md
@@ -1,0 +1,194 @@
+---
+name: edit-doc-sections
+description: Read, edit, and restructure sections of an IT Glue document
+arguments:
+  - name: document_id
+    description: IT Glue document ID
+    required: true
+  - name: action
+    description: "Action to perform: list, create, update, delete, publish"
+    required: true
+  - name: section_id
+    description: Section ID (required for update and delete)
+    required: false
+  - name: content
+    description: HTML content for the section (required for create and update)
+    required: false
+  - name: section_type
+    description: "Section type: heading or text (default: text)"
+    required: false
+    default: text
+---
+
+# Edit IT Glue Document Sections
+
+Read and edit the sections that make up an IT Glue document's body content.
+
+> **Note:** Use this command to modify document content — `PATCH /documents/:id` with a `content` attribute does not work for multi-section documents.
+
+## Prerequisites
+
+- Valid IT Glue API key configured (`IT_GLUE_API_KEY`)
+- IT Glue region configured (`IT_GLUE_REGION`)
+- Document ID of the target document
+
+## Actions
+
+### list — List All Sections
+
+Show all sections in a document in order.
+
+```
+/edit-doc-sections <document_id> list
+```
+
+**API call:**
+
+```http
+GET /documents/{document_id}/relationships/sections
+x-api-key: YOUR_API_KEY
+```
+
+**Output:**
+
+```
+Document 789 — Sections (3)
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+[1001] Heading  (pos 1)
+  <h2>Overview</h2>
+
+[1002] Text     (pos 2)
+  <p>This procedure covers the steps for setting up a new user...</p>
+
+[1003] Heading  (pos 3)
+  <h2>Prerequisites</h2>
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+### create — Add a New Section
+
+Append a new section to the document.
+
+```
+/edit-doc-sections <document_id> create --content "<p>New content.</p>" --section_type text
+```
+
+**Section types:**
+
+| Value | API type | Description |
+|-------|----------|-------------|
+| `heading` | `Document::Heading` | Heading element |
+| `text` | `Document::Text` | Rich HTML text block |
+
+**API call:**
+
+```http
+POST /documents/{document_id}/relationships/sections
+Content-Type: application/vnd.api+json
+x-api-key: YOUR_API_KEY
+```
+
+```json
+{
+  "data": {
+    "type": "document-sections",
+    "attributes": {
+      "section-type": "Document::Text",
+      "content": "<p>New content.</p>"
+    }
+  }
+}
+```
+
+After creating sections, publish the document with the `publish` action.
+
+### update — Edit an Existing Section
+
+Update the content of a specific section.
+
+```
+/edit-doc-sections <document_id> update --section_id 1002 --content "<p>Updated content.</p>"
+```
+
+**API call:**
+
+```http
+PATCH /documents/{document_id}/relationships/sections/{section_id}
+Content-Type: application/vnd.api+json
+x-api-key: YOUR_API_KEY
+```
+
+```json
+{
+  "data": {
+    "type": "document-sections",
+    "attributes": {
+      "content": "<p>Updated content.</p>"
+    }
+  }
+}
+```
+
+After updating sections, publish the document with the `publish` action.
+
+### delete — Remove a Section
+
+Delete a specific section from the document.
+
+```
+/edit-doc-sections <document_id> delete --section_id 1002
+```
+
+**API call:**
+
+```http
+DELETE /documents/{document_id}/relationships/sections/{section_id}
+x-api-key: YOUR_API_KEY
+```
+
+### publish — Publish the Document
+
+Make all section changes visible. **Always use PATCH — POST returns 404.**
+
+```
+/edit-doc-sections <document_id> publish
+```
+
+**API call:**
+
+```http
+PATCH /documents/{document_id}/publish
+x-api-key: YOUR_API_KEY
+```
+
+## Typical Workflow
+
+To restructure a document to match a template:
+
+```
+1. /edit-doc-sections 789 list
+   → see current sections and their IDs
+
+2. /edit-doc-sections 789 update --section_id 1001 --content "<h2>New Heading</h2>"
+3. /edit-doc-sections 789 update --section_id 1002 --content "<p>Updated body text.</p>"
+
+4. /edit-doc-sections 789 publish
+   → changes are now live in IT Glue
+```
+
+## Error Handling
+
+| Situation | Action |
+|-----------|--------|
+| 404 on publish | Make sure you used PATCH, not POST |
+| 404 on document | Verify the document ID exists |
+| 401 Unauthorized | Check `IT_GLUE_API_KEY` value |
+| Sections not updating | Did you call publish after editing? |
+
+## Related Commands
+
+- `/search-docs` — Find the document ID by name
+- `/find-organization` — Look up the organization owning the document

--- a/msp-claude-plugins/kaseya/it-glue/skills/documents/SKILL.md
+++ b/msp-claude-plugins/kaseya/it-glue/skills/documents/SKILL.md
@@ -141,7 +141,7 @@ x-api-key: YOUR_API_KEY
 }
 ```
 
-### Update Document
+### Update Document Metadata
 
 ```http
 PATCH /documents/789
@@ -154,17 +154,168 @@ x-api-key: YOUR_API_KEY
   "data": {
     "type": "documents",
     "attributes": {
-      "content": "<h1>Updated Content</h1><p>New procedure steps...</p>"
+      "name": "Updated Document Title"
     }
   }
 }
 ```
+
+> **Important:** `PATCH /documents/:id` with a `content` attribute does **not** work for multi-section documents. Use the Document Sections API below instead.
 
 ### Delete Document
 
 ```http
 DELETE /documents/789
 x-api-key: YOUR_API_KEY
+```
+
+## Document Sections API
+
+Use the sections API to read and edit the content of multi-section documents. This is the correct approach for modifying document body content — `PATCH /documents/:id` with a `content` attribute silently fails on multi-section documents.
+
+### Section Types
+
+| Type | Description |
+|------|-------------|
+| `Document::Heading` | Heading element (renders as `<h2>`, etc.) |
+| `Document::Text` | Rich HTML text block |
+
+### List Sections
+
+```http
+GET /documents/789/relationships/sections
+x-api-key: YOUR_API_KEY
+Content-Type: application/vnd.api+json
+```
+
+Response:
+
+```json
+{
+  "data": [
+    {
+      "id": "1001",
+      "type": "document-sections",
+      "attributes": {
+        "content": "<h2>Overview</h2>",
+        "section-type": "Document::Heading",
+        "position": 1
+      }
+    },
+    {
+      "id": "1002",
+      "type": "document-sections",
+      "attributes": {
+        "content": "<p>This procedure covers...</p>",
+        "section-type": "Document::Text",
+        "position": 2
+      }
+    }
+  ]
+}
+```
+
+### Create Section
+
+```http
+POST /documents/789/relationships/sections
+Content-Type: application/vnd.api+json
+x-api-key: YOUR_API_KEY
+```
+
+```json
+{
+  "data": {
+    "type": "document-sections",
+    "attributes": {
+      "section-type": "Document::Text",
+      "content": "<p>New section content here.</p>"
+    }
+  }
+}
+```
+
+### Update Section
+
+```http
+PATCH /documents/789/relationships/sections/1002
+Content-Type: application/vnd.api+json
+x-api-key: YOUR_API_KEY
+```
+
+```json
+{
+  "data": {
+    "type": "document-sections",
+    "attributes": {
+      "content": "<p>Updated HTML content.</p>"
+    }
+  }
+}
+```
+
+### Delete Section
+
+```http
+DELETE /documents/789/relationships/sections/1002
+x-api-key: YOUR_API_KEY
+```
+
+### Publish Document
+
+After editing sections, publish the document to make changes visible. Use **PATCH** — POST returns 404.
+
+```http
+PATCH /documents/789/publish
+x-api-key: YOUR_API_KEY
+```
+
+No request body is required. A successful response is HTTP 200 with the updated document.
+
+### Full Workflow: Restructure a Document
+
+```javascript
+async function restructureDocument(docId, newSections) {
+  // 1. List existing sections
+  const existing = await fetch(
+    `${baseUrl}/documents/${docId}/relationships/sections`,
+    { headers: { 'x-api-key': apiKey } }
+  ).then(r => r.json());
+
+  // 2. Delete all existing sections
+  for (const section of existing.data) {
+    await fetch(
+      `${baseUrl}/documents/${docId}/relationships/sections/${section.id}`,
+      { method: 'DELETE', headers: { 'x-api-key': apiKey } }
+    );
+  }
+
+  // 3. Create new sections in order
+  for (const section of newSections) {
+    await fetch(
+      `${baseUrl}/documents/${docId}/relationships/sections`,
+      {
+        method: 'POST',
+        headers: { 'x-api-key': apiKey, 'Content-Type': 'application/vnd.api+json' },
+        body: JSON.stringify({
+          data: {
+            type: 'document-sections',
+            attributes: {
+              'section-type': section.type,  // 'Document::Heading' or 'Document::Text'
+              content: section.content
+            }
+          }
+        })
+      }
+    );
+  }
+
+  // 4. Publish to make changes visible (must use PATCH, not POST)
+  await fetch(
+    `${baseUrl}/documents/${docId}/publish`,
+    { method: 'PATCH', headers: { 'x-api-key': apiKey } }
+  );
+}
 ```
 
 ### Search Documents
@@ -505,6 +656,7 @@ async function cloneDocumentToOrg(templateDocId, targetOrgId, newName) {
 | 400 | Organization required | Include organization-id |
 | 401 | Invalid API key | Check IT_GLUE_API_KEY |
 | 404 | Document not found | Verify document ID |
+| 404 | POST /publish returns 404 | Use **PATCH** not POST for publish |
 | 422 | Invalid folder | Query valid folder IDs |
 
 ### Validation Errors


### PR DESCRIPTION
## Summary

- Adds full Document Sections API reference to `skills/documents/SKILL.md` — GET/POST/PATCH/DELETE sections + PATCH publish
- Documents the critical gotchas: `PATCH /documents/:id` content attribute silently fails on multi-section docs; publish must use PATCH not POST
- Adds a new `/edit-doc-sections` command covering list, create, update, delete, and publish actions with examples

## Test plan

- [ ] Verify `GET /documents/:id/relationships/sections` returns sections with type and position
- [ ] Verify `POST` creates a new section with `Document::Text` or `Document::Heading` type
- [ ] Verify `PATCH /documents/:id/relationships/sections/:id` updates content
- [ ] Verify `DELETE` removes a section
- [ ] Verify `PATCH /documents/:id/publish` (not POST) publishes changes
- [ ] Confirm all endpoints work on EU server (`api.eu.itglue.com`)

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)