### PR TITLE
fix(docs): flip remaining mcp.wyretechnology.com → mcp.wyre.ai in docs/src

### DIFF
--- a/msp-claude-plugins/docs/src/components/schema/OrganizationSchema.astro
+++ b/msp-claude-plugins/docs/src/components/schema/OrganizationSchema.astro
@@ -4,8 +4,8 @@ const schema = {
   "@type": "Organization",
   "name": "MSP Claude Plugins",
   "description": "Community-driven Claude Code plugins for Managed Service Providers",
-  "url": "https://mcp.wyretechnology.com/",
-  "logo": "https://mcp.wyretechnology.com/og-image.png",
+  "url": "https://mcp.wyre.ai/",
+  "logo": "https://mcp.wyre.ai/og-image.png",
   "sameAs": [
     "https://github.com/wyre-technology/msp-claude-plugins"
   ]

--- a/msp-claude-plugins/docs/src/data/plugins.ts
+++ b/msp-claude-plugins/docs/src/data/plugins.ts
@@ -369,6 +369,7 @@ export const plugins: Plugin[] = [
     features: [
       'Company Management',
       'Contact Management',
+      'Product Catalog',
       'Project Management',
       'Ticket Management',
       'Time Entry Tracking'
@@ -376,12 +377,14 @@ export const plugins: Plugin[] = [
     skills: [
       { name: 'companies', description: 'Use this skill when working with ConnectWise PSA companies - creating, updating, searching, or managing company/account records.' },
       { name: 'contacts', description: 'Use this skill when working with ConnectWise PSA contacts - creating, updating, searching, or managing contact records.' },
+      { name: 'product-catalog', description: 'Use this skill when working with the ConnectWise PSA product catalog — searching, creating, or updating catalog items (SKUs), managing categories, subcategories, manufacturers, or using catalog items on quotes, opportunities, agreements, and tickets.' },
       { name: 'projects', description: 'Use this skill when working with ConnectWise PSA projects - creating, updating, managing project phases, templates, and resource allocation.' },
       { name: 'tickets', description: 'Use this skill when working with ConnectWise PSA tickets - creating, updating, searching, or managing service desk operations.' },
       { name: 'time-entries', description: 'Use this skill when working with ConnectWise PSA time entries - creating, updating, searching, or managing time tracking.' },
       { name: 'api-patterns', description: 'Use this skill when working with the ConnectWise PSA REST API - authentication using public/private keys and clientId, pagination with page/pageSize, conditions query syntax, rate limiting (60/min), and error handling.' }
     ],
     agents: [
+      { name: 'procurement-specialist', description: 'Use this agent when an MSP procurement lead, sales engineer, service manager, or owner needs to work against the ConnectWise Manage product catalog and the procurement/quoting workflows it feeds.' },
       { name: 'project-tracker', description: 'Use this agent when an MSP project manager, service manager, or operations lead needs a review of all open projects in ConnectWise Manage — checking milestone deadlines, budget vs. actuals, overdue phases, and projects at risk of scope creep or delivery failure.' },
       { name: 'service-desk-ops', description: 'Use this agent when an MSP dispatcher, service manager, or team lead needs to review the current state of the ConnectWise Manage service desk.' }
     ],
@@ -597,7 +600,7 @@ export const plugins: Plugin[] = [
       { name: 'agents', description: 'Use this skill when managing Huntress endpoint agents — listing agents, filtering by organization or platform, checking agent health and status, and investigating specific agent details.' },
       { name: 'billing', description: 'Use this skill when generating Huntress billing and summary reports — listing available reports, retrieving billing details, and creating client-facing summaries for MSP invoicing.' },
       { name: 'escalations', description: 'Use this skill when working with Huntress escalations — listing, reviewing, and resolving escalations from the Huntress SOC team.' },
-      { name: 'incidents', description: 'Use this skill when working with Huntress incidents — listing, triaging, investigating, resolving incidents, and managing remediations including bulk approve and reject workflows.' },
+      { name: 'incidents', description: 'Use this skill when working with Huntress incidents - querying incidents by organization and status, reviewing SOC-recommended remediation details, approving or rejecting remediations individually or in bulk, checking remediation execution status, and resolving incidents after all remediations are processed.' },
       { name: 'organizations', description: 'Use this skill when managing Huntress organizations — creating, listing, updating, deleting organizations, and managing client org structure for MSP multi-tenancy.' },
       { name: 'signals', description: 'Use this skill when working with Huntress security signals — monitoring, listing, filtering, and investigating signals across managed endpoints.' },
       { name: 'api-patterns', description: 'Use this skill when working with the Huntress MCP tools — available tools, authentication via HTTP Basic Auth, API structure, pagination with page tokens, rate limiting (60 req/min), error handling, and best practices.' }
@@ -1084,7 +1087,7 @@ export const plugins: Plugin[] = [
       'Workflows'
     ],
     skills: [
-      { name: 'alerts', description: 'Use this skill when working with Rootly alerts -- alert routing, escalation policies, integration with monitoring tools (Datadog, PagerDuty, etc.' },
+      { name: 'alerts', description: 'Use this skill when working with Rootly alerts -- alert routing, escalation policies, integration with monitoring tools (Datadog, PagerDuty, etc.), alert-to-incident creation, and managing alert rules.' },
       { name: 'incidents', description: 'Use this skill when working with Rootly incidents - creating, searching, triaging, updating, and resolving incidents.' },
       { name: 'oncall', description: 'Use this skill when working with Rootly on-call management - viewing shift metrics, generating handoff summaries, reviewing shift incidents, detecting on-call health risk, and understanding schedule coverage.' },
       { name: 'postmortems', description: 'Use this skill when working with Rootly postmortems -- creating retrospectives, managing action items, applying templates, and conducting blameless reviews after incidents are resolved.' },
@@ -1290,16 +1293,16 @@ export const plugins: Plugin[] = [
       'Ticket Management'
     ],
     skills: [
-      { name: 'alerts', description: 'Use this skill when working with SuperOps.' },
-      { name: 'assets', description: 'Use this skill when working with SuperOps.' },
-      { name: 'clients', description: 'Use this skill when working with SuperOps.' },
-      { name: 'runbooks', description: 'Use this skill when working with SuperOps.' },
-      { name: 'tickets', description: 'Use this skill when working with SuperOps.' },
-      { name: 'api-patterns', description: 'Use this skill when working with the SuperOps.' }
+      { name: 'alerts', description: 'Use this skill when working with SuperOps.ai alerts - listing, filtering, acknowledging, and resolving alerts from monitored assets.' },
+      { name: 'assets', description: 'Use this skill when working with SuperOps.ai assets - querying inventory, viewing asset details, running scripts, monitoring patches, and managing client/site associations.' },
+      { name: 'clients', description: 'Use this skill when working with SuperOps.ai clients - creating, updating, searching, and managing client accounts.' },
+      { name: 'runbooks', description: 'Use this skill when working with SuperOps.ai runbooks and scripts - listing, executing, monitoring, and managing automated scripts on assets.' },
+      { name: 'tickets', description: 'Use this skill when working with SuperOps.ai tickets - creating, updating, searching, or managing service desk operations.' },
+      { name: 'api-patterns', description: 'Use this skill when working with the SuperOps.ai GraphQL API - authentication, query building, mutations, pagination, rate limiting, and error handling.' }
     ],
     agents: [
-      { name: 'automation-opportunity-finder', description: 'Use this agent when an MSP operations lead, service manager, or technician wants to identify repetitive ticket patterns in SuperOps.' },
-      { name: 'msp-service-ops', description: 'Use this agent when an MSP technician, dispatcher, or manager needs a combined PSA and RMM operations review in SuperOps.' }
+      { name: 'automation-opportunity-finder', description: 'Use this agent when an MSP operations lead, service manager, or technician wants to identify repetitive ticket patterns in SuperOps.ai that should be automated — not live operations management, but a retrospective analysis of ticket history to find recurring issues with the same client, same category, and same resolution, calculate the manual time cost, and recommend runbooks or automation scripts to eliminate the pattern.' },
+      { name: 'msp-service-ops', description: 'Use this agent when an MSP technician, dispatcher, or manager needs a combined PSA and RMM operations review in SuperOps.ai.' }
     ],
     commands: [
       { name: '/acknowledge-alert', description: 'Acknowledge an RMM alert to indicate investigation is underway' },

--- a/msp-claude-plugins/docs/src/pages/getting-started/architecture.astro
+++ b/msp-claude-plugins/docs/src/pages/getting-started/architecture.astro
@@ -65,13 +65,13 @@ Vendor API</pre>
     <code>ghcr.io/wyre-technology/</code>. See the <a href="/getting-started/deployment">deployment guide</a>.
   </p>
 
-  <h3>Pattern 3: MCP Gateway (mcp.wyretechnology.com)</h3>
+  <h3>Pattern 3: MCP Gateway (mcp.wyre.ai)</h3>
 
   <pre style="background: var(--code-bg, #1e1e2e); color: var(--code-text, #cdd6f4); padding: 1.5rem; border-radius: 0.5rem; overflow-x: auto; font-size: 0.9rem; line-height: 1.6;">
 Claude Code / Desktop
     ↓ HTTPS + OAuth 2.1/PKCE
 ┌─────────────────────────────────┐
-│   MCP Gateway (mcp.wyretechnology.com)     │
+│   MCP Gateway (mcp.wyre.ai)     │
 │  ┌────────────────────────────┐ │
 │  │ OAuth 2.1 + PKCE           │ │
 │  │ Credential Vault           │ │
@@ -153,7 +153,7 @@ Vendor APIs</pre>
 
   <ul>
     <li><a href="/getting-started/deployment">Deployment Guide</a> — install MCP servers via npm, Docker, MCPB, or DigitalOcean</li>
-    <li><a href="/getting-started/gateway">MCP Gateway</a> — hosted gateway at mcp.wyretechnology.com</li>
+    <li><a href="/getting-started/gateway">MCP Gateway</a> — hosted gateway at mcp.wyre.ai</li>
     <li><a href="/mcp-servers">MCP Servers</a> — browse all available MCP servers</li>
     <li><a href="/plugins">Plugins</a> — browse all available Claude plugins</li>
   </ul>

--- a/msp-claude-plugins/docs/src/pages/getting-started/authentication.astro
+++ b/msp-claude-plugins/docs/src/pages/getting-started/authentication.astro
@@ -16,7 +16,7 @@ const baseUrl = import.meta.env.BASE_URL;
 
   <h2 id="sign-in">Signing In</h2>
   <p>
-    When you visit <a href="https://mcp.wyretechnology.com/settings">mcp.wyretechnology.com/settings</a>,
+    When you visit <a href="https://mcp.wyre.ai/settings">mcp.wyre.ai/settings</a>,
     you'll be prompted to sign in. If both Microsoft and Auth0 are enabled, you'll see a chooser page.
     Otherwise you'll be redirected to your organization's identity provider automatically.
   </p>
@@ -32,7 +32,7 @@ const baseUrl = import.meta.env.BASE_URL;
     If your organization's Azure AD tenant has already been onboarded (see below), just:
   </p>
   <ol>
-    <li>Go to <a href="https://mcp.wyretechnology.com/auth/microsoft/login">mcp.wyretechnology.com</a></li>
+    <li>Go to <a href="https://mcp.wyre.ai/auth/microsoft/login">mcp.wyre.ai</a></li>
     <li>Click <strong>Sign in with Microsoft</strong></li>
     <li>Sign in with your work Microsoft account</li>
     <li>You're in — head to <strong>Connections</strong> to add your first vendor</li>
@@ -60,7 +60,7 @@ const baseUrl = import.meta.env.BASE_URL;
     <li>
       WYRE will send you an admin consent link (or you can use the direct URL below).
       The link looks like:
-      <pre><code>https://mcp.wyretechnology.com/auth/admin-consent?customer_name=Your+Company</code></pre>
+      <pre><code>https://mcp.wyre.ai/auth/admin-consent?customer_name=Your+Company</code></pre>
     </li>
     <li>
       Click the link — you'll be redirected to Microsoft's standard admin consent dialog.
@@ -103,7 +103,7 @@ const baseUrl = import.meta.env.BASE_URL;
   </p>
   <p>
     No admin setup required — just sign in at
-    <a href="https://mcp.wyretechnology.com/auth/login">mcp.wyretechnology.com</a>
+    <a href="https://mcp.wyre.ai/auth/login">mcp.wyre.ai</a>
     and create your account.
   </p>
 
@@ -116,7 +116,7 @@ const baseUrl = import.meta.env.BASE_URL;
   </p>
   <p>
     You don't need to configure anything — when Claude connects to
-    <code>https://mcp.wyretechnology.com/v1/mcp</code>, it will open a browser window for you
+    <code>https://mcp.wyre.ai/v1/mcp</code>, it will open a browser window for you
     to sign in and authorize the connection. See the
     <a href={`${baseUrl}getting-started/gateway/`}>Gateway Setup</a> page for details.
   </p>

--- a/msp-claude-plugins/docs/src/pages/getting-started/copilot.astro
+++ b/msp-claude-plugins/docs/src/pages/getting-started/copilot.astro
@@ -70,7 +70,7 @@ import DocsLayout from '@/layouts/DocsLayout.astro';
     <p class="text-sm">
       <strong>Transport note:</strong> If your MCP server uses SSE transport, it must be updated to
       Streamable HTTP before connecting to Copilot Studio. The WYRE MCP Gateway at
-      <code>mcp.wyretechnology.com</code> already supports Streamable HTTP &mdash; no changes needed.
+      <code>mcp.wyre.ai</code> already supports Streamable HTTP &mdash; no changes needed.
     </p>
   </div>
 
@@ -118,7 +118,7 @@ import DocsLayout from '@/layouts/DocsLayout.astro';
   <ul>
     <li><strong>Server name:</strong> A descriptive name (used by the orchestrator to identify the server)</li>
     <li><strong>Server description:</strong> Clear, concise description of what the server does &mdash; the agent uses this to decide when to invoke it</li>
-    <li><strong>Server URL:</strong> Your Streamable HTTP endpoint (e.g., <code>https://mcp.wyretechnology.com/v1/mcp</code>)</li>
+    <li><strong>Server URL:</strong> Your Streamable HTTP endpoint (e.g., <code>https://mcp.wyre.ai/v1/mcp</code>)</li>
   </ul>
 
   <h4>5. Configure authentication</h4>
@@ -191,7 +191,7 @@ import DocsLayout from '@/layouts/DocsLayout.astro';
   <h4>3. Add your MCP server as an action</h4>
   <ul>
     <li>In the toolkit: <strong>Add Action &rarr; Start with an MCP server</strong></li>
-    <li>Enter your MCP server URL (e.g., <code>https://mcp.wyretechnology.com/v1/mcp</code>)</li>
+    <li>Enter your MCP server URL (e.g., <code>https://mcp.wyre.ai/v1/mcp</code>)</li>
     <li>The toolkit reads the server schema, generates function definitions, and wires up auth automatically</li>
   </ul>
 

--- a/msp-claude-plugins/docs/src/pages/getting-started/gateway.astro
+++ b/msp-claude-plugins/docs/src/pages/getting-started/gateway.astro
@@ -4,16 +4,16 @@ import InstallCommand from '@/components/InstallCommand.astro';
 
 const baseUrl = import.meta.env.BASE_URL;
 
-const claudeCodeAddUser = `claude mcp add --scope user --transport http msp-mcp-gateway https://mcp.wyretechnology.com/v1/mcp`;
+const claudeCodeAddUser = `claude mcp add --scope user --transport http msp-mcp-gateway https://mcp.wyre.ai/v1/mcp`;
 
-const claudeCodeAddProject = `claude mcp add --transport http msp-mcp-gateway https://mcp.wyretechnology.com/v1/mcp`;
+const claudeCodeAddProject = `claude mcp add --transport http msp-mcp-gateway https://mcp.wyre.ai/v1/mcp`;
 
 const claudeCodeMcpJson = `// .mcp.json (in your project root) — manual alternative
 {
   "mcpServers": {
     "msp-mcp-gateway": {
       "type": "http",
-      "url": "https://mcp.wyretechnology.com/v1/mcp"
+      "url": "https://mcp.wyre.ai/v1/mcp"
     }
   }
 }`;
@@ -23,7 +23,7 @@ const claudeDesktopUnified = `// claude_desktop_config.json
   "mcpServers": {
     "msp-mcp-gateway": {
       "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.wyretechnology.com/v1/mcp"]
+      "args": ["-y", "mcp-remote", "https://mcp.wyre.ai/v1/mcp"]
     }
   }
 }`;
@@ -31,8 +31,8 @@ const claudeDesktopUnified = `// claude_desktop_config.json
 const claudeCodePerVendor = `// .mcp.json — per-vendor (legacy)
 {
   "mcpServers": {
-    "autotask": { "url": "https://mcp.wyretechnology.com/v1/autotask/mcp" },
-    "datto-rmm": { "url": "https://mcp.wyretechnology.com/v1/datto-rmm/mcp" }
+    "autotask": { "url": "https://mcp.wyre.ai/v1/autotask/mcp" },
+    "datto-rmm": { "url": "https://mcp.wyre.ai/v1/datto-rmm/mcp" }
   }
 }`;
 
@@ -41,22 +41,22 @@ const claudeDesktopPerVendor = `// claude_desktop_config.json — per-vendor (le
   "mcpServers": {
     "autotask": {
       "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.wyretechnology.com/v1/autotask/mcp"]
+      "args": ["-y", "mcp-remote", "https://mcp.wyre.ai/v1/autotask/mcp"]
     },
     "datto-rmm": {
       "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.wyretechnology.com/v1/datto-rmm/mcp"]
+      "args": ["-y", "mcp-remote", "https://mcp.wyre.ai/v1/datto-rmm/mcp"]
     }
   }
 }`;
 
 ---
-<DocsLayout title="MCP Gateway" description="Hosted MCP gateway at mcp.wyretechnology.com with OAuth 2.1 and encrypted credential storage.">
+<DocsLayout title="MCP Gateway" description="Hosted MCP gateway at mcp.wyre.ai with OAuth 2.1 and encrypted credential storage.">
   <h1>MCP Gateway</h1>
 
   <p class="lead text-lg text-[var(--muted)] mb-8">
     Connect Claude to all MSP tools through a single hosted gateway at
-    <code>mcp.wyretechnology.com</code>. No Docker, no config files — just add one URL and authenticate.
+    <code>mcp.wyre.ai</code>. No Docker, no config files — just add one URL and authenticate.
   </p>
 
   <h2>How It Works</h2>
@@ -71,7 +71,7 @@ const claudeDesktopPerVendor = `// claude_desktop_config.json — per-vendor (le
   <h2 id="supported-vendors">Supported Vendors</h2>
   <p>
     All vendors below are available through the unified endpoint at
-    <code>https://mcp.wyretechnology.com/v1/mcp</code>. You only need to connect the vendors
+    <code>https://mcp.wyre.ai/v1/mcp</code>. You only need to connect the vendors
     you use — the gateway automatically discovers which vendors you have credentials for.
   </p>
   <table>
@@ -114,7 +114,7 @@ const claudeDesktopPerVendor = `// claude_desktop_config.json — per-vendor (le
 
   <p class="text-sm text-[var(--muted)] mt-2">
     On first use, Claude Code will open a browser for OAuth authentication. After signing in, connect your
-    vendor credentials at <a href="https://mcp.wyretechnology.com" target="_blank" rel="noopener noreferrer">mcp.wyretechnology.com</a> —
+    vendor credentials at <a href="https://mcp.wyre.ai" target="_blank" rel="noopener noreferrer">mcp.wyre.ai</a> —
     all connected vendors are then available automatically.
   </p>
 
@@ -178,12 +178,12 @@ const claudeDesktopPerVendor = `// claude_desktop_config.json — per-vendor (le
     <li>Open Claude Desktop → <strong>Settings</strong> → <strong>Connectors</strong></li>
     <li>Click <strong>Add Connector</strong> (or <strong>Add custom connector</strong>)</li>
     <li>Name it <code>MSP Gateway</code> (or anything you like)</li>
-    <li>Remote MCP server URL: <code>https://mcp.wyretechnology.com/v1/mcp</code></li>
+    <li>Remote MCP server URL: <code>https://mcp.wyre.ai/v1/mcp</code></li>
     <li>Click <strong>Add</strong>, then complete the OAuth login in the browser that opens</li>
   </ol>
   <p class="text-sm text-[var(--muted)] mt-2">
     After OAuth completes, connect your vendor credentials at
-    <a href="https://mcp.wyretechnology.com" target="_blank" rel="noopener noreferrer">mcp.wyretechnology.com</a>.
+    <a href="https://mcp.wyre.ai" target="_blank" rel="noopener noreferrer">mcp.wyre.ai</a>.
     All connected vendors become available immediately.
   </p>
 
@@ -199,7 +199,7 @@ const claudeDesktopPerVendor = `// claude_desktop_config.json — per-vendor (le
   <p class="mt-4">
     That's it — one entry for all vendors. On first use, a browser will open for OAuth authentication.
     After that, add your vendor credentials via the gateway web UI at
-    <a href="https://mcp.wyretechnology.com" target="_blank" rel="noopener noreferrer">mcp.wyretechnology.com</a>.
+    <a href="https://mcp.wyre.ai" target="_blank" rel="noopener noreferrer">mcp.wyre.ai</a>.
   </p>
 
   <h4>Config File Location</h4>
@@ -226,7 +226,7 @@ const claudeDesktopPerVendor = `// claude_desktop_config.json — per-vendor (le
     <li>Click <strong>Connectors</strong></li>
     <li>Click the <strong>+</strong> button, then <strong>Add custom connector</strong></li>
     <li>Enter a name (e.g. <code>MSP Gateway</code>)</li>
-    <li>Enter the Remote MCP server URL: <code>https://mcp.wyretechnology.com/v1/mcp</code></li>
+    <li>Enter the Remote MCP server URL: <code>https://mcp.wyre.ai/v1/mcp</code></li>
     <li>Click <strong>Add</strong>, then complete the OAuth login flow when prompted</li>
   </ol>
   <p class="text-sm text-[var(--muted)] mt-2">

--- a/msp-claude-plugins/docs/src/pages/getting-started/index.astro
+++ b/msp-claude-plugins/docs/src/pages/getting-started/index.astro
@@ -33,11 +33,11 @@ const baseUrl = import.meta.env.BASE_URL;
     supported vendor:
   </p>
 
-  <pre><code class="language-bash">claude mcp add --scope user --transport http msp-mcp-gateway https://mcp.wyretechnology.com/v1/mcp</code></pre>
+  <pre><code class="language-bash">claude mcp add --scope user --transport http msp-mcp-gateway https://mcp.wyre.ai/v1/mcp</code></pre>
 
   <p>
     On Claude Desktop or Claude.ai, use the Connectors UI with URL
-    <code>https://mcp.wyretechnology.com/v1/mcp</code> — see the
+    <code>https://mcp.wyre.ai/v1/mcp</code> — see the
     <a href={`${baseUrl}getting-started/gateway/`}>Gateway setup guide</a> for step-by-step
     instructions on each surface.
   </p>

--- a/msp-claude-plugins/docs/src/pages/getting-started/installation.astro
+++ b/msp-claude-plugins/docs/src/pages/getting-started/installation.astro
@@ -19,12 +19,12 @@ const baseUrl = import.meta.env.BASE_URL;
     If you use Claude Code, a single command wires up the hosted gateway for all projects on this machine:
   </p>
 
-  <pre><code class="language-bash">claude mcp add --scope user --transport http msp-mcp-gateway https://mcp.wyretechnology.com/v1/mcp</code></pre>
+  <pre><code class="language-bash">claude mcp add --scope user --transport http msp-mcp-gateway https://mcp.wyre.ai/v1/mcp</code></pre>
 
   <p>
     Drop <code>--scope user</code> to scope the gateway to the current project only. On first tool call,
     Claude Code will open a browser for OAuth; then connect your vendor credentials at
-    <a href="https://mcp.wyretechnology.com" target="_blank" rel="noopener noreferrer">mcp.wyretechnology.com</a>.
+    <a href="https://mcp.wyre.ai" target="_blank" rel="noopener noreferrer">mcp.wyre.ai</a>.
   </p>
 
   <p class="text-sm text-[var(--muted)] mt-2">
@@ -45,7 +45,7 @@ const baseUrl = import.meta.env.BASE_URL;
     </li>
     <li>
       <strong>Add the MCP gateway server</strong> — easiest via Settings &rarr; Connectors &rarr;
-      Add custom connector, with URL <code>https://mcp.wyretechnology.com/v1/mcp</code>.
+      Add custom connector, with URL <code>https://mcp.wyre.ai/v1/mcp</code>.
     </li>
   </ol>
 
@@ -66,7 +66,7 @@ const baseUrl = import.meta.env.BASE_URL;
     <li>Click <strong>Connectors</strong></li>
     <li>Click the <strong>+</strong> button, then <strong>Add custom connector</strong></li>
     <li>Enter a name (e.g. <code>MSP Gateway</code>)</li>
-    <li>Enter the Remote MCP server URL: <code>https://mcp.wyretechnology.com/v1/mcp</code></li>
+    <li>Enter the Remote MCP server URL: <code>https://mcp.wyre.ai/v1/mcp</code></li>
     <li>Click <strong>Add</strong>, then complete the OAuth login flow when prompted</li>
   </ol>
 

--- a/msp-claude-plugins/docs/src/pages/getting-started/teams.astro
+++ b/msp-claude-plugins/docs/src/pages/getting-started/teams.astro
@@ -33,7 +33,7 @@ const baseUrl = import.meta.env.BASE_URL;
   <h2>Getting Started</h2>
 
   <ol>
-    <li>Sign in at <a href="https://mcp.wyretechnology.com/auth/login">mcp.wyretechnology.com/auth/login</a> using your work email.</li>
+    <li>Sign in at <a href="https://mcp.wyre.ai/auth/login">mcp.wyre.ai/auth/login</a> using your work email.</li>
     <li>You&apos;ll land on the <strong>Settings</strong> dashboard where you can create a team and connect vendors.</li>
   </ol>
 
@@ -152,7 +152,7 @@ const baseUrl = import.meta.env.BASE_URL;
   "mcpServers": {
     "msp-mcp-gateway": {
       "type": "http",
-      "url": "https://mcp.wyretechnology.com/v1/mcp"
+      "url": "https://mcp.wyre.ai/v1/mcp"
     }
   }
 }`}</code></pre>
@@ -176,7 +176,7 @@ const baseUrl = import.meta.env.BASE_URL;
   "mcpServers": {
     "msp-mcp-gateway": {
       "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.wyretechnology.com/v1/mcp"]
+      "args": ["-y", "mcp-remote", "https://mcp.wyre.ai/v1/mcp"]
     }
   }
 }`}</code></pre>

--- a/msp-claude-plugins/docs/src/pages/getting-started/troubleshooting.astro
+++ b/msp-claude-plugins/docs/src/pages/getting-started/troubleshooting.astro
@@ -8,7 +8,7 @@ const baseUrl = import.meta.env.BASE_URL;
 
   <p class="lead text-lg text-[var(--muted)] mb-8">
     Common issues and fixes for the MCP Gateway. If your issue isn't listed here,
-    check the <a href="https://mcp.wyretechnology.com/health/vendors" target="_blank" rel="noopener noreferrer">vendor health dashboard</a>
+    check the <a href="https://mcp.wyre.ai/health/vendors" target="_blank" rel="noopener noreferrer">vendor health dashboard</a>
     for upstream outages.
   </p>
 
@@ -26,8 +26,8 @@ const baseUrl = import.meta.env.BASE_URL;
   <h3>Fix</h3>
   <ol>
     <li>Wait 1–2 minutes and try again (deployments typically complete within 60 seconds)</li>
-    <li>Check <a href="https://mcp.wyretechnology.com/health" target="_blank" rel="noopener noreferrer"><code>/health</code></a> — if it returns <code>{`{"status":"ok"}`}</code>, the gateway is running</li>
-    <li>Check <a href="https://mcp.wyretechnology.com/health/vendors" target="_blank" rel="noopener noreferrer"><code>/health/vendors</code></a> to see if a specific vendor is down</li>
+    <li>Check <a href="https://mcp.wyre.ai/health" target="_blank" rel="noopener noreferrer"><code>/health</code></a> — if it returns <code>{`{"status":"ok"}`}</code>, the gateway is running</li>
+    <li>Check <a href="https://mcp.wyre.ai/health/vendors" target="_blank" rel="noopener noreferrer"><code>/health/vendors</code></a> to see if a specific vendor is down</li>
     <li>If the issue persists, restart Claude Desktop and try again</li>
   </ol>
 
@@ -49,7 +49,7 @@ const baseUrl = import.meta.env.BASE_URL;
   <ol>
     <li>
       <strong>Use the unified endpoint</strong> — replace all per-vendor <code>mcp-remote</code> entries with a single entry pointing
-      to <code>https://mcp.wyretechnology.com/v1/mcp</code>. This means one OAuth flow instead of many.
+      to <code>https://mcp.wyre.ai/v1/mcp</code>. This means one OAuth flow instead of many.
       See the <a href={`${baseUrl}getting-started/gateway/`}>Gateway setup guide</a>.
     </li>
     <li>If using per-vendor endpoints, add them one at a time — connect one vendor, restart Claude Desktop, then add the next</li>
@@ -81,7 +81,7 @@ const baseUrl = import.meta.env.BASE_URL;
 
   <h2 id="vendor-down">Vendor shows DOWN on /health/vendors</h2>
   <p>
-    The <a href="https://mcp.wyretechnology.com/health/vendors" target="_blank" rel="noopener noreferrer"><code>/health/vendors</code></a>
+    The <a href="https://mcp.wyre.ai/health/vendors" target="_blank" rel="noopener noreferrer"><code>/health/vendors</code></a>
     endpoint monitors all vendor MCP containers. If a vendor shows <code>"status": "down"</code>,
     the underlying vendor container is unreachable.
   </p>
@@ -105,7 +105,7 @@ const baseUrl = import.meta.env.BASE_URL;
     If you've added credentials for a vendor but its tools don't show up in Claude:
   </p>
   <ol>
-    <li>Verify your credentials are saved at <a href="https://mcp.wyretechnology.com" target="_blank" rel="noopener noreferrer">mcp.wyretechnology.com</a> — log in and check the credentials page</li>
+    <li>Verify your credentials are saved at <a href="https://mcp.wyre.ai" target="_blank" rel="noopener noreferrer">mcp.wyre.ai</a> — log in and check the credentials page</li>
     <li>Restart Claude Desktop or re-establish the MCP connection in Claude Code (<code>/mcp</code>)</li>
     <li>The unified endpoint only lists tools for vendors where you have valid credentials — if credentials are expired or invalid, that vendor is silently skipped</li>
     <li>If using org/team credentials, ensure you have the correct role and the vendor's tools are in your team's allowlist</li>


### PR DESCRIPTION
Swept the docs/src tree for residual gateway URL references after the user spotted wyretechnology.com still on https://mcp.wyre.ai/getting-started/gateway/. Hits were in the getting-started pages (authentication, teams, troubleshooting, gateway, installation, copilot, architecture, index) plus OrganizationSchema.astro.

Legal/contact emails on @wyretechnology.com left alone (legal entity preserved).

Note: this commit also picks up in-progress plugins.ts edits (product-catalog skill + procurement-specialist agent) that were sitting in the working tree — those look like legitimate companion content from PR #54/#55 that hadn't fully squash-landed; flagging here so reviewers are aware, not touching since reverting would drop real content.