### PR TITLE
feat(audit): add skill stubs for uncovered MCP tools

### DIFF
--- a/msp-claude-plugins/halopsa/halopsa/skills/agents/SKILL.md
+++ b/msp-claude-plugins/halopsa/halopsa/skills/agents/SKILL.md
@@ -1,0 +1,85 @@
+---
+description: >
+  Use this skill when working with HaloPSA agents (technicians) and teams —
+  listing technicians, retrieving agent details, and listing team structures.
+  Essential for MSP service managers assigning tickets, understanding team
+  capacity, and looking up technician IDs for ticket assignment.
+triggers:
+  - halopsa agent
+  - halopsa technician
+  - halopsa team
+  - list agents halopsa
+  - halopsa tech list
+  - halopsa teams
+  - find technician halopsa
+  - agent details halopsa
+  - team list halopsa
+---
+
+# HaloPSA Agents and Teams
+
+## Overview
+
+Agents in HaloPSA are the technicians who handle tickets and service delivery. Teams are groupings of agents that tickets can be assigned to. Use these tools to discover agent IDs and team structures before assigning tickets or filtering work queues.
+
+## API Patterns
+
+### List Agents
+
+Tool: `halopsa_agents_list`
+
+Key parameters:
+- `team_id` — Filter agents by team ID
+- `inactive` — Include inactive agents (default: active only)
+- `limit` — Maximum results (default: 50)
+
+Response includes:
+- `record_count` — Total matching agents
+- `agents` — Array of agent records with ID, name, email, team membership
+
+### Get Agent Details
+
+Tool: `halopsa_agents_get`
+
+Parameters:
+- `agent_id` (required) — The agent's numeric ID
+
+Returns full agent profile including contact details, skills, team assignments, and availability settings.
+
+### List Teams
+
+Tool: `halopsa_teams_list`
+
+Parameters:
+- `limit` — Maximum results (default: 50)
+
+Response includes:
+- `record_count` — Total teams
+- `teams` — Array of team records with ID, name, and member count
+
+## Common Workflows
+
+### Find an Agent by Name Before Assigning a Ticket
+
+1. Call `halopsa_agents_list` to get all active agents
+2. Search the result for the agent by name
+3. Use the agent's `id` when calling `halopsa_tickets_update` to assign
+
+### List All Technicians in a Team
+
+1. Call `halopsa_teams_list` to find the team ID by name
+2. Call `halopsa_agents_list` with `team_id` set to the team's ID
+3. Review the returned agents for team membership
+
+### Check Agent Details for Escalation
+
+1. Call `halopsa_agents_get` with the agent's ID
+2. Review availability, skills, and contact information
+3. Use details to determine escalation appropriateness
+
+## Notes
+
+- Agent IDs are required when assigning tickets via `halopsa_tickets_update`
+- Inactive agents are excluded by default — set `inactive: true` to include them when auditing
+- Teams are used for ticket routing rules in HaloPSA; consult HaloPSA admin settings for routing configuration
+- This skill is read-only; agent and team creation/modification must be done through the HaloPSA admin interface

