### PR TITLE
feat(docs): route Get Started + Sign in to /auth/choose

### DIFF
--- a/msp-claude-plugins/docs/src/components/Header.astro
+++ b/msp-claude-plugins/docs/src/components/Header.astro
@@ -3,7 +3,7 @@ import { plugins } from '@/data/plugins';
 import { mcpServers } from '@/data/mcp-servers';
 
 const baseUrl = import.meta.env.BASE_URL;
-const gatewayUrl = import.meta.env.GATEWAY_URL || 'https://mcp.wyretechnology.com';
+const gatewayUrl = import.meta.env.GATEWAY_URL || 'https://mcp.wyre.ai';
 const currentPath = Astro.url.pathname;
 
 const navLinks = [
@@ -134,7 +134,7 @@ function isExactActive(href?: string): boolean {
           </svg>
         </a>
 
-        <a href={`${gatewayUrl}/auth/login`} class="hidden sm:inline-flex items-center px-4 py-1.5 rounded-lg bg-accent text-white text-sm font-medium hover:bg-accent/90 transition-colors">
+        <a href={`${gatewayUrl}/auth/choose`} class="hidden sm:inline-flex items-center px-4 py-1.5 rounded-lg bg-accent text-white text-sm font-medium hover:bg-accent/90 transition-colors">
           Sign in
         </a>
       </div>

--- a/msp-claude-plugins/docs/src/pages/index.astro
+++ b/msp-claude-plugins/docs/src/pages/index.astro
@@ -10,7 +10,7 @@ import { plugins } from '@/data/plugins';
 import { prompts } from '@/data/prompts';
 
 const baseUrl = import.meta.env.BASE_URL;
-const gatewayUrl = import.meta.env.GATEWAY_URL || 'https://mcp.wyretechnology.com';
+const gatewayUrl = import.meta.env.GATEWAY_URL || 'https://mcp.wyre.ai';
 
 const pluginCount = plugins.length;
 const skillCount = plugins.flatMap(p => p.skills).length;
@@ -126,7 +126,7 @@ const features = [
           <p class="text-[var(--muted)] text-sm mb-4">
             Connect your MSP tools to Claude Desktop in minutes. No servers to manage — just add your API credentials and go.
           </p>
-          <a href={`${gatewayUrl}/waitlist`} class="btn btn-primary w-full text-center">Get Started Free</a>
+          <a href={`${gatewayUrl}/auth/choose`} class="btn btn-primary w-full text-center">Get Started Free</a>
         </div>
 
         <!-- Self-host path -->
@@ -226,7 +226,7 @@ const features = [
             </li>
           </ul>
           <div class="flex flex-wrap gap-3">
-            <a href={`${gatewayUrl}/waitlist`} class="btn btn-primary text-sm">Get Started Free</a>
+            <a href={`${gatewayUrl}/auth/choose`} class="btn btn-primary text-sm">Get Started Free</a>
             <a href={`${baseUrl}getting-started/gateway/`} class="btn btn-secondary text-sm">Learn More</a>
           </div>
         </div>
@@ -298,7 +298,7 @@ const features = [
         </p>
 
         <div class="flex flex-wrap justify-center gap-4 mb-6">
-          <a href={`${gatewayUrl}/waitlist`} class="btn btn-primary">Use the Gateway</a>
+          <a href={`${gatewayUrl}/auth/choose`} class="btn btn-primary">Use the Gateway</a>
           <a href={`${baseUrl}getting-started/`} class="btn btn-secondary">Self-Host Guide</a>
         </div>
 


### PR DESCRIPTION
## Summary
Main-landing Get Started CTAs and header Sign-in button now go to `/auth/choose` (provider-picker) on `mcp.wyre.ai` instead of the Auth0-only `/auth/login` / invite-gated `/waitlist`. Lets users pick Microsoft Entra ID sign-in without hitting Auth0 first.

## Changes
- `docs/src/pages/index.astro` — `gatewayUrl` default → `https://mcp.wyre.ai`; three CTAs (`Get Started Free` x2, `Use the Gateway`) → `${gatewayUrl}/auth/choose`
- `docs/src/components/Header.astro` — same `gatewayUrl` default flip; Sign-in button → `${gatewayUrl}/auth/choose`

## Why `/auth/choose`
Gateway's `src/auth/auth0.ts` exposes `/auth/choose` when multiple auth providers are configured and auto-301s straight to the single provider if only one is active. Safe either way.

## Test plan
- [x] `npm run build` succeeds
- [x] Rendered HTML shows `href="https://mcp.wyre.ai/auth/choose"` on the CTAs, no residual `mcp.wyretechnology.com/auth` or `/waitlist` in the landing
- [ ] After merge + CF Pages deploy, click through from live wyre.ai landing, confirm it lands on the provider-picker