### PR TITLE
feat(nav): marketing-style nav on main site (docs tree moves to Docs tab)

### DIFF
--- a/msp-claude-plugins/docs/src/components/Header.astro
+++ b/msp-claude-plugins/docs/src/components/Header.astro
@@ -6,13 +6,15 @@ const baseUrl = import.meta.env.BASE_URL;
 const gatewayUrl = import.meta.env.GATEWAY_URL || 'https://mcp.wyre.ai';
 const currentPath = Astro.url.pathname;
 
+// Marketing-style top nav. Skills / Commands / MCP Servers / Getting-Started
+// detail pages are still reachable from the Docs entry and the sidebar on
+// any docs page, but they shouldn't crowd out the primary product tabs.
 const navLinks = [
   { href: `${baseUrl}`, label: 'Home' },
-  { href: `${baseUrl}getting-started/`, label: 'Getting Started' },
   { href: `${baseUrl}plugins/`, label: 'Plugins' },
-  { href: `${baseUrl}skills/`, label: 'Skills' },
-  { href: `${baseUrl}commands/`, label: 'Commands' },
   { href: `${baseUrl}pricing/`, label: 'Pricing' },
+  { href: `${baseUrl}getting-started/`, label: 'Docs' },
+  { href: 'mailto:hello@wyre.ai', label: 'Contact' },
 ];
 
 const sidebarSections = [


### PR DESCRIPTION
## Summary
Current nav on mcp.wyre.ai is docs-tree flavored — Home · Getting Started · Plugins · Skills · Commands · Pricing. Redoing it as a product-marketing nav:

```
Home · Plugins · Pricing · Docs · Contact
```

- **Docs** now collapses Getting Started / Skills / Commands / MCP Servers under one tab (links to `/getting-started/` as the entry point). Everything still reachable — each docs page has the full sidebar with all four sections.
- **Contact** is a `mailto:hello@wyre.ai` link pointing at the shared mailbox provisioned earlier today, so it's a real destination not a dead anchor.

## Test plan
- [x] `npm run build` clean; rendered nav shows the 5 new links in order.
- [ ] After merge + CF Pages deploy + gateway image roll, verify live nav on https://mcp.wyre.ai.