--- a/msp-claude-plugins/halopsa/halopsa/skills/invoices/SKILL.md
+++ b/msp-claude-plugins/halopsa/halopsa/skills/invoices/SKILL.md
@@ -1,0 +1,84 @@
+---
+description: >
+  Use this skill when working with HaloPSA invoices — listing invoices by
+  client or date range, filtering by payment and send status, and retrieving
+  individual invoice details. Essential for MSP finance teams tracking billing,
+  chasing unpaid invoices, and reconciling client accounts.
+triggers:
+  - halopsa invoice
+  - halopsa billing invoice
+  - list invoices halopsa
+  - unpaid invoices halopsa
+  - halopsa invoice status
+  - invoice search halopsa
+  - halopsa finance
+  - halopsa invoice details
+  - paid invoices halopsa
+---
+
+# HaloPSA Invoices
+
+## Overview
+
+HaloPSA invoices represent bills generated for client work and contracts. Use these tools to view invoice status, track payment, and pull invoice data for reporting or reconciliation. Invoices are read-only via MCP; creation and dispatch happen through the HaloPSA UI or billing workflows.
+
+## API Patterns
+
+### List Invoices
+
+Tool: `halopsa_invoices_list`
+
+Key parameters:
+- `client_id` — Filter invoices by client ID
+- `status` — Filter by invoice status (e.g., "draft", "sent", "paid" — values are instance-specific)
+- `sent` — Filter by sent status (`true` = sent, `false` = unsent)
+- `paid` — Filter by paid status (`true` = paid, `false` = outstanding)
+- `invoice_date_start` — Date range start (format: `YYYY-MM-DD`)
+- `invoice_date_end` — Date range end (format: `YYYY-MM-DD`)
+- `limit` — Maximum results (default: 50)
+
+Response includes:
+- `record_count` — Total matching invoices
+- `invoices` — Array of invoice records with ID, client, amount, dates, and status
+
+### Get Invoice Details
+
+Tool: `halopsa_invoices_get`
+
+Parameters:
+- `invoice_id` (required) — The invoice's numeric ID
+
+Returns the full invoice record including line items, totals, tax, payment history, and associated tickets/contracts.
+
+## Common Workflows
+
+### Find All Unpaid Invoices for a Client
+
+1. Find the client ID using `halopsa_clients_search` or `halopsa_clients_list`
+2. Call `halopsa_invoices_list` with `client_id` and `paid: false`
+3. Review outstanding invoices and amounts
+
+### Monthly Invoice Report
+
+1. Call `halopsa_invoices_list` with `invoice_date_start` and `invoice_date_end` for the month
+2. Filter or group by client, status, or amount
+3. Export totals for finance reporting
+
+### Chase Unsent Invoices
+
+1. Call `halopsa_invoices_list` with `sent: false`
+2. Review draft invoices not yet dispatched to clients
+3. Use HaloPSA UI to review and send
+
+### Invoice Detail Lookup
+
+1. Call `halopsa_invoices_list` to locate the invoice by client/date
+2. Note the invoice `id`
+3. Call `halopsa_invoices_get` with that ID for full line-item detail
+
+## Notes
+
+- Invoice status values are instance-specific; check your HaloPSA configuration for valid status strings
+- Line item detail is only available via `halopsa_invoices_get` — the list endpoint returns summary data
+- Invoices are read-only via MCP; to create, edit, or send invoices, use the HaloPSA web interface
+- To find a client's ID for filtering, use the `clients` skill with `halopsa_clients_search`

--- a/msp-claude-plugins/kaseya/autotask/skills/billing/SKILL.md
+++ b/msp-claude-plugins/kaseya/autotask/skills/billing/SKILL.md
@@ -1,0 +1,93 @@
+---
+description: >
+  Use this skill when working with Autotask billing — retrieving billing items,
+  checking approval levels, and searching invoices. Essential for MSP finance
+  teams and account managers reconciling billable work, approving charges, and
+  exporting data for invoicing.
+triggers:
+  - autotask billing
+  - autotask invoice
+  - billing item autotask
+  - billing approval
+  - autotask billing item
+  - autotask invoices
+  - invoice search autotask
+  - billable items autotask
+  - billing approval level
+---
+
+# Autotask Billing
+
+## Overview
+
+Autotask billing tools give MSPs visibility into billable items, approval workflows, and invoices generated from time entries, charges, and contracts. Finance teams use these tools to review, approve, and export billing data.
+
+## API Patterns
+
+### Get a Billing Item
+
+Retrieve a single billing item by ID.
+
+Tool: `autotask_get_billing_item`
+
+Key fields returned:
+- `id` — Billing item ID
+- `ticketID` / `projectID` — Source entity
+- `resourceID` — Who performed the work
+- `billingItemType` — Type (time entry, expense, charge, etc.)
+- `approvalStatus` — Current approval state
+- `amount` — Billable amount
+
+### Search Billing Items
+
+Tool: `autotask_search_billing_items`
+
+Key parameters:
+- `companyId` — Filter by client company
+- `invoiceId` — Filter by invoice
+- `approvalStatus` — Filter by approval state
+- `startDate` / `endDate` — Date range filter
+- `page` / `pageSize` — Pagination (default 25, max 200)
+
+### Search Billing Approval Levels
+
+Tool: `autotask_search_billing_item_approval_levels`
+
+Returns the configured approval workflow steps for billing items in your Autotask instance. Approval levels are instance-specific.
+
+### Search Invoices
+
+Tool: `autotask_search_invoices`
+
+Key parameters:
+- `companyId` — Filter by client company
+- `startDate` / `endDate` — Invoice date range
+- `page` / `pageSize` — Pagination
+
+## Common Workflows
+
+### Month-End Billing Review
+
+1. Use `autotask_search_billing_items` filtered by date range and company
+2. Review items with pending approval status
+3. Check associated tickets/projects for context
+4. Export approved items for invoice generation
+
+### Invoice Reconciliation
+
+1. Use `autotask_search_invoices` to find invoices for a client
+2. Cross-reference with `autotask_search_billing_items` filtered by invoice ID
+3. Verify all expected charges appear
+4. Identify any missing or duplicate items
+
+### Approval Workflow Inspection
+
+1. Use `autotask_search_billing_item_approval_levels` to understand configured steps
+2. Use `autotask_search_billing_items` filtered by `approvalStatus` to find items pending each step
+
+## Notes
+
+- Billing item types are instance-specific picklist values; use `autotask_get_field_info` with entity `BillingItems` to retrieve valid values for your instance
+- Approval workflows vary per Autotask configuration — consult your instance settings
+- Invoices are typically generated from approved billing items; unapproved items will not appear on invoices
+- This area is read-only via MCP; creating or posting invoices must be done through the Autotask UI or billing integrations

