### PR TITLE
feat(docs): add comprehensive prompt bank — 12 production MSP prompts

### DIFF
--- a/msp-claude-plugins/docs/src/data/prompts.ts
+++ b/msp-claude-plugins/docs/src/data/prompts.ts
@@ -1,4 +1,4 @@
-export type PromptRole = 'account' | 'finance' | 'sales' | 'support' | 'noc';
+export type PromptRole = 'account' | 'finance' | 'sales' | 'support' | 'noc' | 'incident' | 'security' | 'documentation' | 'bizops';
 
 export interface Prompt {
   id: string;
@@ -11,22 +11,30 @@ export interface Prompt {
 }
 
 export const roleLabels: Record<PromptRole, string> = {
-  account:  'Account Management',
-  finance:  'Finance & Billing',
-  sales:    'Sales & Growth',
-  support:  'Support & Helpdesk',
-  noc:      'NOC & Engineering',
+  account:       'Account Management',
+  finance:       'Finance & Billing',
+  sales:         'Sales & Growth',
+  support:       'Support & Helpdesk',
+  noc:           'NOC & Engineering',
+  incident:      'Incident Response',
+  security:      'Security Operations',
+  documentation: 'Documentation',
+  bizops:        'Business Operations',
 };
 
 export const roleDescriptions: Record<PromptRole, string> = {
-  account:  'QBRs, client health reports, executive summaries, and relationship management.',
-  finance:  'Billing reconciliation, unbilled work, contract compliance, and aged receivables.',
-  sales:    'Growth opportunities, device refresh cycles, at-risk clients, and upsell intelligence.',
-  support:  'Ticket triage, SLA tracking, escalation reviews, and shift handoffs.',
-  noc:      'Infrastructure health, patch status, alert correlation, and maintenance coordination.',
+  account:       'QBRs, client health reports, executive summaries, and relationship management.',
+  finance:       'Billing reconciliation, unbilled work, contract compliance, and aged receivables.',
+  sales:         'Growth opportunities, device refresh cycles, at-risk clients, and upsell intelligence.',
+  support:       'Ticket triage, SLA tracking, escalation reviews, and shift handoffs.',
+  noc:           'Infrastructure health, patch status, alert correlation, and maintenance coordination.',
+  incident:      'P1 war rooms, post-incident reviews, client communications, and timeline reconstruction.',
+  security:      'Account compromise triage, endpoint investigation, phishing intel, and threat hunting.',
+  documentation: 'Doc audits, runbook generation, asset discovery, and password rotation tracking.',
+  bizops:        'QBR data, contract renewals, license waste analysis, and executive reporting.',
 };
 
-export const roleOrder: PromptRole[] = ['account', 'finance', 'sales', 'support', 'noc'];
+export const roleOrder: PromptRole[] = ['account', 'finance', 'sales', 'support', 'noc', 'incident', 'security', 'documentation', 'bizops'];
 
 export const prompts: Prompt[] = [
 
@@ -591,6 +599,390 @@ Cover:
 - Any recommended improvements or upcoming threats to be aware of
 
 Frame it as value delivered: "we blocked X attacks this quarter that could have cost you Y." Keep the language accessible for non-technical executives.`,
+  },
+
+  // ── Incident Response ─────────────────────────────────────────────
+
+  {
+    id: 'incident-p1-war-room',
+    role: 'incident',
+    title: 'P1 War Room Kickoff',
+    description: 'Immediately pull all context for a live P1 incident: alerts, ticket, on-call, and a 2-hour timeline.',
+    plugins: ['pagerduty', 'betterstack', 'rootly'],
+    mcpServers: ['autotask', 'halopsa', 'connectwise-manage', 'ninjaone', 'datto-rmm'],
+    prompt: `I have a [SEVERITY, e.g. P1 / Critical] incident at [CLIENT NAME]. [SYSTEM OR SERVICE] is down affecting approximately [NUMBER] users.
+
+Use the available tools to do the following right now:
+
+1. Pull all active alerts and monitoring events for [CLIENT NAME] from the last 2 hours — list them chronologically
+2. Check for any existing open tickets related to this issue and link them; if none exist, open a P1 ticket with the title "[CLIENT NAME] – [SYSTEM] Outage" and set priority to Critical
+3. Identify the on-call engineer currently assigned and their contact details
+4. Build a timeline of events starting 2 hours ago: alert fires, ticket opens, tech activity, any config changes or deployments if visible
+5. Give me your best current hypothesis for root cause based on what you can see
+
+Format the output as a war room brief — I'm sharing this in a Slack channel right now.
+
+Variation — if you know the affected service:
+Replace "[SYSTEM OR SERVICE] is down" with the specific service, e.g. "The VPN concentrator at their main office is unreachable" or "Microsoft 365 Exchange Online is returning 503s for all users."`,
+  },
+
+  {
+    id: 'incident-pir-from-ticket',
+    role: 'incident',
+    title: 'Post-Incident Review from Ticket History',
+    description: 'Generate a structured PIR document from a resolved incident ticket and its notes.',
+    plugins: ['pagerduty', 'betterstack', 'rootly'],
+    mcpServers: ['autotask', 'halopsa', 'connectwise-manage'],
+    prompt: `Generate a post-incident review (PIR) for the incident documented in ticket [TICKET NUMBER] (or the most recent resolved P1/Critical ticket for [CLIENT NAME] if no ticket number is known).
+
+Pull the full ticket history — all notes, time entries, and status changes — and structure the PIR as follows:
+
+**1. Incident Summary**
+What happened, what was the business impact, and how long did it last (detection to resolution)?
+
+**2. Timeline**
+A bullet-point chronology from first alert/report through to confirmed resolution. Include timestamps.
+
+**3. Root Cause**
+What was the actual underlying cause? Be specific — not "server was down" but why it was down.
+
+**4. Contributing Factors**
+What made the incident worse or delayed our response? (monitoring gaps, escalation delays, missing runbooks, etc.)
+
+**5. What Went Well**
+At least 2-3 things the team did right during the response.
+
+**6. Action Items**
+Specific tasks to prevent recurrence or improve response time. For each: description, owner (assign to [YOUR NAME] if unspecified), and a due date 2 weeks from today.
+
+Keep the tone blameless. This document will be shared with the client.
+
+Variation — multi-system incident:
+Add a "Scope" section listing all affected systems, services, and user counts before the Timeline.`,
+  },
+
+  {
+    id: 'incident-client-communication',
+    role: 'incident',
+    title: 'Incident Client Communication Draft',
+    description: 'Draft an executive-facing incident update for a client — clear, calm, and action-oriented.',
+    plugins: [],
+    mcpServers: ['autotask', 'halopsa', 'connectwise-manage'],
+    prompt: `Draft a client-facing incident communication for [CLIENT NAME] regarding the [SYSTEM/SERVICE] issue that [started at TIME / is currently ongoing / was resolved at TIME].
+
+The audience is their [CTO / IT Director / Executive team] — assume they are not technical. Do not use internal jargon.
+
+The message should:
+- Acknowledge the issue and its impact on their business clearly (no minimising)
+- State the current status: [investigating / identified and implementing fix / resolved]
+- Explain what we know so far in plain language (1-2 sentences max on technical detail)
+- Describe what we are doing right now
+- Give a realistic next update time: [TIME or "within X hours"]
+- End with a direct contact name and number for urgent escalation
+
+Tone: professional, calm, and accountable. We own this — no blaming the vendor unless explicitly directed.
+
+Pull any relevant details from the open ticket for [CLIENT NAME] to populate specifics.
+
+Variation — resolved incident update:
+Change the status to resolved and include: actual resolution time, root cause in one sentence, and what we are doing to prevent recurrence.`,
+  },
+
+  // ── Security Operations ───────────────────────────────────────────
+
+  {
+    id: 'security-account-compromise-triage',
+    role: 'security',
+    title: 'Suspicious User Activity Triage',
+    description: 'Investigate a risk alert for a user — sign-in history, MFA changes, forwarding rules, and compromise verdict.',
+    plugins: ['sentinelone'],
+    mcpServers: ['sentinelone'],
+    prompt: `User [USER EMAIL ADDRESS] at [CLIENT NAME] just triggered a risk alert. I need to determine if this is account compromise.
+
+Use available tools to pull the following:
+
+1. **Sign-in history** — last 7 days of authentication events: location, IP, device, and whether MFA was satisfied. Flag any sign-ins from new countries, anonymous IPs, or unusual times.
+2. **MFA changes** — any MFA method additions, removals, or phone number changes in the last 7 days
+3. **Email forwarding rules** — check for any inbox forwarding rules created recently, especially to external addresses
+4. **Email delegation** — any recently added mailbox delegates
+5. **Recent email activity** — any bulk send/delete activity in the last 48 hours
+6. **Device compliance** — is their primary device compliant and managed? Any new device registrations?
+
+After pulling the data, give me a verdict:
+- **Likely compromised**: list the specific indicators and recommend immediate actions (password reset, MFA re-enrol, session revoke, ticket open)
+- **Suspicious but inconclusive**: list what's unusual and what additional steps to take
+- **False positive**: explain why
+
+If you assess compromise as likely, draft the first response ticket note I should post.
+
+Variation — no email security tool connected:
+Focus on sign-in logs and MFA changes only, and note that email forwarding check requires manual review in M365 admin.`,
+  },
+
+  {
+    id: 'security-endpoint-compromise-triage',
+    role: 'security',
+    title: 'Endpoint Compromise Triage',
+    description: 'Pull all security signals for a specific device — EDR alerts, patch status, network activity, and risk verdict.',
+    plugins: ['sentinelone'],
+    mcpServers: ['sentinelone', 'ninjaone', 'datto-rmm', 'connectwise-automate'],
+    prompt: `I need to triage a potentially compromised endpoint. Device: [DEVICE NAME or HOSTNAME] at [CLIENT NAME].
+
+Pull every available signal for this device:
+
+1. **EDR alerts** — any active or recent threats, detections, or quarantined files from SentinelOne or equivalent. Include severity and current status.
+2. **RMM status** — is the device online? Last check-in time? Any active alerts in the RMM?
+3. **Patch status** — is the device current on OS and third-party patches? How many critical patches are missing?
+4. **Running processes / script execution** — any recent script runs or remote commands executed on this device (from RMM history)?
+5. **Network isolation status** — is the device currently network-isolated? If not, should it be?
+6. **Open tickets** — any existing tickets for this device in the last 30 days
+
+After gathering the data:
+- Rate the risk: **Critical / High / Medium / Low**
+- List the top indicators driving your assessment
+- Recommend the immediate next steps (isolate, remediate, monitor, close)
+- Draft the internal ticket note to document the triage findings
+
+If the device should be isolated, remind me to get client approval before doing so — unless a critical threat is actively executing.
+
+Variation — server triage:
+Add "Check for any scheduled tasks or services added in the last 72 hours" and treat network isolation as a last resort given potential service impact.`,
+  },
+
+  {
+    id: 'security-phishing-investigation',
+    role: 'security',
+    title: 'Phishing Email Full Investigation',
+    description: 'Given a reported phish, gather all available intel — delivery scope, click activity, credential exposure, and remediation.',
+    plugins: ['proofpoint', 'avanan', 'abnormal', 'ironscales', 'knowbe4'],
+    mcpServers: ['proofpoint', 'avanan', 'abnormal', 'ironscales', 'knowbe4'],
+    prompt: `I need to fully investigate a reported phishing email at [CLIENT NAME].
+
+Known details:
+- Reported by: [USER EMAIL]
+- Subject line: [SUBJECT LINE if known]
+- Sender address: [SENDER ADDRESS if known]
+- Approximate time received: [DATE / TIME if known]
+
+Work through the following investigation steps:
+
+1. **Locate the email** — find it in the email security platform by sender, subject, or time window
+2. **Blast radius** — identify every mailbox at [CLIENT NAME] (and across all clients if the platform supports cross-tenant search) that received this email or a variant of it
+3. **Interaction check** — for each recipient, determine: did they open it? Click any links? Download an attachment?
+4. **Link / attachment analysis** — what do the URLs or files resolve to? Any known malicious indicators?
+5. **Credential exposure** — if any user clicked a link to a credential-harvest page, flag them for immediate password reset
+6. **Threat intel** — is this part of a known campaign? Any IOCs (sender IP, domain, hash) in threat intel feeds?
+7. **Remaining copies** — list every mailbox that still has a copy of the email (for quarantine/deletion)
+
+End with a prioritised remediation checklist:
+- [ ] Accounts to lock/reset (list them)
+- [ ] Mailboxes to remediate (list them)
+- [ ] Allowlist/blocklist rules to create
+- [ ] User notifications to send
+- [ ] Ticket to open (draft the title and description)
+
+Variation — internal phishing simulation:
+If the email turns out to be a KnowBe4 or similar security awareness simulation, note the click rate and flag users who clicked for training follow-up instead of remediation.`,
+  },
+
+  // ── Documentation ─────────────────────────────────────────────────
+
+  {
+    id: 'docs-completeness-audit',
+    role: 'documentation',
+    title: 'Documentation Completeness Audit',
+    description: 'Find active devices with no runbook, stale passwords, and undocumented services in IT Glue or Hudu.',
+    plugins: ['it-glue', 'hudu'],
+    mcpServers: ['itglue', 'hudu', 'ninjaone', 'datto-rmm', 'connectwise-automate'],
+    prompt: `Run a documentation audit for [CLIENT NAME] (or all clients if not specified).
+
+Cross-reference the RMM's device inventory against the documentation platform and flag gaps:
+
+1. **Missing runbooks / configurations** — devices or services that are active and monitored in the RMM but have no corresponding configuration record or runbook in IT Glue / Hudu. List: device name, device type, and how long it's been active.
+
+2. **Stale passwords** — any passwords stored in the documentation platform that haven't been rotated in 90 or more days. Include: password title, last rotated date, and associated asset or service.
+
+3. **Undocumented network devices** — switches, firewalls, or APs visible in the RMM that have no documentation entry
+
+4. **Missing contacts** — client contacts in the PSA with no corresponding entry in the documentation platform (gaps in the contact list)
+
+5. **Expired SSL certificates or licenses** — any documented items with an expiry date that has passed or is within 30 days
+
+Produce a prioritised gap list. Rate each gap: **Critical** (passwords, active servers), **High** (network devices, key services), or **Medium** (workstations, nice-to-have docs). Suggest which gaps to close first.
+
+Variation — new client onboarding:
+Run this immediately after onboarding discovery is complete to generate the documentation work backlog for the first 30 days.`,
+  },
+
+  {
+    id: 'docs-runbook-generator',
+    role: 'documentation',
+    title: 'Runbook Generator',
+    description: 'Generate a structured runbook for a device or service using data already in the RMM and documentation platform.',
+    plugins: ['it-glue', 'hudu'],
+    mcpServers: ['itglue', 'hudu', 'ninjaone', 'datto-rmm', 'connectwise-automate'],
+    prompt: `Generate a runbook for [DEVICE NAME / SERVICE NAME] at [CLIENT NAME].
+
+Pull all available data from the RMM and documentation platform to populate the runbook, then structure it as follows:
+
+**Overview**
+- Device / service name, type, and purpose
+- Client and physical or logical location
+- Criticality: [Mission Critical / Important / Standard] — infer from device type and ticket history if not specified
+
+**Access & Credentials**
+- Primary access method (RDP, SSH, web console, etc.)
+- Credential references (link to IT Glue / Hudu password entries — do not include actual passwords in the runbook)
+- MFA or jump host requirements
+
+**Key Details**
+- IP address(es), hostnames, relevant ports
+- OS, firmware, or application version
+- Licensing or warranty expiry if known
+
+**Monitoring**
+- What monitors are configured for this device/service in the RMM?
+- What alerts should a tech expect to see, and what do they mean?
+
+**Common Issues & Fixes**
+- List up to 5 common issues found in the ticket history for this device (pull from PSA if connected)
+- For each: symptom, likely cause, resolution steps
+
+**Maintenance Schedule**
+- Patching cadence, restart windows, backup schedule if known
+
+**Escalation Path**
+- Who to contact if this device/service fails after hours
+- Vendor support details if applicable
+
+After generating, tell me which sections you had to leave blank due to missing data — those are documentation gaps to fill in.`,
+  },
+
+  {
+    id: 'docs-asset-discovery-summary',
+    role: 'documentation',
+    title: 'Asset Discovery Summary',
+    description: 'Summarise undocumented assets discovered by the RMM that need to be reviewed and added to the documentation platform.',
+    plugins: ['it-glue', 'hudu'],
+    mcpServers: ['itglue', 'hudu', 'ninjaone', 'datto-rmm', 'connectwise-automate', 'liongard'],
+    prompt: `Perform an asset discovery summary for [CLIENT NAME].
+
+I need to understand what's in their environment and what is or isn't documented.
+
+1. **Full device inventory** — pull every device currently reporting into the RMM. For each: name, type (workstation / server / network / other), OS, last seen, and online/offline status.
+
+2. **Documentation coverage** — for each device, check whether a matching record exists in IT Glue / Hudu. Flag devices with no documentation record.
+
+3. **Shadow IT / unexpected devices** — flag any devices that don't match the expected naming convention, have an unknown device type, or appear to have been added recently without a corresponding ticket.
+
+4. **End-of-life OS** — list any devices running an OS that is past Microsoft or Apple's end-of-support date (Windows 10 21H2 and earlier, Windows Server 2012 and earlier, macOS Ventura and earlier).
+
+5. **Unmanaged devices** — if Liongard is connected, check for systems detected during inspector runs that are not in the RMM agent inventory (e.g., network devices with no agent).
+
+Produce:
+- A summary table of the full inventory with documentation coverage percentage
+- A "needs action" list sorted by risk: EOL devices first, then undocumented servers, then undocumented workstations
+- Recommended next steps to close coverage gaps
+
+Variation — post-M&A or site acquisition:
+Use this prompt immediately after taking on a new site to generate the baseline discovery report before the first QBR.`,
+  },
+
+  // ── Business Operations ───────────────────────────────────────────
+
+  {
+    id: 'bizops-qbr-data-pull',
+    role: 'bizops',
+    title: 'QBR Data Pull',
+    description: 'Pull all quantitative data needed for a client QBR — tickets, SLAs, devices, alerts, and trends.',
+    plugins: [],
+    mcpServers: ['autotask', 'halopsa', 'connectwise-manage', 'ninjaone', 'datto-rmm', 'atera'],
+    prompt: `Pull all the data I need to prepare a QBR for [CLIENT NAME] covering the period [START DATE] to [END DATE, e.g. "January 1 – March 31 2025"].
+
+From the PSA:
+- Total tickets opened and closed in the period
+- Ticket breakdown by category (hardware, software, network, user error, security, other)
+- SLA compliance rate: % of tickets resolved within SLA, and total breach count
+- Average time to first response and average time to resolution
+- Top 5 ticket categories by volume
+- Open tickets at the end of the period (carryover)
+- Any critical or P1 incidents — title, date, and resolution time
+
+From the RMM (if connected):
+- Total managed device count at start and end of period (growth?)
+- Devices with persistent alerts or recurring issues
+- Patch compliance rate at end of period
+- Any devices that went offline for more than 4 hours during the period
+
+Formatting:
+- Present numbers in a clear table where possible
+- Highlight improvements vs the previous period if prior data is available
+- Flag any metrics that are worse than industry benchmarks (SLA <95%, patch compliance <90%)
+
+I'll use this raw data to build the QBR deck — just get me the numbers.
+
+Variation — multi-client QBR data:
+Run for all clients and sort results by SLA compliance rate ascending (worst performers first) so I can prioritise conversations.`,
+  },
+
+  {
+    id: 'bizops-contract-renewal-review',
+    role: 'bizops',
+    title: 'Contract Renewal Review',
+    description: 'Surface upcoming contract renewals, flag underpriced agreements, and recommend pricing updates.',
+    plugins: ['autotask', 'halopsa', 'connectwise-psa'],
+    mcpServers: ['autotask', 'halopsa', 'connectwise-manage'],
+    prompt: `Review all managed services contracts that are due for renewal in the next [TIMEFRAME, e.g. 90 days].
+
+For each contract:
+1. **Renewal date and contract value** — current MRR or ARR, renewal date, and auto-renewal status
+2. **Device count drift** — compare contracted device count to actual devices currently managed in the RMM. Flag any contracts where we are managing significantly more (or fewer) devices than contracted.
+3. **Hours consumption** — for block-hour or capped plans, what was the average monthly consumption vs included hours over the contract term? Are we consistently over or under?
+4. **Profitability signals** — which contracts had high ticket volume relative to their revenue? Flag contracts where ticket volume was more than 20% above the portfolio average per device.
+5. **Pricing age** — how long since this contract was last repriced? Flag any contracts that haven't had a rate increase in 24+ months.
+
+For each contract that has a flag, suggest a renewal recommendation:
+- **Increase MRR**: by how much, and the justification
+- **Renegotiate scope**: what to add or remove
+- **Renew as-is**: if the contract is well-balanced
+
+Sort by renewal date ascending. I'm using this for my renewal pipeline planning.
+
+Variation — single client:
+Run for [CLIENT NAME] only and include full contract history for context.`,
+  },
+
+  {
+    id: 'bizops-license-waste-finder',
+    role: 'bizops',
+    title: 'License Waste Finder',
+    description: 'Identify unused M365 seats and other SaaS licenses across a client tenant to find cost savings.',
+    plugins: [],
+    mcpServers: ['autotask', 'halopsa', 'connectwise-manage'],
+    prompt: `Identify unused or wasted software licenses for [CLIENT NAME] so we can surface a cost savings opportunity.
+
+Check the following (use connected tools for what's available; note which checks require manual review):
+
+**Microsoft 365**
+- Total licensed seats vs active users (users who have signed in within the last 30 days)
+- Licenses assigned to terminated or disabled accounts
+- Licenses assigned to shared mailboxes or room resources that could be downgraded
+- Users on E3/E5 plans who are only using Exchange and Teams (potential downgrade to M365 Business Basic/Standard)
+- Any Microsoft add-on licenses (Intune, Defender, PowerBI) with zero recent usage
+
+**Other SaaS / recurring software** (from PSA contract or documentation platform if available):
+- Any software licenses that appear in contracts but have no matching active user or device in the RMM
+- Renewals coming up for tools that may no longer be in use (flag for client conversation)
+
+**Output format:**
+- For each waste category: list the license type, count of wasted seats, estimated monthly savings at current rate
+- Total estimated monthly savings if all waste is reclaimed
+- Recommended action for each item (remove, downgrade, reassign, or verify with client)
+
+Note: actual savings depend on contract terms — flag any that require vendor negotiation vs immediate self-serve changes.
+
+Variation — run across all clients:
+Generate a portfolio-wide license waste report sorted by estimated savings descending. Use this to prioritise client conversations.`,
   },
 
 ];

--- a/msp-claude-plugins/docs/src/pages/prompts/index.astro
+++ b/msp-claude-plugins/docs/src/pages/prompts/index.astro
@@ -7,11 +7,15 @@ import { mcpServers } from '@/data/mcp-servers';
 const baseUrl = import.meta.env.BASE_URL;
 
 const roleIcons: Record<string, string> = {
-  account: '🤝',
-  finance:  '💰',
-  sales:    '📈',
-  support:  '🎧',
-  noc:      '🖥️',
+  account:       '🤝',
+  finance:       '💰',
+  sales:         '📈',
+  support:       '🎧',
+  noc:           '🖥️',
+  incident:      '🚨',
+  security:      '🔐',
+  documentation: '📋',
+  bizops:        '📊',
 };
 
 function getPluginLabel(id: string): string {


### PR DESCRIPTION
## Summary

Populates the existing (empty) `prompts/` section of the docs site with 12 production-quality, copy-pasteable prompts for MSP technicians. Built data-driven, matching the existing site architecture exactly.

**Categories:**
- **Incident Response** — P1 war room kickoff, post-incident review, client communication draft
- **Security Operations** — suspicious user/account compromise triage, endpoint compromise triage, phishing investigation
- **Documentation** — doc completeness audit, runbook generator, asset discovery summary
- **Business Operations** — QBR data pull, contract renewal review, license waste finder

Each prompt includes `[VARIABLE]` placeholders, required plugins/tools, expected output description, and scenario variations.

## Test plan

- [ ] Docs site builds clean (`npm run build` — 0 errors)
- [ ] Prompts page renders all 4 categories
- [ ] Copy-paste a prompt into Claude with the relevant plugin loaded and verify it produces useful output