### PR TITLE
feat: pricing page, open signup, and nav updates

### DIFF
--- a/msp-claude-plugins/docs/src/components/Header.astro
+++ b/msp-claude-plugins/docs/src/components/Header.astro
@@ -12,6 +12,7 @@ const navLinks = [
   { href: `${baseUrl}plugins/`, label: 'Plugins' },
   { href: `${baseUrl}skills/`, label: 'Skills' },
   { href: `${baseUrl}commands/`, label: 'Commands' },
+  { href: `${baseUrl}pricing/`, label: 'Pricing' },
 ];
 
 const sidebarSections = [

--- a/msp-claude-plugins/docs/src/components/Header.astro
+++ b/msp-claude-plugins/docs/src/components/Header.astro
@@ -3,7 +3,7 @@ import { plugins } from '@/data/plugins';
 import { mcpServers } from '@/data/mcp-servers';
 
 const baseUrl = import.meta.env.BASE_URL;
-const gatewayUrl = import.meta.env.GATEWAY_URL || 'https://mcp.wyretechnology.com';
+const gatewayUrl = import.meta.env.GATEWAY_URL || 'https://mcp.wyre.ai';
 const currentPath = Astro.url.pathname;
 
 const navLinks = [
@@ -135,7 +135,7 @@ function isExactActive(href?: string): boolean {
           </svg>
         </a>
 
-        <a href={`${gatewayUrl}/auth/login`} class="hidden sm:inline-flex items-center px-4 py-1.5 rounded-lg bg-accent text-white text-sm font-medium hover:bg-accent/90 transition-colors">
+        <a href={`${gatewayUrl}/auth/choose`} class="hidden sm:inline-flex items-center px-4 py-1.5 rounded-lg bg-accent text-white text-sm font-medium hover:bg-accent/90 transition-colors">
           Sign in
         </a>
       </div>

--- a/msp-claude-plugins/docs/src/components/PricingCard.astro
+++ b/msp-claude-plugins/docs/src/components/PricingCard.astro
@@ -21,7 +21,7 @@ const { plan, price, description, features, cta, ctaHref, highlighted = false } 
   {highlighted && (
     <div class="flex items-center gap-2 mb-4">
       <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-accent/10 text-accent border border-accent/30">
-        Recommended
+        Most Popular
       </span>
     </div>
   )}

--- a/msp-claude-plugins/docs/src/components/PricingCard.astro
+++ b/msp-claude-plugins/docs/src/components/PricingCard.astro
@@ -1,0 +1,60 @@
+---
+interface Props {
+  plan: string;
+  price: string;
+  description: string;
+  features: string[];
+  cta: string;
+  ctaHref: string;
+  highlighted?: boolean;
+}
+
+const { plan, price, description, features, cta, ctaHref, highlighted = false } = Astro.props;
+---
+
+<div class:list={[
+  'card flex flex-col',
+  highlighted
+    ? 'border-accent dark:border-accent/60 bg-white dark:bg-neutral-900 ring-2 ring-accent/30 shadow-lg'
+    : 'border-[var(--border)]'
+]}>
+  {highlighted && (
+    <div class="flex items-center gap-2 mb-4">
+      <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-accent/10 text-accent border border-accent/30">
+        Recommended
+      </span>
+    </div>
+  )}
+
+  <div class="mb-4">
+    <h3 class="text-xl font-bold mb-1">{plan}</h3>
+    <p class="text-3xl font-bold text-[var(--text)] mb-2">{price}</p>
+    <p class="text-[var(--muted)] text-sm">{description}</p>
+  </div>
+
+  <ul class="space-y-3 mb-8 flex-1">
+    {features.map(feature => (
+      <li class="flex items-start gap-2 text-sm">
+        <svg
+          class:list={['w-5 h-5 mt-0.5 shrink-0', highlighted ? 'text-accent' : 'text-green-500']}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+        </svg>
+        <span>{feature}</span>
+      </li>
+    ))}
+  </ul>
+
+  <a
+    href={ctaHref}
+    class:list={[
+      'btn w-full text-center',
+      highlighted ? 'btn-primary' : 'btn-secondary'
+    ]}
+  >
+    {cta}
+  </a>
+</div>

--- a/msp-claude-plugins/docs/src/components/PricingMatrix.astro
+++ b/msp-claude-plugins/docs/src/components/PricingMatrix.astro
@@ -1,0 +1,143 @@
+---
+// Full feature comparison matrix for the pricing page
+---
+
+<div class="overflow-x-auto rounded-xl border border-[var(--border)]">
+  <table class="w-full text-sm border-collapse min-w-[600px]">
+    <thead>
+      <tr class="border-b border-[var(--border)]">
+        <th class="text-left py-4 px-6 font-semibold text-[var(--text)] w-2/5 bg-white dark:bg-neutral-900"></th>
+        <th class="text-center py-4 px-6 font-semibold text-[var(--text)] bg-white dark:bg-neutral-900">Free</th>
+        <th class="text-center py-4 px-6 font-semibold text-[var(--text)] bg-neutral-800/50 relative">
+          <span class="text-accent">Pro</span>
+          <span class="absolute top-2 right-2 inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold bg-accent/10 text-accent border border-accent/30">Popular</span>
+        </th>
+        <th class="text-center py-4 px-6 font-semibold text-[var(--text)] bg-white dark:bg-neutral-900">Business</th>
+      </tr>
+    </thead>
+    <tbody>
+
+      <!-- Section: Usage limits -->
+      <tr class="border-b border-[var(--border)]">
+        <td colspan="4" class="py-3 px-6 text-xs font-semibold uppercase tracking-wider text-neutral-400 bg-neutral-50 dark:bg-neutral-900/70">
+          Usage Limits
+        </td>
+      </tr>
+      <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
+        <td class="py-3 px-6 text-[var(--text)]">Users</td>
+        <td class="py-3 px-6 text-center text-[var(--muted)]">1</td>
+        <td class="py-3 px-6 text-center text-[var(--muted)] bg-neutral-800/50">Up to 3</td>
+        <td class="py-3 px-6 text-center text-[var(--muted)]">5+</td>
+      </tr>
+      <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
+        <td class="py-3 px-6 text-[var(--text)]">Personal connections</td>
+        <td class="py-3 px-6 text-center text-[var(--muted)]">3</td>
+        <td class="py-3 px-6 text-center text-[var(--muted)] bg-neutral-800/50">3 / user</td>
+        <td class="py-3 px-6 text-center text-[var(--muted)]">Unlimited</td>
+      </tr>
+      <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
+        <td class="py-3 px-6 text-[var(--text)]">Org / shared connections</td>
+        <td class="py-3 px-6 text-center text-neutral-400">—</td>
+        <td class="py-3 px-6 text-center text-[var(--muted)] bg-neutral-800/50">5</td>
+        <td class="py-3 px-6 text-center text-[var(--muted)]">Unlimited</td>
+      </tr>
+      <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
+        <td class="py-3 px-6 text-[var(--text)]">Credits / month</td>
+        <td class="py-3 px-6 text-center text-[var(--muted)]">500</td>
+        <td class="py-3 px-6 text-center text-[var(--muted)] bg-neutral-800/50">2,000 / seat</td>
+        <td class="py-3 px-6 text-center text-[var(--muted)]">4,000 / seat pooled</td>
+      </tr>
+      <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
+        <td class="py-3 px-6 text-[var(--text)]">Rate limit</td>
+        <td class="py-3 px-6 text-center text-[var(--muted)]">100 req / hr</td>
+        <td class="py-3 px-6 text-center text-[var(--muted)] bg-neutral-800/50">1,000 req / hr</td>
+        <td class="py-3 px-6 text-center text-[var(--muted)]">1,000 req / hr</td>
+      </tr>
+
+      <!-- Section: Team features -->
+      <tr class="border-b border-[var(--border)]">
+        <td colspan="4" class="py-3 px-6 text-xs font-semibold uppercase tracking-wider text-neutral-400 bg-neutral-50 dark:bg-neutral-900/70">
+          Team Features
+        </td>
+      </tr>
+      <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
+        <td class="py-3 px-6 text-[var(--text)]">Team RBAC (roles)</td>
+        <td class="py-3 px-6 text-center text-neutral-400">—</td>
+        <td class="py-3 px-6 text-center text-accent bg-neutral-800/50">✓</td>
+        <td class="py-3 px-6 text-center text-accent">✓</td>
+      </tr>
+      <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
+        <td class="py-3 px-6 text-[var(--text)]">Invite members</td>
+        <td class="py-3 px-6 text-center text-neutral-400">—</td>
+        <td class="py-3 px-6 text-center text-accent bg-neutral-800/50">✓</td>
+        <td class="py-3 px-6 text-center text-accent">✓</td>
+      </tr>
+      <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
+        <td class="py-3 px-6 text-[var(--text)]">Shared org credentials</td>
+        <td class="py-3 px-6 text-center text-neutral-400">—</td>
+        <td class="py-3 px-6 text-center text-accent bg-neutral-800/50">✓</td>
+        <td class="py-3 px-6 text-center text-accent">✓</td>
+      </tr>
+
+      <!-- Section: Advanced -->
+      <tr class="border-b border-[var(--border)]">
+        <td colspan="4" class="py-3 px-6 text-xs font-semibold uppercase tracking-wider text-neutral-400 bg-neutral-50 dark:bg-neutral-900/70">
+          Advanced
+        </td>
+      </tr>
+      <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
+        <td class="py-3 px-6 text-[var(--text)]">Audit log</td>
+        <td class="py-3 px-6 text-center text-neutral-400">—</td>
+        <td class="py-3 px-6 text-center text-neutral-400 bg-neutral-800/50">—</td>
+        <td class="py-3 px-6 text-center text-accent">✓</td>
+      </tr>
+      <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
+        <td class="py-3 px-6 text-[var(--text)]">Log shipping</td>
+        <td class="py-3 px-6 text-center text-neutral-400">—</td>
+        <td class="py-3 px-6 text-center text-neutral-400 bg-neutral-800/50">—</td>
+        <td class="py-3 px-6 text-center text-accent">✓</td>
+      </tr>
+      <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
+        <td class="py-3 px-6 text-[var(--text)]">Tool allowlists</td>
+        <td class="py-3 px-6 text-center text-neutral-400">—</td>
+        <td class="py-3 px-6 text-center text-neutral-400 bg-neutral-800/50">—</td>
+        <td class="py-3 px-6 text-center text-accent">✓</td>
+      </tr>
+      <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
+        <td class="py-3 px-6 text-[var(--text)]">Service clients (AI agents)</td>
+        <td class="py-3 px-6 text-center text-neutral-400">—</td>
+        <td class="py-3 px-6 text-center text-neutral-400 bg-neutral-800/50">—</td>
+        <td class="py-3 px-6 text-center text-accent">✓</td>
+      </tr>
+
+      <!-- Section: Security -->
+      <tr class="border-b border-[var(--border)]">
+        <td colspan="4" class="py-3 px-6 text-xs font-semibold uppercase tracking-wider text-neutral-400 bg-neutral-50 dark:bg-neutral-900/70">
+          Security
+        </td>
+      </tr>
+      <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
+        <td class="py-3 px-6 text-[var(--text)]">SSO</td>
+        <td class="py-3 px-6 text-center text-neutral-400">—</td>
+        <td class="py-3 px-6 text-center text-neutral-400 bg-neutral-800/50">—</td>
+        <td class="py-3 px-6 text-center text-neutral-400">Coming soon</td>
+      </tr>
+
+      <!-- Section: Support -->
+      <tr class="border-b border-[var(--border)]">
+        <td colspan="4" class="py-3 px-6 text-xs font-semibold uppercase tracking-wider text-neutral-400 bg-neutral-50 dark:bg-neutral-900/70">
+          Support
+        </td>
+      </tr>
+      <tr class="hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
+        <td class="py-3 px-6 text-[var(--text)]">Support tier</td>
+        <td class="py-3 px-6 text-center text-[var(--muted)]">Community</td>
+        <td class="py-3 px-6 text-center text-[var(--muted)] bg-neutral-800/50">Email</td>
+        <td class="py-3 px-6 text-center text-[var(--muted)]">Dedicated</td>
+      </tr>
+
+    </tbody>
+  </table>
+</div>
+
+<p class="text-xs text-neutral-400 mt-3 text-center">1 credit = 1 successful vendor tool call.</p>

--- a/msp-claude-plugins/docs/src/components/PricingMatrix.astro
+++ b/msp-claude-plugins/docs/src/components/PricingMatrix.astro
@@ -100,7 +100,7 @@
       <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
         <td class="py-3 px-6 text-[var(--text)]">Tool allowlists</td>
         <td class="py-3 px-6 text-center text-neutral-400">—</td>
-        <td class="py-3 px-6 text-center text-neutral-400 bg-neutral-800/50">—</td>
+        <td class="py-3 px-6 text-center text-accent bg-neutral-800/50">✓</td>
         <td class="py-3 px-6 text-center text-accent">✓</td>
       </tr>
       <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
@@ -108,19 +108,6 @@
         <td class="py-3 px-6 text-center text-neutral-400">—</td>
         <td class="py-3 px-6 text-center text-neutral-400 bg-neutral-800/50">—</td>
         <td class="py-3 px-6 text-center text-accent">✓</td>
-      </tr>
-
-      <!-- Section: Security -->
-      <tr class="border-b border-[var(--border)]">
-        <td colspan="4" class="py-3 px-6 text-xs font-semibold uppercase tracking-wider text-neutral-400 bg-neutral-50 dark:bg-neutral-900/70">
-          Security
-        </td>
-      </tr>
-      <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
-        <td class="py-3 px-6 text-[var(--text)]">SSO</td>
-        <td class="py-3 px-6 text-center text-neutral-400">—</td>
-        <td class="py-3 px-6 text-center text-neutral-400 bg-neutral-800/50">—</td>
-        <td class="py-3 px-6 text-center text-neutral-400">Coming soon</td>
       </tr>
 
       <!-- Section: Support -->

--- a/msp-claude-plugins/docs/src/pages/index.astro
+++ b/msp-claude-plugins/docs/src/pages/index.astro
@@ -281,11 +281,11 @@ const features = [
       <div class="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-5xl mx-auto">
         <PricingCard
           plan="Free"
-          price="Free"
+          price="$0"
           description="Get started with no commitment."
           features={[
-            "Up to 3 connected vendors",
             "1 user",
+            "3 vendor connections",
             "Community support",
           ]}
           cta="Get started free"
@@ -294,13 +294,13 @@ const features = [
 
         <PricingCard
           plan="Pro"
-          price="$79/mo per org"
-          description="Everything your team needs to move fast."
+          price="$49/user/mo"
+          description="For growing MSP teams, up to 3 users."
           features={[
-            "Unlimited vendors",
-            "Up to 10 users",
+            "Up to 3 users",
+            "Unlimited connections",
             "Email support",
-            "Vendor credential management",
+            "Team credential management",
           ]}
           cta="Start free trial"
           ctaHref="https://gateway.wyre.technology/auth/signup"
@@ -308,14 +308,16 @@ const features = [
         />
 
         <PricingCard
-          plan="Enterprise"
-          price="Contact us"
-          description="For MSPs that need the full package."
+          plan="Business"
+          price="$99/user/mo"
+          description="For MSP teams of 5–15 users (minimum 5)."
           features={[
-            "Unlimited everything",
-            "SSO / SAML",
-            "SLA + dedicated support",
-            "Custom vendor integrations",
+            "5–15 users",
+            "Everything in Pro",
+            "Org-level shared credentials",
+            "Audit log & log shipping",
+            "Tool allowlists",
+            "Dedicated support",
           ]}
           cta="Talk to sales"
           ctaHref="mailto:sales@wyre.technology"

--- a/msp-claude-plugins/docs/src/pages/index.astro
+++ b/msp-claude-plugins/docs/src/pages/index.astro
@@ -321,7 +321,6 @@ const features = [
             "4,000 credits/seat/month (pooled)",
             "Audit log & log shipping",
             "Tool allowlists & service clients",
-            "SSO (coming soon)",
             "Dedicated support",
           ]}
           cta="Talk to sales"

--- a/msp-claude-plugins/docs/src/pages/index.astro
+++ b/msp-claude-plugins/docs/src/pages/index.astro
@@ -11,7 +11,7 @@ import { plugins } from '@/data/plugins';
 import { prompts } from '@/data/prompts';
 
 const baseUrl = import.meta.env.BASE_URL;
-const gatewayUrl = import.meta.env.GATEWAY_URL || 'https://mcp.wyretechnology.com';
+const gatewayUrl = import.meta.env.GATEWAY_URL || 'https://mcp.wyre.ai';
 
 const pluginCount = plugins.length;
 const skillCount = plugins.flatMap(p => p.skills).length;
@@ -53,7 +53,7 @@ const faqs = [
   },
   {
     question: "How does the hosted gateway work?",
-    answer: "The hosted gateway at mcp.wyretechnology.com acts as a secure proxy between Claude Desktop and your MSP platforms. You authenticate via OAuth 2.1 with PKCE, store your vendor API credentials (encrypted with per-user isolation), and Claude connects through a single MCP endpoint. No local servers, no Docker, no maintenance required."
+    answer: "The hosted gateway at mcp.wyre.ai acts as a secure proxy between Claude Desktop and your MSP platforms. You authenticate via OAuth 2.1 with PKCE, store your vendor API credentials (encrypted with per-user isolation), and Claude connects through a single MCP endpoint. No local servers, no Docker, no maintenance required."
   },
   {
     question: "Is my data secure with the gateway?",
@@ -127,7 +127,7 @@ const features = [
           <p class="text-[var(--muted)] text-sm mb-4">
             Connect your MSP tools to Claude Desktop in minutes. No servers to manage — just add your API credentials and go.
           </p>
-          <a href={`${gatewayUrl}/auth/signup`} class="btn btn-primary w-full text-center">Get Started Free</a>
+          <a href={`${gatewayUrl}/auth/choose`} class="btn btn-primary w-full text-center">Get Started Free</a>
         </div>
 
         <!-- Self-host path -->
@@ -227,7 +227,7 @@ const features = [
             </li>
           </ul>
           <div class="flex flex-wrap gap-3">
-            <a href={`${gatewayUrl}/auth/signup`} class="btn btn-primary text-sm">Get Started Free</a>
+            <a href={`${gatewayUrl}/auth/choose`} class="btn btn-primary text-sm">Get Started Free</a>
             <a href={`${baseUrl}getting-started/gateway/`} class="btn btn-secondary text-sm">Learn More</a>
           </div>
         </div>
@@ -290,7 +290,7 @@ const features = [
             "Community support",
           ]}
           cta="Get started free"
-          ctaHref="https://mcp.wyretechnology.com/auth/signup"
+          ctaHref="https://mcp.wyre.ai/auth/choose"
         />
 
         <PricingCard
@@ -306,7 +306,7 @@ const features = [
             "Email support",
           ]}
           cta="Start free trial"
-          ctaHref="https://mcp.wyretechnology.com/auth/signup"
+          ctaHref="https://mcp.wyre.ai/auth/choose"
           highlighted={true}
         />
 
@@ -365,7 +365,7 @@ const features = [
         </p>
 
         <div class="flex flex-wrap justify-center gap-4 mb-6">
-          <a href={`${gatewayUrl}/auth/signup`} class="btn btn-primary">Use the Gateway</a>
+          <a href={`${gatewayUrl}/auth/choose`} class="btn btn-primary">Use the Gateway</a>
           <a href={`${baseUrl}getting-started/`} class="btn btn-secondary">Self-Host Guide</a>
         </div>
 

--- a/msp-claude-plugins/docs/src/pages/index.astro
+++ b/msp-claude-plugins/docs/src/pages/index.astro
@@ -6,6 +6,7 @@ import PluginCard from '@/components/PluginCard.astro';
 import InstallCommand from '@/components/InstallCommand.astro';
 import FAQSchema from '@/components/schema/FAQSchema.astro';
 import OrganizationSchema from '@/components/schema/OrganizationSchema.astro';
+import PricingCard from '@/components/PricingCard.astro';
 import { plugins } from '@/data/plugins';
 import { prompts } from '@/data/prompts';
 
@@ -264,6 +265,66 @@ const features = [
           </div>
         </div>
       </div>
+    </div>
+  </section>
+
+  <!-- Plans & Pricing Section -->
+  <section class="py-20 bg-neutral-50 dark:bg-neutral-900/50">
+    <div class="container">
+      <div class="text-center mb-12">
+        <h2 class="text-3xl font-bold mb-4">Plans &amp; Pricing</h2>
+        <p class="text-[var(--muted)] max-w-2xl mx-auto">
+          Start free and scale as your team grows. All plans include the full MCP integration suite.
+        </p>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-5xl mx-auto">
+        <PricingCard
+          plan="Free"
+          price="Free"
+          description="Get started with no commitment."
+          features={[
+            "Up to 3 connected vendors",
+            "1 user",
+            "Community support",
+          ]}
+          cta="Get started free"
+          ctaHref="/getting-started"
+        />
+
+        <PricingCard
+          plan="Pro"
+          price="$79/mo per org"
+          description="Everything your team needs to move fast."
+          features={[
+            "Unlimited vendors",
+            "Up to 10 users",
+            "Email support",
+            "Vendor credential management",
+          ]}
+          cta="Start free trial"
+          ctaHref="https://gateway.wyre.technology/auth/signup"
+          highlighted={true}
+        />
+
+        <PricingCard
+          plan="Enterprise"
+          price="Contact us"
+          description="For MSPs that need the full package."
+          features={[
+            "Unlimited everything",
+            "SSO / SAML",
+            "SLA + dedicated support",
+            "Custom vendor integrations",
+          ]}
+          cta="Talk to sales"
+          ctaHref="mailto:sales@wyre.technology"
+        />
+      </div>
+
+      <p class="text-center text-sm text-[var(--muted)] mt-8">
+        Need a custom plan? <a href="mailto:sales@wyre.technology" class="text-accent hover:underline">Get in touch.</a>
+      </p>
     </div>
   </section>
 

--- a/msp-claude-plugins/docs/src/pages/index.astro
+++ b/msp-claude-plugins/docs/src/pages/index.astro
@@ -285,11 +285,12 @@ const features = [
           description="Get started with no commitment."
           features={[
             "1 user",
-            "3 vendor connections",
+            "3 personal vendor connections",
+            "500 credits/month",
             "Community support",
           ]}
           cta="Get started free"
-          ctaHref="/getting-started"
+          ctaHref="https://mcp.wyretechnology.com/auth/signup"
         />
 
         <PricingCard
@@ -298,25 +299,29 @@ const features = [
           description="For growing MSP teams, up to 3 users."
           features={[
             "Up to 3 users",
-            "Unlimited connections",
+            "3 personal connections per user",
+            "5 shared org connections",
+            "2,000 credits/seat/month",
+            "Team roles & invites",
             "Email support",
-            "Team credential management",
           ]}
           cta="Start free trial"
-          ctaHref="https://gateway.wyre.technology/auth/signup"
+          ctaHref="https://mcp.wyretechnology.com/auth/signup"
           highlighted={true}
         />
 
         <PricingCard
           plan="Business"
           price="$99/user/mo"
-          description="For MSP teams of 5–15 users (minimum 5)."
+          description="For MSP teams of 5+ users."
           features={[
-            "5–15 users",
-            "Everything in Pro",
-            "Org-level shared credentials",
+            "5+ users",
+            "Unlimited personal connections",
+            "Unlimited shared org connections",
+            "4,000 credits/seat/month (pooled)",
             "Audit log & log shipping",
-            "Tool allowlists",
+            "Tool allowlists & service clients",
+            "SSO (coming soon)",
             "Dedicated support",
           ]}
           cta="Talk to sales"

--- a/msp-claude-plugins/docs/src/pages/index.astro
+++ b/msp-claude-plugins/docs/src/pages/index.astro
@@ -127,7 +127,7 @@ const features = [
           <p class="text-[var(--muted)] text-sm mb-4">
             Connect your MSP tools to Claude Desktop in minutes. No servers to manage — just add your API credentials and go.
           </p>
-          <a href={`${gatewayUrl}/waitlist`} class="btn btn-primary w-full text-center">Get Started Free</a>
+          <a href={`${gatewayUrl}/auth/signup`} class="btn btn-primary w-full text-center">Get Started Free</a>
         </div>
 
         <!-- Self-host path -->
@@ -227,7 +227,7 @@ const features = [
             </li>
           </ul>
           <div class="flex flex-wrap gap-3">
-            <a href={`${gatewayUrl}/waitlist`} class="btn btn-primary text-sm">Get Started Free</a>
+            <a href={`${gatewayUrl}/auth/signup`} class="btn btn-primary text-sm">Get Started Free</a>
             <a href={`${baseUrl}getting-started/gateway/`} class="btn btn-secondary text-sm">Learn More</a>
           </div>
         </div>
@@ -365,7 +365,7 @@ const features = [
         </p>
 
         <div class="flex flex-wrap justify-center gap-4 mb-6">
-          <a href={`${gatewayUrl}/waitlist`} class="btn btn-primary">Use the Gateway</a>
+          <a href={`${gatewayUrl}/auth/signup`} class="btn btn-primary">Use the Gateway</a>
           <a href={`${baseUrl}getting-started/`} class="btn btn-secondary">Self-Host Guide</a>
         </div>
 

--- a/msp-claude-plugins/docs/src/pages/pricing.astro
+++ b/msp-claude-plugins/docs/src/pages/pricing.astro
@@ -64,7 +64,7 @@ const faqs = [
             "Community support",
           ]}
           cta="Get started free"
-          ctaHref="https://mcp.wyretechnology.com/auth/signup"
+          ctaHref="https://mcp.wyre.ai/auth/choose"
         />
 
         <PricingCard
@@ -81,7 +81,7 @@ const faqs = [
             "Email support",
           ]}
           cta="Start free trial"
-          ctaHref="https://mcp.wyretechnology.com/auth/signup"
+          ctaHref="https://mcp.wyre.ai/auth/choose"
           highlighted={true}
         />
 
@@ -164,7 +164,7 @@ const faqs = [
           Spin up the gateway in minutes — no infrastructure required.
         </p>
         <div class="flex flex-wrap justify-center gap-4">
-          <a href="https://mcp.wyretechnology.com/auth/signup" class="btn btn-primary">Start free trial</a>
+          <a href="https://mcp.wyre.ai/auth/choose" class="btn btn-primary">Start free trial</a>
           <a href="/getting-started" class="btn btn-secondary">Read the docs</a>
         </div>
       </div>

--- a/msp-claude-plugins/docs/src/pages/pricing.astro
+++ b/msp-claude-plugins/docs/src/pages/pricing.astro
@@ -3,30 +3,39 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
 import Header from '@/components/Header.astro';
 import Footer from '@/components/Footer.astro';
 import PricingCard from '@/components/PricingCard.astro';
+import PricingMatrix from '@/components/PricingMatrix.astro';
 
 const faqs = [
   {
-    question: "What counts as a vendor connection?",
-    answer: "Each PSA, RMM, or business tool you connect through the gateway (e.g. ConnectWise, NinjaOne, HaloPSA) is one connection."
+    question: "What's a credit?",
+    answer: "One credit = one successful tool call to a connected vendor (e.g. fetching a ticket from ConnectWise, looking up a device in IT Glue). Browsing tools or failed calls don't count."
+  },
+  {
+    question: "What's the difference between personal and org connections?",
+    answer: "Personal connections use your individual API credentials and are only usable by you. Org/shared connections are set up once by an admin and available to everyone on the team."
   },
   {
     question: "Can I change plans later?",
-    answer: "Yes. Upgrade or downgrade at any time; changes take effect at the next billing cycle."
+    answer: "Yes. Upgrade or downgrade any time; changes take effect at the next billing cycle."
   },
   {
-    question: "What happens if I exceed my user limit?",
-    answer: "You'll be prompted to upgrade to the next tier. We won't cut off access mid-cycle."
+    question: "What happens when I run out of credits?",
+    answer: "You can purchase credit blocks ($10 per 1,000 credits, no expiry) or upgrade to the next tier."
   },
   {
     question: "Is there an annual discount?",
-    answer: "Coming soon. Sign up for early access to lock in launch pricing."
+    answer: "Coming soon. Sign up to lock in launch pricing."
+  },
+  {
+    question: "What counts as a user?",
+    answer: "Anyone who has joined your organization and can make MCP calls through the gateway."
   }
 ];
 ---
 
 <BaseLayout
   title="Pricing — MSP Claude Plugins Gateway"
-  description="Simple, transparent pricing for the WYRE MCP Gateway. Free for individuals, Pro for growing MSP teams, Enterprise for full-scale deployments."
+  description="Simple, transparent pricing for the WYRE MCP Gateway. Free for individuals, Pro for growing MSP teams, Business for full-scale deployments."
 >
   <Header />
 
@@ -50,11 +59,12 @@ const faqs = [
           description="Get started with no commitment."
           features={[
             "1 user",
-            "3 vendor connections",
+            "3 personal vendor connections",
+            "500 credits/month",
             "Community support",
           ]}
           cta="Get started free"
-          ctaHref="/getting-started"
+          ctaHref="https://mcp.wyretechnology.com/auth/signup"
         />
 
         <PricingCard
@@ -63,25 +73,29 @@ const faqs = [
           description="For growing MSP teams, up to 3 users."
           features={[
             "Up to 3 users",
-            "Unlimited connections",
+            "3 personal connections per user",
+            "5 shared org connections",
+            "2,000 credits/seat/month",
+            "Team roles & invites",
             "Email support",
-            "Team credential management",
           ]}
           cta="Start free trial"
-          ctaHref="https://gateway.wyre.technology/auth/signup"
+          ctaHref="https://mcp.wyretechnology.com/auth/signup"
           highlighted={true}
         />
 
         <PricingCard
           plan="Business"
           price="$99/user/mo"
-          description="For MSP teams of 5–15 users (minimum 5)."
+          description="For MSP teams of 5+ users."
           features={[
-            "5–15 users",
-            "Everything in Pro",
-            "Org-level shared credentials",
+            "5+ users",
+            "Unlimited personal connections",
+            "Unlimited shared org connections",
+            "4,000 credits/seat/month (pooled)",
             "Audit log & log shipping",
-            "Tool allowlists",
+            "Tool allowlists & service clients",
+            "SSO (coming soon)",
             "Dedicated support",
           ]}
           cta="Talk to sales"
@@ -95,8 +109,23 @@ const faqs = [
     </div>
   </section>
 
+  <!-- Full comparison matrix -->
+  <section class="py-16 bg-neutral-50 dark:bg-neutral-900/50">
+    <div class="container">
+      <div class="text-center mb-10">
+        <h2 class="text-3xl font-bold mb-4">Full Feature Comparison</h2>
+        <p class="text-[var(--muted)] max-w-2xl mx-auto">
+          Everything across every tier, side by side.
+        </p>
+      </div>
+      <div class="max-w-5xl mx-auto">
+        <PricingMatrix />
+      </div>
+    </div>
+  </section>
+
   <!-- FAQ -->
-  <section class="py-20 bg-neutral-50 dark:bg-neutral-900/50">
+  <section class="py-20">
     <div class="container">
       <div class="text-center mb-12">
         <h2 class="text-3xl font-bold mb-4">Frequently Asked Questions</h2>
@@ -127,7 +156,7 @@ const faqs = [
   </section>
 
   <!-- CTA -->
-  <section class="py-20">
+  <section class="py-20 bg-neutral-50 dark:bg-neutral-900/50">
     <div class="container">
       <div class="card max-w-3xl mx-auto text-center p-12">
         <h2 class="text-2xl font-bold mb-4">Ready to Connect Your MSP Stack?</h2>
@@ -135,7 +164,7 @@ const faqs = [
           Spin up the gateway in minutes — no infrastructure required.
         </p>
         <div class="flex flex-wrap justify-center gap-4">
-          <a href="https://gateway.wyre.technology/auth/signup" class="btn btn-primary">Start free trial</a>
+          <a href="https://mcp.wyretechnology.com/auth/signup" class="btn btn-primary">Start free trial</a>
           <a href="/getting-started" class="btn btn-secondary">Read the docs</a>
         </div>
       </div>

--- a/msp-claude-plugins/docs/src/pages/pricing.astro
+++ b/msp-claude-plugins/docs/src/pages/pricing.astro
@@ -6,20 +6,20 @@ import PricingCard from '@/components/PricingCard.astro';
 
 const faqs = [
   {
+    question: "What counts as a vendor connection?",
+    answer: "Each PSA, RMM, or business tool you connect through the gateway (e.g. ConnectWise, NinjaOne, HaloPSA) is one connection."
+  },
+  {
     question: "Can I change plans later?",
-    answer: "Yes. You can upgrade or downgrade your plan at any time from your account settings. Upgrades take effect immediately; downgrades apply at the next billing cycle."
+    answer: "Yes. Upgrade or downgrade at any time; changes take effect at the next billing cycle."
   },
   {
-    question: "What counts as a 'connected vendor'?",
-    answer: "A connected vendor is any MSP platform (e.g. Autotask, ConnectWise, Datto RMM) for which you have stored API credentials in the gateway. Vendors you haven't configured credentials for don't count toward your limit."
+    question: "What happens if I exceed my user limit?",
+    answer: "You'll be prompted to upgrade to the next tier. We won't cut off access mid-cycle."
   },
   {
-    question: "Is there a free trial on the Pro plan?",
-    answer: "Yes — Pro comes with a 14-day free trial, no credit card required. At the end of the trial you can subscribe or drop back to the Free tier."
-  },
-  {
-    question: "How does Enterprise pricing work?",
-    answer: "Enterprise is scoped to your organisation's needs — number of users, vendors, SLA tier, and any custom integrations you require. Contact sales@wyre.technology and we'll put together a proposal within one business day."
+    question: "Is there an annual discount?",
+    answer: "Coming soon. Sign up for early access to lock in launch pricing."
   }
 ];
 ---
@@ -46,11 +46,11 @@ const faqs = [
       <div class="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-5xl mx-auto">
         <PricingCard
           plan="Free"
-          price="Free"
+          price="$0"
           description="Get started with no commitment."
           features={[
-            "Up to 3 connected vendors",
             "1 user",
+            "3 vendor connections",
             "Community support",
           ]}
           cta="Get started free"
@@ -59,13 +59,13 @@ const faqs = [
 
         <PricingCard
           plan="Pro"
-          price="$79/mo per org"
-          description="Everything your team needs to move fast."
+          price="$49/user/mo"
+          description="For growing MSP teams, up to 3 users."
           features={[
-            "Unlimited vendors",
-            "Up to 10 users",
+            "Up to 3 users",
+            "Unlimited connections",
             "Email support",
-            "Vendor credential management",
+            "Team credential management",
           ]}
           cta="Start free trial"
           ctaHref="https://gateway.wyre.technology/auth/signup"
@@ -73,14 +73,16 @@ const faqs = [
         />
 
         <PricingCard
-          plan="Enterprise"
-          price="Contact us"
-          description="For MSPs that need the full package."
+          plan="Business"
+          price="$99/user/mo"
+          description="For MSP teams of 5–15 users (minimum 5)."
           features={[
-            "Unlimited everything",
-            "SSO / SAML",
-            "SLA + dedicated support",
-            "Custom vendor integrations",
+            "5–15 users",
+            "Everything in Pro",
+            "Org-level shared credentials",
+            "Audit log & log shipping",
+            "Tool allowlists",
+            "Dedicated support",
           ]}
           cta="Talk to sales"
           ctaHref="mailto:sales@wyre.technology"

--- a/msp-claude-plugins/docs/src/pages/pricing.astro
+++ b/msp-claude-plugins/docs/src/pages/pricing.astro
@@ -77,6 +77,7 @@ const faqs = [
             "5 shared org connections",
             "2,000 credits/seat/month",
             "Team roles & invites",
+            "Tool allowlists",
             "Email support",
           ]}
           cta="Start free trial"
@@ -95,7 +96,6 @@ const faqs = [
             "4,000 credits/seat/month (pooled)",
             "Audit log & log shipping",
             "Tool allowlists & service clients",
-            "SSO (coming soon)",
             "Dedicated support",
           ]}
           cta="Talk to sales"

--- a/msp-claude-plugins/docs/src/pages/pricing.astro
+++ b/msp-claude-plugins/docs/src/pages/pricing.astro
@@ -1,0 +1,150 @@
+---
+import BaseLayout from '@/layouts/BaseLayout.astro';
+import Header from '@/components/Header.astro';
+import Footer from '@/components/Footer.astro';
+import PricingCard from '@/components/PricingCard.astro';
+
+const faqs = [
+  {
+    question: "Can I change plans later?",
+    answer: "Yes. You can upgrade or downgrade your plan at any time from your account settings. Upgrades take effect immediately; downgrades apply at the next billing cycle."
+  },
+  {
+    question: "What counts as a 'connected vendor'?",
+    answer: "A connected vendor is any MSP platform (e.g. Autotask, ConnectWise, Datto RMM) for which you have stored API credentials in the gateway. Vendors you haven't configured credentials for don't count toward your limit."
+  },
+  {
+    question: "Is there a free trial on the Pro plan?",
+    answer: "Yes — Pro comes with a 14-day free trial, no credit card required. At the end of the trial you can subscribe or drop back to the Free tier."
+  },
+  {
+    question: "How does Enterprise pricing work?",
+    answer: "Enterprise is scoped to your organisation's needs — number of users, vendors, SLA tier, and any custom integrations you require. Contact sales@wyre.technology and we'll put together a proposal within one business day."
+  }
+];
+---
+
+<BaseLayout
+  title="Pricing — MSP Claude Plugins Gateway"
+  description="Simple, transparent pricing for the WYRE MCP Gateway. Free for individuals, Pro for growing MSP teams, Enterprise for full-scale deployments."
+>
+  <Header />
+
+  <!-- Hero -->
+  <section class="py-20 lg:py-28 bg-gradient-to-b from-cyan-50 to-transparent dark:from-cyan-950/20">
+    <div class="container text-center">
+      <h1 class="text-4xl lg:text-5xl font-bold mb-4 tracking-tight">Plans &amp; Pricing</h1>
+      <p class="text-xl text-[var(--muted)] max-w-2xl mx-auto">
+        Start free and scale as your team grows. All plans include the full MCP integration suite.
+      </p>
+    </div>
+  </section>
+
+  <!-- Pricing Cards -->
+  <section class="py-16">
+    <div class="container">
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-5xl mx-auto">
+        <PricingCard
+          plan="Free"
+          price="Free"
+          description="Get started with no commitment."
+          features={[
+            "Up to 3 connected vendors",
+            "1 user",
+            "Community support",
+          ]}
+          cta="Get started free"
+          ctaHref="/getting-started"
+        />
+
+        <PricingCard
+          plan="Pro"
+          price="$79/mo per org"
+          description="Everything your team needs to move fast."
+          features={[
+            "Unlimited vendors",
+            "Up to 10 users",
+            "Email support",
+            "Vendor credential management",
+          ]}
+          cta="Start free trial"
+          ctaHref="https://gateway.wyre.technology/auth/signup"
+          highlighted={true}
+        />
+
+        <PricingCard
+          plan="Enterprise"
+          price="Contact us"
+          description="For MSPs that need the full package."
+          features={[
+            "Unlimited everything",
+            "SSO / SAML",
+            "SLA + dedicated support",
+            "Custom vendor integrations",
+          ]}
+          cta="Talk to sales"
+          ctaHref="mailto:sales@wyre.technology"
+        />
+      </div>
+
+      <p class="text-center text-sm text-[var(--muted)] mt-8">
+        Need a custom plan? <a href="mailto:sales@wyre.technology" class="text-accent hover:underline">Get in touch.</a>
+      </p>
+    </div>
+  </section>
+
+  <!-- FAQ -->
+  <section class="py-20 bg-neutral-50 dark:bg-neutral-900/50">
+    <div class="container">
+      <div class="text-center mb-12">
+        <h2 class="text-3xl font-bold mb-4">Frequently Asked Questions</h2>
+        <p class="text-[var(--muted)] max-w-2xl mx-auto">
+          Common questions about plans, billing, and limits.
+        </p>
+      </div>
+
+      <div class="max-w-3xl mx-auto space-y-4">
+        {faqs.map((faq, i) => (
+          <details class="card group" open={i === 0}>
+            <summary class="cursor-pointer list-none flex items-center justify-between font-semibold text-lg select-none">
+              {faq.question}
+              <svg
+                class="w-5 h-5 shrink-0 text-[var(--muted)] transition-transform duration-200 group-open:rotate-180"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+              </svg>
+            </summary>
+            <p class="mt-3 text-[var(--muted)] text-sm leading-relaxed">{faq.answer}</p>
+          </details>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="py-20">
+    <div class="container">
+      <div class="card max-w-3xl mx-auto text-center p-12">
+        <h2 class="text-2xl font-bold mb-4">Ready to Connect Your MSP Stack?</h2>
+        <p class="text-[var(--muted)] mb-8 max-w-xl mx-auto">
+          Spin up the gateway in minutes — no infrastructure required.
+        </p>
+        <div class="flex flex-wrap justify-center gap-4">
+          <a href="https://gateway.wyre.technology/auth/signup" class="btn btn-primary">Start free trial</a>
+          <a href="/getting-started" class="btn btn-secondary">Read the docs</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <Footer />
+</BaseLayout>
+
+<style>
+  details > summary::-webkit-details-marker {
+    display: none;
+  }
+</style>


### PR DESCRIPTION
## Summary

- Adds \`/pricing\` page with Free/Pro/Business tier definitions and full comparison matrix
- Adds Pricing link to header nav
- Switches all "Get Started Free" / "Use the Gateway" CTA buttons from \`/waitlist\` → \`/auth/signup\` (open signup)
- Removes SSO as a tier differentiator (no SSO tax)

## Status

**Draft — do not merge yet.** Holding for user communication planning before going live with pricing and open signup.

## What changes when merged

- Waitlist CTAs on the homepage become live signup links
- Pricing page becomes publicly visible
- Gateway already has the matching 301 redirect on \`GET /waitlist\` (merged to main)

## Test plan

- [ ] Verify pricing page renders at \`/pricing/\`
- [ ] Verify all 3 homepage CTAs link to \`https://mcp.wyretechnology.com/auth/signup\`
- [ ] Verify Pricing nav link appears and is active on \`/pricing/\`
- [ ] Verify existing docs pages unaffected