### PR TITLE
fix(ci): Correct typos in auto-add-to-project workflow

### DIFF
--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -1,11 +1,10 @@
 name: Auto-add to Project Board
 
 on:
-  issues
-:
-    types: [aopened]
+  issues:
+    types: [opened]
   pull_request:
-    types: [aopened]
+    types: [opened]
 
 jobs:
   add-to-project:


### PR DESCRIPTION
This PR corrects typos in the  section of the  workflow. Specifically, it changes  to , and  to  for both  and  triggers. This should resolve the workflow failure.