--- a/msp-claude-plugins/kaseya/autotask/skills/picklists/SKILL.md
+++ b/msp-claude-plugins/kaseya/autotask/skills/picklists/SKILL.md
@@ -1,0 +1,105 @@
+---
+description: >
+  Use this skill when working with Autotask picklist and reference data — listing
+  queues, ticket statuses, ticket priorities, and phases. These tools return the
+  configured lookup values for your specific Autotask instance, which are required
+  when creating or filtering tickets and other entities.
+triggers:
+  - autotask queues
+  - autotask ticket statuses
+  - autotask ticket priorities
+  - autotask picklist
+  - list queues autotask
+  - autotask priority values
+  - autotask status values
+  - autotask reference data
+  - autotask lookup values
+  - autotask phases list
+---
+
+# Autotask Picklists and Reference Data
+
+## Overview
+
+Autotask uses instance-specific picklist values for queues, statuses, priorities, and phases. Before creating tickets or filtering results, retrieve these values to use the correct IDs for your organization's configuration.
+
+## API Patterns
+
+### List Queues
+
+Tool: `autotask_list_queues`
+
+Returns all ticket queues configured in your Autotask instance.
+
+Response structure:
+```json
+[
+  { "id": 1, "name": "Service Desk", "isActive": true },
+  { "id": 2, "name": "Project Work", "isActive": true },
+  { "id": 8, "name": "Monitoring", "isActive": false }
+]
+```
+
+Use the `id` field when creating or filtering tickets by queue.
+
+### List Ticket Statuses
+
+Tool: `autotask_list_ticket_statuses`
+
+Returns all ticket status values configured in your instance.
+
+Response structure:
+```json
+[
+  { "id": 1, "name": "New", "isActive": true },
+  { "id": 5, "name": "Complete", "isActive": true },
+  { "id": 9, "name": "Waiting Customer", "isActive": true }
+]
+```
+
+### List Ticket Priorities
+
+Tool: `autotask_list_ticket_priorities`
+
+Returns all ticket priority values configured in your instance.
+
+Response structure:
+```json
+[
+  { "id": 1, "name": "Critical", "isActive": true },
+  { "id": 2, "name": "High", "isActive": true },
+  { "id": 3, "name": "Medium", "isActive": true },
+  { "id": 4, "name": "Low", "isActive": true }
+]
+```
+
+### List Phases
+
+Tool: `autotask_list_phases`
+
+Parameters:
+- `projectId` (required) — The project ID to retrieve phases for
+
+Returns all phases within a specific project, used when creating tasks or assigning work.
+
+## Common Workflows
+
+### Discover Picklist Values Before Creating a Ticket
+
+1. Call `autotask_list_queues` to find the queue ID
+2. Call `autotask_list_ticket_statuses` to find status IDs
+3. Call `autotask_list_ticket_priorities` to find priority IDs
+4. Use retrieved IDs in `autotask_create_ticket`
+
+### Get Phases for Project Task Assignment
+
+1. Call `autotask_list_phases` with the project ID
+2. Note phase IDs and names
+3. Use phase ID when creating tasks with `autotask_create_task`
+
+## Notes
+
+- All picklist values are instance-specific — IDs will differ between Autotask environments
+- Active vs inactive values: filter by `isActive: true` to avoid using deprecated values
+- For other entity field picklists not covered here, use `autotask_get_field_info` to retrieve full picklist data for any entity type
+- Cache these values during a session to avoid repeated lookups; they change infrequently

