### PR TITLE
fix(pricing): correct sales email to sales@wyre.ai

### DIFF
--- a/msp-claude-plugins/docs/src/pages/pricing.astro
+++ b/msp-claude-plugins/docs/src/pages/pricing.astro
@@ -99,12 +99,12 @@ const faqs = [
             "Dedicated support",
           ]}
           cta="Talk to sales"
-          ctaHref="mailto:sales@wyre.technology"
+          ctaHref="mailto:sales@wyre.ai"
         />
       </div>
 
       <p class="text-center text-sm text-[var(--muted)] mt-8">
-        Need a custom plan? <a href="mailto:sales@wyre.technology" class="text-accent hover:underline">Get in touch.</a>
+        Need a custom plan? <a href="mailto:sales@wyre.ai" class="text-accent hover:underline">Get in touch.</a>
       </p>
     </div>
   </section>


### PR DESCRIPTION
## Summary
The pricing page had `mailto:sales@wyre.technology` in two spots — the "Talk to sales" CTA on the Business tier and the "Need a custom plan? Get in touch." line. **`wyre.technology` isn't a domain we own**, so those links silently bounced. Flipped both to `mailto:sales@wyre.ai`.

The `sales@wyre.ai` shared mailbox is being provisioned separately (Aaron + Tyler York + Jerry Tse on FullAccess + SendAs).