### PR TITLE
fix(docs): flip canonical SITE_URL + public/ refs to mcp.wyre.ai

### DIFF
--- a/msp-claude-plugins/docs/astro.config.mjs
+++ b/msp-claude-plugins/docs/astro.config.mjs
@@ -5,10 +5,10 @@ import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
 
 // Build target: set SITE_URL and BASE_PATH env vars to override.
-// Primary (mcp.wyretechnology.com): defaults below
+// Primary (mcp.wyre.ai): defaults below
 // GitHub Pages: SITE_URL=https://wyre-technology.github.io BASE_PATH=/msp-claude-plugins/
-// Gateway (Docker): SITE_URL=https://mcp.wyretechnology.com BASE_PATH=/docs/
-const site = process.env.SITE_URL || 'https://mcp.wyretechnology.com';
+// Gateway (Docker): SITE_URL=https://mcp.wyre.ai BASE_PATH=/docs/
+const site = process.env.SITE_URL || 'https://mcp.wyre.ai';
 const base = process.env.BASE_PATH || '/';
 
 // https://astro.build/config

--- a/msp-claude-plugins/docs/public/llms.txt
+++ b/msp-claude-plugins/docs/public/llms.txt
@@ -8,7 +8,7 @@ MSP Claude Plugins is a free, open-source collection of integrations that connec
 
 MSP Claude Plugins provides two ways to connect MSP tools to Claude:
 
-1. **Hosted Gateway** (recommended): A cloud-hosted MCP gateway at mcp.wyretechnology.com. Connect Claude Desktop or any MCP client with OAuth 2.1 + PKCE authentication. No servers to manage, encrypted credential storage with per-user isolation.
+1. **Hosted Gateway** (recommended): A cloud-hosted MCP gateway at mcp.wyre.ai. Connect Claude Desktop or any MCP client with OAuth 2.1 + PKCE authentication. No servers to manage, encrypted credential storage with per-user isolation.
 
 2. **Self-Hosted**: Run MCP servers locally. Install via Claude Code marketplace with `/plugin marketplace add wyre-technology/msp-claude-plugins`. Full control, credentials stay on your machine.
 
@@ -54,13 +54,13 @@ MSP Claude Plugins provides two ways to connect MSP tools to Claude:
 
 ## Pricing
 
-All MSP Claude Plugins are free and open source under the Apache 2.0 license. The hosted gateway has a free tier (details at mcp.wyretechnology.com/waitlist).
+All MSP Claude Plugins are free and open source under the Apache 2.0 license. The hosted gateway has a free tier (details at mcp.wyre.ai/waitlist).
 
 ## Links
 
-- Website: https://mcp.wyretechnology.com
+- Website: https://mcp.wyre.ai
 - GitHub: https://github.com/wyre-technology/msp-claude-plugins
-- Getting Started: https://mcp.wyretechnology.com/getting-started/
-- Gateway: https://mcp.wyretechnology.com/getting-started/gateway/
-- All Plugins: https://mcp.wyretechnology.com/plugins/
-- Waitlist: https://mcp.wyretechnology.com/waitlist
+- Getting Started: https://mcp.wyre.ai/getting-started/
+- Gateway: https://mcp.wyre.ai/getting-started/gateway/
+- All Plugins: https://mcp.wyre.ai/plugins/
+- Waitlist: https://mcp.wyre.ai/waitlist

--- a/msp-claude-plugins/docs/public/robots.txt
+++ b/msp-claude-plugins/docs/public/robots.txt
@@ -26,4 +26,4 @@ Allow: /
 User-agent: Google-Extended
 Allow: /
 
-Sitemap: https://mcp.wyretechnology.com/sitemap-index.xml
+Sitemap: https://mcp.wyre.ai/sitemap-index.xml


### PR DESCRIPTION
Completes the sweep after PR #61 — the remaining live wyretechnology.com residuals on mcp.wyre.ai pages came from canonical `site` in astro.config.mjs (used for JSON-LD logo, OG image URL, sitemap) plus robots.txt and llms.txt in public/. All three flipped to mcp.wyre.ai. Build verified clean.