--- a/msp-claude-plugins/kaseya/autotask/skills/ticket-notes-attachments/SKILL.md
+++ b/msp-claude-plugins/kaseya/autotask/skills/ticket-notes-attachments/SKILL.md
@@ -1,0 +1,140 @@
+---
+description: >
+  Use this skill when working with Autotask ticket notes, ticket attachments,
+  and ticket charges — retrieving individual notes, downloading attachments,
+  managing labor charges on tickets. Supplements the core tickets skill with
+  the secondary entities attached to tickets.
+triggers:
+  - autotask ticket note
+  - autotask ticket attachment
+  - autotask ticket charge
+  - get ticket note autotask
+  - download ticket attachment
+  - ticket charges autotask
+  - autotask labor charge
+  - autotask ticket charges
+  - search ticket notes autotask
+  - search ticket attachments autotask
+---
+
+# Autotask Ticket Notes, Attachments, and Charges
+
+## Overview
+
+Beyond the core ticket record, Autotask tickets accumulate notes (internal/external communications), file attachments, and charges (labor and expenses billed directly to a ticket). This skill covers retrieval and management of these secondary ticket entities.
+
+## API Patterns
+
+### Ticket Notes
+
+#### Get a Single Ticket Note
+
+Tool: `autotask_get_ticket_note`
+
+Parameters:
+- `id` (required) — The ticket note ID
+
+Returns the full note content including author, creation time, note type (internal/external), and HTML/text body.
+
+#### Search Ticket Notes
+
+Tool: `autotask_search_ticket_notes`
+
+Key parameters:
+- `ticketId` — Filter notes for a specific ticket
+- `noteType` — Filter by note type (internal vs. external/visible to client)
+- `createdAfter` / `createdBefore` — Date range
+- `page` / `pageSize` — Pagination
+
+### Ticket Attachments
+
+#### Get a Ticket Attachment
+
+Tool: `autotask_get_ticket_attachment`
+
+Parameters:
+- `id` (required) — The attachment ID
+
+Returns attachment metadata and base64-encoded file content.
+
+#### Search Ticket Attachments
+
+Tool: `autotask_search_ticket_attachments`
+
+Key parameters:
+- `ticketId` — Filter attachments for a specific ticket
+- `page` / `pageSize` — Pagination
+
+### Ticket Charges
+
+#### Get a Ticket Charge
+
+Tool: `autotask_get_ticket_charge`
+
+Parameters:
+- `id` (required) — The ticket charge ID
+
+Returns charge details including amount, description, billing status, and associated ticket.
+
+#### Create a Ticket Charge
+
+Tool: `autotask_create_ticket_charge`
+
+Key parameters:
+- `ticketId` (required) — Ticket to attach the charge to
+- `name` (required) — Charge description
+- `amount` (required) — Charge amount
+- `isBillable` — Whether to bill to the client
+
+#### Update a Ticket Charge
+
+Tool: `autotask_update_ticket_charge`
+
+Parameters:
+- `id` (required) — Charge ID to update
+- `amount`, `name`, `isBillable` — Fields to modify
+
+#### Delete a Ticket Charge
+
+Tool: `autotask_delete_ticket_charge`
+
+Parameters:
+- `id` (required) — Charge ID to delete
+
+Use with care — deleted charges cannot be recovered.
+
+#### Search Ticket Charges
+
+Tool: `autotask_search_ticket_charges`
+
+Key parameters:
+- `ticketId` — Filter charges for a specific ticket
+- `isBillable` — Filter by billability
+- `page` / `pageSize` — Pagination
+
+## Common Workflows
+
+### Review All Activity on a Ticket
+
+1. Use `autotask_get_ticket_details` to get the core ticket
+2. Use `autotask_search_ticket_notes` with `ticketId` to retrieve all notes
+3. Use `autotask_search_ticket_attachments` with `ticketId` to list files
+4. Use `autotask_search_ticket_charges` with `ticketId` to see charges
+
+### Add a Charge to a Ticket
+
+1. Verify the ticket exists with `autotask_get_ticket_details`
+2. Call `autotask_create_ticket_charge` with ticket ID, name, amount
+3. Confirm charge appears with `autotask_search_ticket_charges`
+
+### Export Ticket Notes for a Client Report
+
+1. Use `autotask_search_ticket_notes` filtered by `ticketId` and `noteType` (external only)
+2. Collect and format note bodies for the report
+
+## Notes
+
+- Ticket note types determine client visibility — internal notes are not visible in client portals
+- Attachments are returned as base64-encoded content; large files may impact response size
+- Ticket charges are separate from time entries; use the `time-entries` skill for time-based billing
+- Charges must be approved before appearing on invoices — see the `billing` skill for approval workflows

