### PR TITLE
docs(hero): replace static MSP-platforms stat with dynamic subagent count

### DIFF
--- a/msp-claude-plugins/docs/src/pages/index.astro
+++ b/msp-claude-plugins/docs/src/pages/index.astro
@@ -14,7 +14,7 @@ const gatewayUrl = import.meta.env.GATEWAY_URL || 'https://mcp.wyretechnology.co
 
 const pluginCount = plugins.length;
 const skillCount = plugins.flatMap(p => p.skills).length;
-const platformCount = pluginCount;
+const agentCount = plugins.flatMap(p => p.agents).length;
 const vendorNames = plugins.map(p => p.name).join(', ');
 
 // Short, punchy prompt examples for the typewriter — demonstrating real value
@@ -105,7 +105,7 @@ const features = [
       <!-- Animated stat counters -->
       <p class="text-lg font-semibold max-w-2xl mx-auto mb-4">
         <span class="counter" data-target={pluginCount}>{pluginCount}</span> plugins &middot;
-        <span class="counter" data-target={platformCount}>{platformCount}</span> MSP platforms &middot;
+        <span class="counter" data-target={agentCount} data-suffix="+">{agentCount}+</span> subagents &middot;
         <span class="counter" data-target={skillCount} data-suffix="+">{skillCount}+</span> specialized skills
       </p>
 


### PR DESCRIPTION
## Summary
The front-page hero stat was `31 plugins · 31 MSP platforms · 194+ specialized skills` — `platformCount` was literally `= pluginCount`, so it showed the same number twice with different labels. Replaced with a dynamic `agentCount` so we're surfacing something users actually care about: the size of the subagent roster.

## Change
```diff
- const platformCount = pluginCount;
+ const agentCount = plugins.flatMap(p => p.agents).length;
```
```diff
-   <span class="counter" data-target={platformCount}>{platformCount}</span> MSP platforms &middot;
+   <span class="counter" data-target={agentCount} data-suffix="+">{agentCount}+</span> subagents &middot;
```

## Verification
Built locally with `npm run build`. Rendered hero now reads:
> 31 plugins · 48+ subagents · 195+ specialized skills

The count updates automatically as plugins gain agents — no manual bookkeeping.

## Test plan
- [x] `npm run build` succeeds
- [x] Rendered HTML shows new counts and "subagents" label
- [ ] After merge + CF Pages deploy, verify live site shows the updated stat line