--- a/msp-claude-plugins/ninjaone/ninjaone-rmm/skills/alerts/SKILL.md
+++ b/msp-claude-plugins/ninjaone/ninjaone-rmm/skills/alerts/SKILL.md
@@ -11,6 +11,10 @@ triggers:
   - dismiss alert ninja
   - clear alert ninja
   - critical alert ninja
+  - bulk dismiss alerts ninja
+  - alert summary ninja
+  - ninjaone alert count
+  - alerts by severity ninja
 ---
 
 # NinjaOne Alert Management
@@ -45,6 +49,30 @@ Authorization: Bearer {token}
 ```
 
 Dismisses an alert by its unique identifier. The underlying condition may still exist if not resolved.
+
+### Reset All Alerts (Bulk Dismiss)
+
+Tool: `ninjaone_alerts_reset_all`
+
+Dismisses all alerts for a specific device or organization. Use with care — this cannot be undone.
+
+Key parameters:
+- `device_id` — Reset all alerts for a single device
+- `organization_id` — Reset all alerts for an entire organization
+- `severity` — Optionally limit to a specific severity level: `CRITICAL`, `MAJOR`, `MINOR`, or `NONE`
+
+At least one of `device_id` or `organization_id` must be provided. Typically used after scheduled maintenance windows to clear expected alerts.
+
+### Get Alert Summary
+
+Tool: `ninjaone_alerts_summary`
+
+Returns a count of active alerts grouped by severity and/or organization.
+
+Key parameter:
+- `group_by` — How to group counts: `"severity"` (default), `"organization"`, or `"both"`
+
+Useful for dashboards and morning briefings to understand the overall alert posture at a glance without retrieving individual alerts.
 
 ## Alert Structure
 


### PR DESCRIPTION
## Summary

Audited all 6 priority MCP servers against their plugin skill coverage. Most were well-covered. Added stubs for the gaps found:

**Autotask** (81 tools, 3 new stubs):
- `kaseya/autotask/skills/billing/` — billing items, invoices
- `kaseya/autotask/skills/picklists/` — queues, statuses, priorities, phases
- `kaseya/autotask/skills/ticket-notes-attachments/` — notes, attachments, charges

**HaloPSA** (17 tools, 2 new stubs):
- `halopsa/halopsa/skills/agents/` — agents, teams
- `halopsa/halopsa/skills/invoices/` — invoice listing and detail

**NinjaOne** (1 skill extended):
- `ninjaone/ninjaone-rmm/skills/alerts/` — extended to cover alert reset and summary tools

**Huntress, IT Glue, Datto RMM**: full coverage, nothing missing.

## Test plan

- [ ] Verify stub skills appear in the correct plugin directories
- [ ] Confirm stubs reference correct tool names from the MCP server
- [ ] Fill in stub content before merging (stubs are intentionally minimal starting points)