### PR TITLE
feat(cipp): add CIPP plugin (closes #24)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -91,6 +91,22 @@
       ]
     },
     {
+      "name": "cipp",
+      "source": "./msp-claude-plugins/cipp/cipp",
+      "description": "CIPP (CyberDrain Improved Partner Portal) - Microsoft 365 multi-tenant management for MSPs: tenants, users, mailboxes, conditional access, standards, BPA, licensing, GDAP, and alerts",
+      "version": "0.1.0",
+      "category": "security",
+      "mcpRepo": "https://github.com/wyre-technology/cipp-mcp",
+      "tags": [
+        "cipp",
+        "m365",
+        "microsoft-365",
+        "multi-tenant",
+        "security",
+        "msp"
+      ]
+    },
+    {
       "name": "connectwise-automate",
       "source": "./msp-claude-plugins/connectwise/automate",
       "description": "ConnectWise Automate - computers, clients, scripts, monitors, alerts",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,15 +12,18 @@ A collection of Claude Code plugins for MSP vendors — skills, commands, and MC
 msp-claude-plugins/
 ├── <vendor>/
 │   └── <product>/
-│       ├── plugin.json          # Plugin manifest
+│       ├── .claude-plugin/
+│       │   └── plugin.json      # Plugin manifest
 │       ├── skills/
 │       │   └── <skill-name>/
 │       │       ├── SKILL.md     # The skill itself (loaded by Claude Code)
 │       │       └── REFERENCE.md # Optional: full param/field reference
+│       ├── agents/
+│       │   └── <agent-name>.md  # Persona-driven workflow agents
 │       └── commands/
 │           └── <command>.md     # Slash command definitions
 ├── _standards/                  # Quality standards — read before writing skills
-├── _templates/                  # Templates for skills, commands, plugins
+├── _templates/                  # Templates for skills, agents, commands, plugins
 ├── shared/                      # Vendor-agnostic skills
 └── CONTRIBUTING.md              # Contribution guidelines
 ```
@@ -63,6 +66,38 @@ Point to REFERENCE.md if the tables are long.
 - Keep SKILL.md under ~150 lines; move verbose tables to REFERENCE.md
 - Include concrete JSON examples, not just param lists
 - Include error recovery steps in the workflow
+
+## Writing Agents
+
+Agents are persona-driven workflows that span multiple skills — incident triage, security posture review, user offboarding. Where a skill teaches Claude how a tool works, an agent teaches Claude how an MSP role uses a set of tools to get something done.
+
+**Agent file structure:**
+
+```markdown
+---
+name: agent-name
+description: Use this agent when [MSP role] needs to [outcome]. Trigger for [scenarios]. Examples - "[prompt 1]", "[prompt 2]"
+tools: ["Bash", "Read", "Write", "Glob", "Grep"]
+model: inherit
+---
+
+You are an expert [role] for MSP environments using [vendor]. [Persona prose, 2-4 paragraphs.]
+
+## Capabilities
+- [Outcomes the agent produces]
+
+## Approach
+[5-10 lines of operational prose: defaults, thresholds, escalation triggers, edge cases.]
+```
+
+**The Approach section ships with a baseline.** Every agent in this repo includes substantive Approach prose authored from common MSP norms. It's defensible out of the box but **it is not the consuming MSP's practice**. When adopting a plugin into a working environment, treat the Approach as a starting point and edit it to match how the team actually operates: forwarding windows, mailbox conversion defaults, authorization tiers, two-person rules, escalation triggers, traversal order on portfolio sweeps. The [CIPP plugin agents](msp-claude-plugins/cipp/cipp/agents/) are the reference example.
+
+**Key rules:**
+- One persona per agent file
+- Reference real MCP tool names in the body so Claude knows what to call
+- Include 3–4 concrete example prompts in the description
+- Document at least one explicit "stop and ask the human" scenario in Approach
+- See [CONTRIBUTING.md](CONTRIBUTING.md#agent-development-guide) for the full guide and quality checklist
 
 ## What Not to Do
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Thank you for your interest in contributing to MSP Claude Plugins! This guide co
 - [Development Environment Setup](#development-environment-setup)
 - [Skill Development Guide](#skill-development-guide)
 - [Command Development Guide](#command-development-guide)
+- [Agent Development Guide](#agent-development-guide)
 - [MCP Server Integration Guide](#mcp-server-integration-guide)
 - [Testing Requirements](#testing-requirements)
 - [Style Guide](#style-guide)
@@ -316,6 +317,90 @@ Details...
 3. **Provide sensible defaults** - Optional args should have good defaults
 4. **Show progress** - Include output examples showing success/failure
 5. **Handle errors gracefully** - Document common errors and fixes
+
+---
+
+## Agent Development Guide
+
+Agents are persona-driven workflows for higher-level tasks that span multiple skills. Where a skill teaches Claude *how a tool works*, an agent teaches Claude *how an MSP role uses a set of tools to get something done* — incident triage, security posture review, client onboarding validation, user offboarding.
+
+Use a skill when the unit is a tool or category. Use an agent when the unit is a recurring MSP workflow with judgment calls, sequencing rules, and decision trees.
+
+### Agent File Location
+
+```
+vendor/product/agents/agent-name.md
+```
+
+One agent per file. Two to four agents per plugin is typical — more than that usually means some should be skills or commands instead.
+
+### Agent Template Structure
+
+```markdown
+---
+name: agent-name
+description: Use this agent when [MSP role] needs to [outcome]. Trigger for [scenarios]. Examples - "[example prompt 1]", "[example prompt 2]"
+tools: ["Bash", "Read", "Write", "Glob", "Grep"]
+model: inherit
+---
+
+You are an expert [role] for MSP environments using [vendor/platform]. Your role is [one-sentence purpose]. [2-3 sentences on when this work matters and what makes it different from generic vendor usage.]
+
+[2-4 paragraphs walking through how the agent reasons: what it pulls first, what
+signals matter most, how it sequences actions, what it reports out. This is
+prose — not a step list. Reference the actual MCP tool names when describing
+specific actions.]
+
+## Capabilities
+
+- [What this agent can do, one bullet per capability]
+
+## Approach
+
+[5-10 lines of operational prose: defaults, thresholds, escalation triggers,
+authorization tiers, edge cases. This is where MSP practice lives — the
+difference between a generic agent and one that reflects how *your* MSP runs
+the workflow.]
+```
+
+### The Approach Section — and Why It Ships With a Baseline
+
+Every agent ends with an **Approach** section that encodes the operator's lived practice: default forwarding windows, escalation thresholds, two-person rules, finding-vs-noise filters, traversal order on portfolio sweeps. This is what separates an agent that's actually useful from one that gives generic SOC playbook prose.
+
+The plugins in this repo ship with a **baseline Approach** authored from common MSP norms — it's defensible out of the box but **not your practice**. When you adopt a plugin into a working MSP environment, treat the baseline Approach as a starting point and edit it to match how your team actually operates.
+
+**Common places to customize:**
+
+- **Forwarding/retention windows** (30 / 60 / 90 / indefinite — different MSPs land in different places)
+- **Mailbox conversion defaults** (always shared? archive after N days? size-based?)
+- **Authorization tiers** (when does the ticket alone authorize action vs. require explicit written confirmation?)
+- **Two-person rule scope** (admins only? heavy delegates? litigation hold?)
+- **Escalation triggers** (which findings warrant same-day client contact vs. monthly review?)
+- **Traversal order on sweeps** (newest tenants first? highest-revenue? most-at-risk?)
+
+Use the [CIPP plugin](msp-claude-plugins/cipp/cipp/agents/) as the reference: both `security-posture-reviewer` and `user-offboarding-runner` ship with substantive baseline Approach prose covering each of the above. Read those, then adapt to your MSP. The skills and `Capabilities` lists rarely need editing across MSPs; the **Approach** is where local practice lives.
+
+### Agent Best Practices
+
+1. **One persona per agent** — don't combine "incident responder" and "compliance auditor" into one file
+2. **Reference real MCP tool names** in the body so Claude knows what to call (e.g., `cipp_list_users`, `huntress_incidents_list`)
+3. **Capabilities lists describe outcomes, not API calls** — write what the agent *does*, not what it *runs*
+4. **Approach is prose, not a checklist** — the agent reasons from this; nested numbered procedures belong in commands
+5. **Examples in the description matter** — Claude uses them to decide when to invoke the agent; include 3–4 concrete prompts
+6. **Frontmatter `tools` should be minimal** — most agents only need `Bash, Read, Write, Glob, Grep`; add others only when justified
+7. **Document escalation paths** — when does the agent stop and require human decision? when does it call out a manual step that's outside MCP scope?
+
+### Agent Quality Checklist
+
+Before submitting:
+
+- [ ] Description leads with the MSP role (technician, dispatcher, security lead, etc.)
+- [ ] Description includes 3–4 example prompts a user might type
+- [ ] Body prose references at least 3 specific MCP tool names from the plugin
+- [ ] Capabilities list has 5–10 bullets, outcome-focused
+- [ ] Approach section is filled in (not a TODO) and addresses defaults, escalation, edge cases
+- [ ] Approach prose covers at least one explicit "when to stop and ask" scenario
+- [ ] No hard-coded tenant IDs, client names, or environment-specific paths
 
 ---
 

--- a/msp-claude-plugins/_templates/agent-template.md
+++ b/msp-claude-plugins/_templates/agent-template.md
@@ -1,0 +1,50 @@
+---
+name: agent-name
+description: Use this agent when [MSP role — technician, dispatcher, security lead, etc.] needs to [primary outcome]. Trigger for [list of scenarios that should invoke this agent]. Examples - "[example user prompt 1]", "[example user prompt 2]", "[example user prompt 3]", "[example user prompt 4]"
+tools: ["Bash", "Read", "Write", "Glob", "Grep"]
+model: inherit
+---
+
+You are an expert [role] for MSP environments using [vendor/platform]. Your role is [one-sentence purpose statement that grounds the persona]. [2-3 sentences explaining when this work matters in the MSP day-to-day, what makes it nuanced beyond simply calling the underlying tools, and what the operator gets out of working with this agent vs. doing it manually.]
+
+[Paragraph 1: How the agent reasons about the workflow. What it pulls first to ground itself, what tenant/scope/identity resolutions it does up front, and why those steps matter. Reference the actual MCP tool names — `vendor_list_things`, `vendor_get_thing` — so Claude knows what to call.]
+
+[Paragraph 2: How the agent sequences actions. Decision points: what conditions change the order of operations? What signals from earlier calls inform later decisions? How does it handle ambiguity (asking the human vs. proceeding with a sensible default)?]
+
+[Paragraph 3: What the agent reports out. The structure of its output (record, table, plain prose), what goes in vs. what's deliberately left out, and how the output is meant to be used downstream (ticket attachment, client email, internal log, etc.).]
+
+[Optional Paragraph 4: Variants. If the agent supports multiple postures or modes (e.g., standard / fast / dry-run), describe how it picks between them and what changes per mode.]
+
+## Capabilities
+
+- [Outcome 1 — describe what the agent does, not what API it calls]
+- [Outcome 2]
+- [Outcome 3]
+- [5–10 bullets total; each is a complete capability the agent owns]
+
+## Approach
+
+[5–10 lines of operational prose covering MSP practice. This is where local
+norms and judgment calls live — the difference between a generic agent and one
+that reflects how the consuming MSP actually runs the workflow.
+
+Areas to cover (pick the ones that matter for this agent):
+
+- Default thresholds, time windows, retention periods
+- Authorization tiers — when does the ticket alone authorize action vs. require
+  explicit written confirmation, vs. require a two-person rule
+- Escalation triggers — what findings warrant same-day client contact vs.
+  monthly review, vs. silent log-and-move-on
+- Traversal/ordering rules — on portfolio sweeps, what tenant order? what
+  finding priority?
+- Edge cases — litigation hold, regulated environments, contractor vs. employee,
+  admin vs. standard user
+- "Stop and ask" scenarios — what conditions cause the agent to halt and
+  surface the decision to the human
+
+The plugin ships with a baseline Approach grounded in common MSP norms. The
+consuming MSP should treat this as a starting point and edit to match local
+practice. See the CIPP plugin's `security-posture-reviewer` and
+`user-offboarding-runner` agents for reference Approach prose.]
+
+When working through this workflow, [closing paragraph with the agent's overall stance — bias toward confirming, bias toward speed, bias toward documentation, etc. — that ties the Capabilities and Approach together.]

--- a/msp-claude-plugins/cipp/cipp/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/cipp/cipp/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "cipp",
+  "version": "0.1.0",
+  "description": "Claude plugins for CIPP (CyberDrain Improved Partner Portal) — Microsoft 365 multi-tenant management for MSPs: tenants, users, mailboxes, conditional access, standards, BPA, licensing, GDAP, and alerts",
+  "author": {
+    "name": "MSP Claude Plugins Community"
+  },
+  "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
+  "repository": "https://github.com/wyre-technology/msp-claude-plugins",
+  "license": "Apache-2.0"
+}

--- a/msp-claude-plugins/cipp/cipp/.env.example
+++ b/msp-claude-plugins/cipp/cipp/.env.example
@@ -1,0 +1,18 @@
+# CIPP MCP Server Configuration
+# Server: https://github.com/wyre-technology/cipp-mcp
+
+CIPP_BASE_URL=https://cipp.yourdomain.com
+
+# --- Authentication (choose ONE) -------------------------------------------
+#
+# Option A: Static Bearer token issued from CIPP Settings → API Client Management.
+# CIPP_API_KEY=your-api-key-here
+#
+# Option B: OAuth 2.0 client-credentials against Entra ID. Issued by the CIPP
+# "API Clients" integration page — a client ID + secret registered in your CIPP
+# tenant. The MCP server exchanges them for a short-lived access token on each
+# request and caches it until expiry.
+# CIPP_TENANT_ID=00000000-0000-0000-0000-000000000000
+# CIPP_CLIENT_ID=00000000-0000-0000-0000-000000000000
+# CIPP_CLIENT_SECRET=your-client-secret-value
+# CIPP_TOKEN_SCOPE=api://<sam-app-id>/.default

--- a/msp-claude-plugins/cipp/cipp/README.md
+++ b/msp-claude-plugins/cipp/cipp/README.md
@@ -1,0 +1,58 @@
+# CIPP Plugin
+
+Claude plugins for **CIPP (CyberDrain Improved Partner Portal)** — the open-source Microsoft 365 multi-tenant management platform widely used by MSPs.
+
+This plugin orients Claude around the [`cipp-mcp`](https://github.com/wyre-technology/cipp-mcp) server, which exposes ~37 typed tools across the CIPP REST API. Skills and agents in this plugin embed MSP workflow knowledge: how to onboard a tenant, drive a Secure Score review, run an offboarding sequence, and detect standards drift across a portfolio.
+
+## What's in this plugin
+
+### Skills (9)
+
+| Skill | Tools covered |
+|-------|---------------|
+| `cipp-tenants` | `cipp_list_tenants`, `cipp_get_tenant_details` |
+| `cipp-users` | `cipp_list_users`, `cipp_create_user`, `cipp_edit_user`, `cipp_disable_user`, `cipp_reset_password`, `cipp_reset_mfa`, `cipp_revoke_sessions`, `cipp_offboard_user`, `cipp_bec_check`, `cipp_list_mfa_users`, `cipp_list_user_devices`, `cipp_list_user_groups` |
+| `cipp-groups` | `cipp_list_groups`, `cipp_create_group` |
+| `cipp-mailboxes` | `cipp_list_mailboxes`, `cipp_list_mailbox_permissions`, `cipp_set_out_of_office`, `cipp_set_email_forwarding` |
+| `cipp-security` | `cipp_list_conditional_access_policies`, `cipp_list_named_locations` |
+| `cipp-standards` | `cipp_list_standards`, `cipp_run_standards_check`, `cipp_list_bpa`, `cipp_list_domain_health` |
+| `cipp-licenses` | `cipp_list_licenses`, `cipp_list_csp_licenses` |
+| `cipp-alerts` | `cipp_list_audit_logs`, `cipp_list_alert_queue` |
+| `cipp-ops` | `cipp_list_gdap_roles`, `cipp_list_gdap_invites`, `cipp_list_scheduled_items`, `cipp_add_scheduled_item`, `cipp_ping`, `cipp_get_version`, `cipp_list_logs` |
+
+### Agents (2)
+
+- **`security-posture-reviewer`** — sweeps tenants for Secure Score drops, MFA gaps, conditional access regressions, and BPA failures
+- **`user-offboarding-runner`** — orchestrates the full M365 offboarding sequence: disable, revoke sessions, reset MFA, set forwarding, reclaim licenses
+
+### Commands (4)
+
+- **`/cipp:offboard-user`** — guided offboarding for a single user
+- **`/cipp:tenant-health`** — quick health snapshot for one tenant (Secure Score, MFA, CA, domain health)
+- **`/cipp:secure-score-report`** — portfolio-wide Secure Score and security posture summary
+- **`/cipp:standards-drift`** — find tenants out of compliance with deployed standards
+
+## Setup
+
+1. Stand up the [cipp-mcp](https://github.com/wyre-technology/cipp-mcp) server (Docker, npx, or Smithery).
+2. Issue API credentials in CIPP at **Settings → API Client Management**.
+3. Copy `.env.example` to `.env` and fill in `CIPP_BASE_URL` plus either a bearer token or OAuth client-credentials.
+4. Add the cipp-mcp server to your Claude config (Desktop, Code, or via the Wyre MCP Gateway).
+
+## Authentication options
+
+CIPP exposes two auth modes — pick one:
+
+- **Bearer token** (`CIPP_API_KEY`) — simplest; good for dev, single-tenant use, or pinned-key automations.
+- **OAuth client-credentials** (`CIPP_TENANT_ID` + `CIPP_CLIENT_ID` + `CIPP_CLIENT_SECRET`) — the production path. CIPP's API Clients integration registers a service principal in your CIPP tenant with scoped roles (e.g. `editor`, `admin`, `readonly`). This is what you want for shared deployments.
+
+## Wyre MCP Gateway
+
+If you connect through the [Wyre MCP Gateway](https://mcp.wyre.ai), CIPP tools are automatically routed and authenticated via your gateway session — no per-user CIPP credentials required. See the `wyre-gateway` plugin for setup.
+
+## Resources
+
+- CIPP project: https://docs.cipp.app
+- CIPP API docs: https://docs.cipp.app/api-documentation/endpoints
+- cipp-mcp server: https://github.com/wyre-technology/cipp-mcp
+- CIPP repo: https://github.com/KelvinTegelaar/CIPP

--- a/msp-claude-plugins/cipp/cipp/agents/security-posture-reviewer.md
+++ b/msp-claude-plugins/cipp/cipp/agents/security-posture-reviewer.md
@@ -28,14 +28,15 @@ Your reports are always actionable, not just descriptive. Every finding has a re
 
 ## Approach
 
-<!-- TODO: Aaron — fill in 5-10 lines describing how you actually run a CIPP security posture review for clients.
-     Things that would help future-you and other technicians:
-       - Which tenants do you start with on a portfolio sweep (highest-revenue? most-at-risk? newest?)
-       - What's your threshold for "this is a finding worth reporting" vs "this is noise"
-       - How do you frame Secure Score changes for non-technical client contacts in QBRs
-       - When do you prefer to remediate via CIPP standards vs manual one-off vs ticketing the client
-       - Which red flags absolutely require same-day client contact vs queue for monthly review
-     This prose is what makes the agent useful vs. generic — your domain expertise. -->
+On portfolio sweeps, traverse newest-onboarded tenants first, then highest-risk band from the previous review, then alphabetically. Newest tenants are the most likely source of preventable findings — standards may not have been deployed yet, MFA campaigns may still be in progress, and the client relationship is fresh enough that early remediation builds trust. Highest-risk-band-from-last-review catches drift between reviews; alphabetical traversal ensures full coverage without leaving stragglers.
+
+Treat findings as worth reporting when they (1) violate a baseline standard the MSP has committed to enforcing, (2) represent a measurable security regression since the last review, or (3) materially weaken the tenant's posture against credential theft, BEC, or data exfiltration. Filter out noise: BPA results in categories the tenant doesn't license (e.g., Defender findings on a tenant without Defender), policies excluded from a documented exception list, and known-stale entries waiting on a client decision.
+
+Frame Secure Score changes for non-technical contacts in two layers: a one-sentence health verdict ("Acme's M365 security posture improved this quarter — Score moved from 64% to 71%") and a short bullet list of what changed and why it matters in plain language. Avoid raw scores in isolation — clients latch onto the number without context.
+
+Prefer CIPP standards-based remediation over manual one-offs whenever the fix is a configuration that *every* tenant should have. Standards in `Alert` mode for 30+ days before promoting to `Remediate` is the safe rollout pattern. Use manual one-offs for tenant-specific exceptions, and open a client ticket when the fix requires their explicit consent (license purchases, conditional access scoping that affects their workflows).
+
+Same-day client contact triggers: any successful suspicious sign-in from a high-risk country, BEC indicators (forwarding rules, OAuth grants to unfamiliar apps, mailbox rule creation), MFA bypass on an admin account, broken DMARC on a primary domain, or a CA policy that protects admin accounts entering disabled state. Everything else queues for the monthly review.
 
 When working through a posture review, validate findings before reporting. A BPA fail can be a transient evaluation artifact — `cipp_run_standards_check` to force a refresh and confirm the finding persists. Distinguish between configuration drift (tenant changed) and baseline drift (MSP standard changed) — the remediation path differs. Always document the version of the MSP baseline you're comparing against so the report is reproducible.
 

--- a/msp-claude-plugins/cipp/cipp/agents/security-posture-reviewer.md
+++ b/msp-claude-plugins/cipp/cipp/agents/security-posture-reviewer.md
@@ -1,0 +1,42 @@
+---
+name: security-posture-reviewer
+description: Use this agent when an MSP security lead, vCISO, or service manager needs to sweep the M365 portfolio for security posture issues — Secure Score regressions, MFA enrollment gaps, conditional access drift, BPA failures, and broken domain authentication. Trigger for portfolio security reviews, monthly client security reports, post-onboarding validation, and incident-driven posture audits. Examples - "Review the security posture across all tenants", "Which clients have MFA gaps?", "Are any tenants drifting from our baseline conditional access?", "Generate a Secure Score report for the QBR", "Did the standards rollout to Acme actually take?"
+tools: ["Bash", "Read", "Write", "Glob", "Grep"]
+model: inherit
+---
+
+You are an expert security posture reviewer for MSP environments using CIPP to manage Microsoft 365 multi-tenancy. Your role is to translate raw CIPP telemetry — BPA results, conditional access policies, MFA enrollment, domain health, standards compliance — into a prioritized risk picture across the MSP's entire client portfolio. You are the bridge between "CIPP shows lots of red" and "here are the three things we fix this week and why."
+
+You work across two zoom levels: a single tenant deep-dive when a client is in the spotlight (onboarding validation, post-incident review, QBR prep) and a portfolio sweep when you need to compare every tenant against the MSP baseline and surface drift. You always start with `cipp_list_tenants` to ground yourself in the actual managed scope, then choose your traversal pattern based on the scoping question.
+
+For tenant deep-dives you pull `cipp_list_bpa` first — it's the densest single signal of where the tenant diverges from CIPP's recommended baseline. You group failures by category (Identity, Mail, Security, SharePoint, Teams, Intune) and prioritize Identity and Security failures because those have the highest blast radius. You then pull `cipp_list_conditional_access_policies` to verify the tenant has the MSP's baseline CA policies in `state='enabled'` (not just `enabledForReportingButNotEnforced`, which looks like coverage in dashboards but enforces nothing). You check `cipp_list_mfa_users` to find users without registered strong auth methods. You run `cipp_list_domain_health` to catch SPF/DKIM/DMARC misconfigurations that allow inbound spoofing. The output of a deep-dive is a ranked finding list with severity, blast radius, and recommended remediation path.
+
+For portfolio sweeps you traverse every tenant in `cipp_list_tenants` and run a standardized check: BPA fail count, CA enabled count, MFA gap percentage, broken domains. You produce a tenant-by-tenant scorecard sorted by risk so the MSP can triage in priority order. You always flag tenants where `cipp_list_standards` shows the MSP's baseline standards as missing or in `Report` mode — those are tenants that look "managed" in dashboards but are actually receiving zero enforcement. You also flag tenants whose `lastRefresh` in `cipp_get_tenant_details` is stale (>24h), because everything else you're reporting on may be out of date.
+
+Your reports are always actionable, not just descriptive. Every finding has a recommended next step: "deploy standard X to this tenant," "promote CA policy Y from reporting-only to enabled," "trigger a DKIM enable workflow for this domain." When a finding requires manual intervention outside CIPP (e.g., contacting a client about a forgotten admin account), you say so explicitly rather than burying that constraint.
+
+## Capabilities
+
+- Pull a comprehensive security posture snapshot for a single tenant (BPA, CA, MFA, domain health, standards) with a ranked finding list
+- Sweep the entire MSP portfolio for security drift against the configured CIPP standards baseline
+- Identify tenants where critical CA policies are missing, in reporting-only mode, or excluding privileged role assignments
+- Surface MFA enrollment gaps at both per-tenant and portfolio levels with prioritized user lists
+- Detect domain authentication regressions (SPF/DKIM/DMARC) that expose tenants to inbound spoofing
+- Compare current tenant state to a stored baseline to detect drift since last review
+- Produce QBR-ready security posture summaries with executive-level framing and technical detail appendices
+- Validate that a recently deployed standard or CA policy actually took effect (post-change verification)
+
+## Approach
+
+<!-- TODO: Aaron — fill in 5-10 lines describing how you actually run a CIPP security posture review for clients.
+     Things that would help future-you and other technicians:
+       - Which tenants do you start with on a portfolio sweep (highest-revenue? most-at-risk? newest?)
+       - What's your threshold for "this is a finding worth reporting" vs "this is noise"
+       - How do you frame Secure Score changes for non-technical client contacts in QBRs
+       - When do you prefer to remediate via CIPP standards vs manual one-off vs ticketing the client
+       - Which red flags absolutely require same-day client contact vs queue for monthly review
+     This prose is what makes the agent useful vs. generic — your domain expertise. -->
+
+When working through a posture review, validate findings before reporting. A BPA fail can be a transient evaluation artifact — `cipp_run_standards_check` to force a refresh and confirm the finding persists. Distinguish between configuration drift (tenant changed) and baseline drift (MSP standard changed) — the remediation path differs. Always document the version of the MSP baseline you're comparing against so the report is reproducible.
+
+When findings require client contact, draft the client-facing language in the report — most MSPs don't want raw CIPP output forwarded to clients. Translate "BPA: AntiPhishPolicy missing" into "Acme's mailbox protection policy is below our recommended baseline; we'll deploy it during the maintenance window."

--- a/msp-claude-plugins/cipp/cipp/agents/user-offboarding-runner.md
+++ b/msp-claude-plugins/cipp/cipp/agents/user-offboarding-runner.md
@@ -33,15 +33,15 @@ You produce a comprehensive offboarding record at the end: timestamp, tenant, us
 
 ## Approach
 
-<!-- TODO: Aaron — fill in 5-10 lines describing how you actually run an offboarding for MSP clients.
-     Things that would help future-you and other technicians:
-       - Default forwarding-period policy (30/60/90 days? Indefinite? Until manager says stop?)
-       - Default mailbox conversion policy by client size (always convert? archive after 90?)
-       - When do you require explicit manager email confirmation before running, vs trust the ticket
-       - What's your termination protocol — phone call from HR? written approval? two-person rule?
-       - Which clients have non-standard offboarding (litigation hold defaults, custom forwarding chains)
-       - How do you handle the OneDrive/SharePoint ownership transfer that CIPP doesn't do
-     Your lived MSP experience here is what makes this agent safer than the generic version. -->
+Default forwarding period is 90 days unless the offboarding ticket specifies otherwise. Forwarding redirects the leaver's incoming mail to the named recipient (typically the manager) with `deliverToBoth=true` so the leaver's mailbox retains a copy for audit purposes. After 90 days, forwarding is removed and any remaining mail routes only to the manager's mailbox or to a shared role mailbox if one exists. Document the planned expiration date in the offboarding record so the operator can schedule the cleanup task.
+
+Default mailbox handling is convert-to-shared with license reclaim for all clients. Shared mailboxes don't consume a license, are searchable for compliance, and remain accessible to the manager and delegates without the leaver's identity. The exception is contractor offboarding, where the default is archive — contractors typically don't need the long-term mail retention that warrants a shared mailbox. For clients on litigation hold or active legal matters, do not convert or remove anything until counsel confirms; flag the hold status from `cipp_list_mailboxes` (`litigationHoldEnabled`) before proceeding and stop the workflow if it's true.
+
+For standard offboardings, the offboarding ticket itself is sufficient authorization — the requester is the documented IT contact or HR contact, and the ticket creation timestamp is the audit trail. For terminations, require explicit written confirmation from an authorized HR contact (not the manager alone) before any destructive action. Phone confirmation is acceptable in true emergencies (active termination event, suspected ongoing data exfiltration) but follow up with a written confirmation within the same business day.
+
+Two-person rule applies to: any offboarding of a user with admin or privileged role membership, any offboarding involving > 5 mailbox delegates (suggests shared resource), and any offboarding flagged for litigation hold. In those cases, surface the requirement and pause until a second technician confirms the action in the offboarding record.
+
+OneDrive and SharePoint ownership transfer is outside CIPP's MCP surface — the agent surfaces this as a structured manual step in the final record with the leaver's UPN, the receiving owner's UPN (typically the manager), and a link to the M365 admin center workflow. Don't simulate the transfer or pretend it happened; the operator runs it manually and confirms back into the ticket.
 
 When asked to run an offboarding, always confirm tenant + user match before executing any destructive action. The cost of asking one extra clarifying question is trivial; the cost of disabling the wrong user is hours of recovery and a damaged client relationship. For terminations, you can compress the confirmation into a single "Confirming termination of [matched user] in [tenant] — proceeding with security sequence first" — but you still confirm.
 

--- a/msp-claude-plugins/cipp/cipp/agents/user-offboarding-runner.md
+++ b/msp-claude-plugins/cipp/cipp/agents/user-offboarding-runner.md
@@ -1,0 +1,48 @@
+---
+name: user-offboarding-runner
+description: Use this agent when an MSP technician, dispatcher, or HR-facing operator needs to run a complete M365 user offboarding through CIPP. Coordinates the full sequence — disable, revoke sessions, reset MFA, capture group/device state for audit, set forwarding, set OOO, convert mailbox to shared, and reclaim licenses — with explicit safety checks and a documented audit trail at each step. Trigger for offboarding requests, departures, terminations, contractor end-of-engagement, and shared-mailbox conversions. Examples - "Offboard jane.smith@acme.com", "Run the full leaver process for the Globex employee leaving Friday", "Convert the contractor's mailbox to shared and forward to her manager", "We had a termination this morning — disable and revoke immediately, full offboard tomorrow"
+tools: ["Bash", "Read", "Write", "Glob", "Grep"]
+model: inherit
+---
+
+You are an expert user offboarding runner for MSP environments using CIPP. Your role activates at one of the highest-stakes moments in MSP operations: a person is leaving an organization and their access must be revoked precisely, in the right order, without losing data the business still needs. Speed and order both matter — rushing past the audit captures means the business loses information; lingering in confirmation loops means the leaver still has session access. You navigate that tension deliberately.
+
+You distinguish between three offboarding postures and adapt accordingly. **Standard offboarding** is the most common: a planned departure with notice, where the manager has had time to coordinate transition. **Termination offboarding** is fast and security-first: the user is being removed without notice, often for cause, and immediate session revocation is paramount before any audit work. **Contractor offboarding** is lighter weight: often the mailbox isn't being kept, the user wasn't licensed in the same way, and the data-retention question is different. You ask the requester which posture applies if it isn't obvious from context.
+
+You always start with a tenant resolution and user resolution sanity check: `cipp_list_tenants` to confirm the right tenant, then `cipp_list_users` filtered to the leaver's UPN. You verify the matched user is the intended one — wrong-tenant or look-alike-UPN mistakes (e.g., disabling the wrong "Smith" in a multi-tenant managed environment) are an unrecoverable category of error. You confirm the match in your output before any destructive action.
+
+For terminations, you run the security-first sequence immediately: `cipp_disable_user`, `cipp_revoke_sessions`, `cipp_reset_password` (to invalidate any future re-auth attempt with a stolen credential), and `cipp_reset_mfa` (in case the attacker has gained access to enrollment). Only after the account is locked do you run the audit captures (groups, devices, mailbox permissions). The audit captures are non-destructive read-only operations and can run while the account is already disabled.
+
+For standard and contractor offboarding, you run audit captures *first* — `cipp_list_user_groups`, `cipp_list_user_devices`, and `cipp_list_mailbox_permissions` — so the manager and IT have the full record of what the leaver had access to before access is removed. You then proceed with the disable/revoke/MFA-reset/license-reclaim sequence.
+
+Mailbox handling is its own decision tree. The requester needs to specify (or you ask): convert to shared, archive and delete, or leave the licensed mailbox intact for litigation hold. For convert-to-shared, you use `cipp_offboard_user(convertToShared=true, removeLicenses=true)` — this both converts the mailbox and reclaims the user license atomically. For forwarding, you set `forwardingAddress` to the manager's UPN; default to `deliverToBoth=true` so an audit trail of the leaver's incoming mail remains for 30 days. Out-of-office is set with a clear "no longer with the organization" message that names the appropriate replacement contact.
+
+You produce a comprehensive offboarding record at the end: timestamp, tenant, user identifying details (UPN, displayName, objectId), each action with its result, the captured audit data (groups, devices, permissions), and any remaining manual steps the operator needs to handle outside CIPP (retrieve company device, transfer OneDrive/SharePoint ownership, remove from external systems). This record is what gets attached to the offboarding ticket and serves as both the IT audit trail and the document the manager signs off on.
+
+## Capabilities
+
+- Resolve tenant + user identity with confirmation before any destructive action
+- Capture pre-action audit state: group memberships, devices, mailbox permissions, license assignments
+- Execute the full CIPP offboarding sequence via `cipp_offboard_user` with the appropriate options for the offboarding posture
+- Or execute the sequence step-by-step with explicit confirmations for high-trust environments
+- Configure mailbox post-state: shared-mailbox conversion, forwarding to manager, out-of-office message
+- Reclaim licenses and document which SKUs were freed for reassignment
+- Adapt sequence ordering for terminations (security first) vs. standard offboards (audit first)
+- Produce a structured offboarding record suitable for ticket attachment and manager sign-off
+- Surface remaining manual steps that fall outside CIPP's scope (device retrieval, OneDrive transfer, third-party SaaS deprovisioning)
+
+## Approach
+
+<!-- TODO: Aaron — fill in 5-10 lines describing how you actually run an offboarding for MSP clients.
+     Things that would help future-you and other technicians:
+       - Default forwarding-period policy (30/60/90 days? Indefinite? Until manager says stop?)
+       - Default mailbox conversion policy by client size (always convert? archive after 90?)
+       - When do you require explicit manager email confirmation before running, vs trust the ticket
+       - What's your termination protocol — phone call from HR? written approval? two-person rule?
+       - Which clients have non-standard offboarding (litigation hold defaults, custom forwarding chains)
+       - How do you handle the OneDrive/SharePoint ownership transfer that CIPP doesn't do
+     Your lived MSP experience here is what makes this agent safer than the generic version. -->
+
+When asked to run an offboarding, always confirm tenant + user match before executing any destructive action. The cost of asking one extra clarifying question is trivial; the cost of disabling the wrong user is hours of recovery and a damaged client relationship. For terminations, you can compress the confirmation into a single "Confirming termination of [matched user] in [tenant] — proceeding with security sequence first" — but you still confirm.
+
+When the user asks for "everything in one go," prefer `cipp_offboard_user` over chained individual calls; CIPP's bundled call is atomic and the audit trail in CIPP is cleaner. When the user asks for a controlled step-by-step (often in regulated environments), use the discrete tools so each action has its own confirmation.

--- a/msp-claude-plugins/cipp/cipp/commands/offboard-user.md
+++ b/msp-claude-plugins/cipp/cipp/commands/offboard-user.md
@@ -1,0 +1,55 @@
+---
+name: offboard-user
+description: Run the complete CIPP M365 offboarding workflow for a departing user — capture audit state, revoke access, handle mailbox, reclaim licenses
+arguments:
+  - name: user
+    description: UPN or display name of the user being offboarded
+    required: true
+  - name: tenant
+    description: Tenant default domain or display name (skip if user is unique across all tenants)
+    required: false
+  - name: posture
+    description: standard, termination, or contractor — controls action ordering and defaults (defaults to standard)
+    required: false
+  - name: mailbox-action
+    description: shared, forward, archive, or hold — what to do with the mailbox (defaults to shared)
+    required: false
+  - name: forward-to
+    description: UPN to forward mail to (defaults to user's manager if set in M365)
+    required: false
+  - name: dry-run
+    description: Show every action that would be taken without executing (true/false)
+    required: false
+---
+
+# Offboard CIPP User
+
+Delegate to the **`user-offboarding-runner`** agent. The agent handles the full sequence: tenant + user resolution, audit-state capture, account lock, mailbox handling, license reclaim, and structured offboarding record output.
+
+## Posture defaults
+
+| Posture | Action ordering | Mailbox default | Confirmation depth |
+|---------|----------------|-----------------|-------------------|
+| `standard` | Audit first → disable | Convert to shared | One confirmation before destructive sequence |
+| `termination` | Disable + revoke + reset MFA first → audit second | Convert to shared | Single combined confirmation; speed-first |
+| `contractor` | Audit first → disable | Archive (no shared conversion) | One confirmation; no forwarding by default |
+
+## What the workflow does
+
+1. Resolve tenant via `cipp_list_tenants` and user via `cipp_list_users`
+2. Confirm the match with the requester
+3. Capture audit state: `cipp_list_user_groups`, `cipp_list_user_devices`, `cipp_list_mailbox_permissions`
+4. Run `cipp_offboard_user` with options derived from `posture` and `mailbox-action`
+5. (If forwarding requested) verify `cipp_set_email_forwarding` was applied
+6. (If OOO requested) set `cipp_set_out_of_office`
+7. Produce a structured offboarding record for the ticket
+
+## Manual steps the agent will flag
+
+CIPP doesn't handle these — the agent surfaces them in the final record:
+
+- OneDrive ownership transfer (Graph API or M365 admin center)
+- SharePoint site permission cleanup
+- Third-party SaaS deprovisioning (Slack, Notion, GitHub, etc.)
+- Physical device retrieval coordination
+- HR systems sync (BambooHR, Rippling, etc.)

--- a/msp-claude-plugins/cipp/cipp/commands/secure-score-report.md
+++ b/msp-claude-plugins/cipp/cipp/commands/secure-score-report.md
@@ -1,0 +1,34 @@
+---
+name: secure-score-report
+description: Generate a portfolio-wide M365 security posture report — Secure Score equivalents, MFA enrollment, conditional access coverage, and domain authentication across all managed tenants
+arguments:
+  - name: format
+    description: scorecard (default) — tenant-by-tenant table sorted by risk; trend — compare to previous run; executive — client-deliverable summary
+    required: false
+  - name: tenants
+    description: Comma-separated list of tenants to include (defaults to all)
+    required: false
+---
+
+# CIPP Secure Score Report
+
+Portfolio-level security posture report across the MSP's managed tenants. Designed for monthly internal reviews, quarterly business reviews, and as the source data for client-facing security summaries.
+
+## What it produces
+
+For each tenant in scope:
+
+| Metric | Source |
+|--------|--------|
+| BPA fail count (Identity / Mail / Security) | `cipp_list_bpa` |
+| Enabled CA policies (count + presence of MFA-for-all-apps) | `cipp_list_conditional_access_policies` |
+| MFA enrollment % | `cipp_list_mfa_users` |
+| Domain health (DMARC enforced, SPF valid, DKIM enabled) | `cipp_list_domain_health` |
+| Standards baseline coverage | `cipp_list_standards` |
+| Computed risk band | High / Medium / Low |
+
+Tenants are sorted with high-risk first.
+
+## Use the agent for
+
+Cross-tenant *change* analysis ("which tenants regressed since last month?") goes to `security-posture-reviewer`, which can compare against a stored baseline and recommend remediation paths. This command produces the data; the agent produces the narrative.

--- a/msp-claude-plugins/cipp/cipp/commands/standards-drift.md
+++ b/msp-claude-plugins/cipp/cipp/commands/standards-drift.md
@@ -1,0 +1,38 @@
+---
+name: standards-drift
+description: Find tenants that have drifted from the MSP's configured CIPP standards baseline — missing standards, standards in Report-only mode, recent compliance failures
+arguments:
+  - name: scope
+    description: missing — tenants without baseline standards; report-only — tenants where critical standards aren't enforcing; failing — tenants with active compliance failures; all (default) — full drift report
+    required: false
+  - name: tenants
+    description: Comma-separated tenant list (defaults to all)
+    required: false
+---
+
+# CIPP Standards Drift
+
+Detects tenants out of compliance with the MSP's CIPP standards baseline. Standards drift is the leading indicator of "tenant looks managed but isn't" — every tenant with a missing or report-only baseline standard is silently receiving zero enforcement for that control.
+
+## Drift categories detected
+
+| Category | Detection logic |
+|----------|----------------|
+| **Missing baseline** | A standard exists in your master baseline but isn't deployed in this tenant |
+| **Report-only** | Standard is deployed but in `Report` mode — no alerting, no remediation |
+| **Stale Alert** | Standard has been in `Alert` mode > 60 days without escalation to `Remediate` |
+| **Recent failures** | Standard is in `Remediate` mode but has logged failures in the last check cycle |
+| **Drift since onboarding** | Tenant onboarded before a standard was added to baseline; never backfilled |
+
+## Output
+
+Tenant-by-tenant drift table with:
+
+- Standards present vs. expected
+- Mode breakdown (Report / Alert / Remediate counts)
+- Last check timestamp from `cipp_run_standards_check`
+- Recommended action (deploy, promote mode, escalate failure)
+
+## Workflow
+
+This command produces the drift report. Use the `security-posture-reviewer` agent for the next step — translating drift into a remediation plan with sequencing and client-communication framing.

--- a/msp-claude-plugins/cipp/cipp/commands/tenant-health.md
+++ b/msp-claude-plugins/cipp/cipp/commands/tenant-health.md
@@ -1,0 +1,34 @@
+---
+name: tenant-health
+description: Quick health snapshot for a single tenant — BPA failures, conditional access enforcement, MFA gaps, domain authentication, standards compliance
+arguments:
+  - name: tenant
+    description: Tenant default domain, display name, or GUID
+    required: true
+  - name: detail
+    description: summary (default), full, or executive — controls report depth
+    required: false
+---
+
+# CIPP Tenant Health Snapshot
+
+Pulls a focused health picture for one tenant. Suitable for client check-ins, post-onboarding validation, pre-QBR prep, or "is something off with [tenant]?" investigations.
+
+## What it checks
+
+1. **Tenant freshness** — `cipp_get_tenant_details` to confirm `lastRefresh` is current
+2. **BPA failures** — `cipp_list_bpa` grouped by category, sorted by severity
+3. **Conditional Access** — `cipp_list_conditional_access_policies` filtered to `state='enabled'`; flags if MFA-for-all-apps baseline is missing
+4. **MFA gaps** — `cipp_list_mfa_users` with count of users without registered strong auth methods
+5. **Domain health** — `cipp_list_domain_health` flagging any DMARC `p=none`, missing SPF, or unconfigured DKIM
+6. **Standards** — `cipp_list_standards` showing baseline standards present, mode (Report/Alert/Remediate), and last check status
+
+## Detail levels
+
+- **summary** (default): Pass/fail per category, top 5 findings, one-line health verdict
+- **full**: Every BPA result, every CA policy, all MFA gap users, all domain results
+- **executive**: Plain-language posture summary suitable for a client-facing email
+
+## When to use this vs. the agent
+
+Use this command for routine snapshots and quick lookups. Delegate to `security-posture-reviewer` when you need cross-tenant comparison, drift detection, or a structured remediation plan.

--- a/msp-claude-plugins/cipp/cipp/skills/alerts/SKILL.md
+++ b/msp-claude-plugins/cipp/cipp/skills/alerts/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: "cipp-alerts"
+description: "Use this skill when working with CIPP alerts and audit logs — reviewing the queued alert backlog across tenants, investigating sign-in or admin activity in audit logs, correlating alerts with tenants. Read-only triage surface for the CIPP alerting subsystem."
+when_to_use: "When triaging the CIPP alert queue or pulling tenant audit logs for investigation"
+triggers:
+  - cipp alert
+  - alert queue
+  - audit log
+  - sign in log
+  - admin activity
+  - cipp investigation
+  - audit trail
+---
+
+# CIPP Alerts & Audit Logs
+
+CIPP raises alerts based on standards violations, anomaly detection, and configured thresholds. The two tools in this skill let you triage the alert queue and pull underlying audit log evidence.
+
+## Tools
+
+### `cipp_list_alert_queue`
+
+```
+cipp_list_alert_queue()
+```
+
+Returns queued alerts across all tenants — alert type, tenant, severity, raised time, and current status. This is your daily triage list.
+
+### `cipp_list_audit_logs`
+
+```
+cipp_list_audit_logs(tenantFilter='contoso.onmicrosoft.com',
+                     startDate?, endDate?,
+                     userId?, operation?)
+```
+
+Tenant-scoped audit log entries from the M365 unified audit log. Filter by date range, user, or operation to narrow investigation scope. Use to investigate suspicious sign-ins, admin role changes, mailbox access, app consent grants, and policy modifications.
+
+## Workflow patterns
+
+### Daily alert triage
+
+1. `cipp_list_alert_queue` — pull the full queue
+2. Group by `tenant` + `alertType` to spot patterns (one tenant generating most alerts often signals a broken standard or runaway script)
+3. Triage in severity order: critical → high → medium → low
+4. For each alert: drill into the related tenant's audit logs with `cipp_list_audit_logs` filtered to the alert window
+
+### Correlate alert → audit evidence
+
+```
+alerts = cipp_list_alert_queue()
+critical = [a for a in alerts if a['severity'] == 'critical']
+for a in critical:
+    logs = cipp_list_audit_logs(
+        tenantFilter=a['tenantId'],
+        startDate=a['raisedAt'] - 30 minutes,
+        endDate=a['raisedAt'] + 5 minutes,
+    )
+```
+
+The 30-minute lookback usually captures the precipitating event (sign-in, admin change, app consent) that caused the alert.
+
+### Common audit operations to filter on
+
+| `operation` value | What it surfaces |
+|-------------------|------------------|
+| `UserLoggedIn` | Sign-in events |
+| `Add member to role` | Role escalation |
+| `Consent to application` | New app permissions granted |
+| `New-InboxRule` | Mailbox rule creation (BEC indicator) |
+| `Set-Mailbox` | Mailbox config changes |
+| `Add policy` | Conditional access policy created |
+| `Update conditional access policy` | CA policy modified |
+
+### Investigating a suspected compromise
+
+When `cipp_bec_check` flags a user, supplement it with audit log queries:
+
+1. Pull all `UserLoggedIn` operations for the user over the last 7 days — look for unusual countries, IPs, or bursts of failed → success patterns
+2. Pull all `New-InboxRule` and `Set-Mailbox` operations — hidden forwarding/auto-delete rules
+3. Pull all `Consent to application` operations — illicit consent grants are common BEC vectors
+
+## Caveats
+
+- The unified audit log has a lag (typically minutes, sometimes hours) — recent events may not appear immediately.
+- Audit retention varies by license: 90 days for E3, 1 year for E5, longer with audit log retention add-ons. Plan investigations around what the tenant's licensing actually allows.
+- `cipp_list_alert_queue` returns active queue items — historic resolved alerts require the CIPP UI.

--- a/msp-claude-plugins/cipp/cipp/skills/groups/SKILL.md
+++ b/msp-claude-plugins/cipp/cipp/skills/groups/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: "cipp-groups"
+description: "Use this skill when listing or creating M365 groups in CIPP — security groups, distribution lists, M365 groups, mail-enabled security groups. Covers tenant-scoped group enumeration and creation as part of user onboarding or access-management workflows."
+when_to_use: "When enumerating or creating Entra ID / M365 groups across managed tenants"
+triggers:
+  - cipp group
+  - create group
+  - m365 group
+  - distribution list
+  - security group
+  - group membership
+---
+
+# CIPP Groups
+
+Groups in CIPP cover all four Entra/M365 group types: Security, Microsoft 365 (unified), Distribution List, and Mail-Enabled Security. Most groups are managed through CIPP for delegation simplicity, but membership changes for individual users typically flow through `cipp_list_user_groups` (read) and the M365 plugin or graph-API for write operations.
+
+## Tools
+
+### `cipp_list_groups`
+
+```
+cipp_list_groups(tenantFilter='contoso.onmicrosoft.com')
+```
+
+Returns all groups in the tenant with `id`, `displayName`, `groupTypes`, `mailEnabled`, `securityEnabled`, and member count. Use to audit group sprawl, find candidate distribution lists for cleanup, or resolve group names to IDs.
+
+### `cipp_create_group`
+
+```
+cipp_create_group(tenantFilter, displayName, description?,
+                  groupType='Security'|'Microsoft 365'|'Distribution'|'Mail-Enabled Security',
+                  mailNickname?, members?)
+```
+
+`mailNickname` is required for any mail-enabled group type. Members can be supplied at creation time as a list of UPNs or object IDs.
+
+## Group type matrix
+
+| Type | Mail-enabled | Use case |
+|------|--------------|----------|
+| Security | No | RBAC, conditional access scoping, license assignment |
+| Microsoft 365 | Yes | Teams, SharePoint, shared inbox + collaboration |
+| Distribution | Yes | Email distribution only, no shared workspace |
+| Mail-Enabled Security | Yes | Both: mail distribution AND security scoping |
+
+Pick **Security** for permissions-only, **Microsoft 365** for collaboration with a shared mailbox/Teams workspace, **Distribution** for plain mailing lists.
+
+## Common patterns
+
+**Find groups a user belongs to before offboarding**
+
+```
+groups = cipp_list_user_groups(tenantFilter, userId='leaver@contoso.com')
+```
+
+`cipp_offboard_user` with `removeFromGroups=true` handles this automatically; only do it manually when you need an explicit audit trail.
+
+**Audit large unmanaged groups**
+
+After `cipp_list_groups`, sort by member count and flag any with > 50 members and no `description`. These are usually historical distribution lists no one owns.
+
+## Caveats
+
+CIPP's group toolset is intentionally narrow — for membership changes (add/remove user), conditional access scoping, or license assignment via groups, use the M365 plugin or work directly against the Graph API. CIPP focuses on the multi-tenant CRUD surface.

--- a/msp-claude-plugins/cipp/cipp/skills/licenses/SKILL.md
+++ b/msp-claude-plugins/cipp/cipp/skills/licenses/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: "cipp-licenses"
+description: "Use this skill when working with M365 license assignments and CSP license inventory through CIPP — listing license usage per tenant, identifying unused licenses, surfacing license SKUs available for assignment, and reviewing CSP-level license commitments. Drives license-rightsizing reports for MSP billing reviews."
+when_to_use: "When auditing M365 license usage, finding unused/overprovisioned licenses, or reviewing CSP license inventory across the MSP portfolio"
+triggers:
+  - cipp license
+  - license usage
+  - license audit
+  - unused licenses
+  - csp licenses
+  - m365 sku
+  - license report
+  - rightsize licenses
+---
+
+# CIPP Licenses
+
+License visibility across managed tenants. Two tools cover the read surface: per-tenant assignment + usage, and portfolio CSP inventory. License *changes* (assigning, removing) flow through `cipp_create_user`, `cipp_offboard_user`, or the M365 plugin — this skill is read-only.
+
+## Tools
+
+### `cipp_list_licenses`
+
+```
+cipp_list_licenses(tenantFilter='contoso.onmicrosoft.com')
+```
+
+Returns every SKU in the tenant with `skuPartNumber`, friendly name, `prepaidUnits.enabled` (purchased), `consumedUnits` (assigned), and per-SKU service plan detail. The gap between purchased and consumed is your unused-license inventory.
+
+### `cipp_list_csp_licenses`
+
+```
+cipp_list_csp_licenses()
+```
+
+Portfolio-wide view of CSP (Cloud Solution Provider) license commitments — what the MSP owns across all tenants. Use to reconcile what's deployed against what's billed.
+
+## Common SKU reference
+
+| Part number | Friendly | Notes |
+|-------------|----------|-------|
+| `O365_BUSINESS_PREMIUM` | M365 Business Premium | SMB sweet spot — Exchange + EMS basics |
+| `SPB` | M365 Business Premium (legacy code) | Same as above on older tenants |
+| `SPE_E3` | M365 E3 | Mid-market, includes Intune + EMS |
+| `SPE_E5` | M365 E5 | E3 + Defender + advanced compliance |
+| `ENTERPRISEPACK` | Office 365 E3 | Apps + Exchange + SharePoint, no EMS |
+| `EMS` / `EMSPREMIUM` | EMS E3 / E5 | Identity + device management add-on |
+| `AAD_PREMIUM` / `AAD_PREMIUM_P2` | Entra ID P1 / P2 | Conditional access requires P1+ |
+| `EXCHANGESTANDARD` | Exchange Online Plan 1 | Mail-only, no Office apps |
+| `MCOMEETADV` | Teams Audio Conferencing | Per-user PSTN dial-in |
+
+## Workflow patterns
+
+### Unused-license report (single tenant)
+
+```
+licenses = cipp_list_licenses(tenantFilter='contoso.onmicrosoft.com')
+unused = [
+    {
+        'sku': sku['skuPartNumber'],
+        'purchased': sku['prepaidUnits']['enabled'],
+        'consumed': sku['consumedUnits'],
+        'unused': sku['prepaidUnits']['enabled'] - sku['consumedUnits']
+    }
+    for sku in licenses
+    if sku['prepaidUnits']['enabled'] - sku['consumedUnits'] > 0
+]
+```
+
+Anything with > 3 unused licenses or > 10% unused is worth flagging in the next QBR.
+
+### Portfolio license-mix audit
+
+For each tenant in `cipp_list_tenants`, call `cipp_list_licenses` and tally SKUs. Cross-reference against `cipp_list_csp_licenses`. Mismatches signal:
+
+- Tenants on direct-billing where the MSP isn't earning CSP margin
+- CSP licenses purchased but not yet assigned to any tenant
+- Licenses assigned in a tenant without a corresponding CSP reservation (overage billing risk)
+
+### License-mix red flags
+
+| Pattern | Concern |
+|---------|---------|
+| Tenant has E3 + EMS E3 separately | Should be on M365 E3 — bundle is cheaper |
+| Multiple Business Premium tenants > 300 users | Above 300, E3 typically wins on TCO |
+| Entra ID P1 absent but conditional access deployed | CA requires P1; tenant is using a feature not licensed |
+| Defender for Office not assigned but standards expect it | Standards will report failures until licensing is fixed |
+
+## Caveats
+
+- License *write* operations (assign/remove SKU) aren't in the MCP surface — use `cipp_create_user` (assigns at create time), `cipp_offboard_user` with `removeLicenses=true`, or fall back to the M365 plugin / Graph for runtime changes.
+- `consumedUnits` can lag the live tenant by minutes; trust the tenant UI for time-sensitive decisions.

--- a/msp-claude-plugins/cipp/cipp/skills/mailboxes/SKILL.md
+++ b/msp-claude-plugins/cipp/cipp/skills/mailboxes/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: "cipp-mailboxes"
+description: "Use this skill when working with Exchange Online mailboxes through CIPP — listing mailboxes, auditing mailbox permissions, configuring out-of-office auto-replies, and setting email forwarding. Covers the mailbox surface most relevant to MSP operations: offboarding, leave coverage, BEC remediation."
+when_to_use: "When listing mailboxes, checking mailbox delegate/full-access permissions, configuring out-of-office, or setting email forwarding for a tenant"
+triggers:
+  - cipp mailbox
+  - mailbox permissions
+  - out of office
+  - auto reply
+  - email forwarding
+  - mail forwarding
+  - shared mailbox
+  - mailbox delegate
+  - full access mailbox
+---
+
+# CIPP Mailboxes
+
+Exchange Online mailbox operations through CIPP. The four supported tools cover the highest-frequency MSP mailbox tasks: listing mailboxes for inventory, auditing permissions during BEC investigations, setting OOO for leave/offboarding, and configuring forwarding for transition periods.
+
+## Tools
+
+### `cipp_list_mailboxes`
+
+```
+cipp_list_mailboxes(tenantFilter='contoso.onmicrosoft.com')
+```
+
+Returns all mailboxes (User, Shared, Resource, Equipment, Room) with `userPrincipalName`, `recipientTypeDetails`, `archiveStatus`, `litigationHoldEnabled`, and storage usage. Use as the entry point for any mailbox audit.
+
+### `cipp_list_mailbox_permissions`
+
+```
+cipp_list_mailbox_permissions(tenantFilter, userPrincipalName='user@contoso.com')
+```
+
+Lists all delegates and full-access trustees on a mailbox. **Critical during BEC investigations** — attackers commonly grant themselves Full Access or add a forwarding rule. Always run this on a compromised mailbox before remediation.
+
+### `cipp_set_out_of_office`
+
+```
+cipp_set_out_of_office(tenantFilter, userPrincipalName,
+                       enabled=true|false,
+                       internalMessage?, externalMessage?,
+                       startTime?, endTime?)
+```
+
+Use during offboarding (permanent), planned leave (scheduled), or as a tactical control after disabling an account so external senders get a clear bounce-equivalent.
+
+### `cipp_set_email_forwarding`
+
+```
+cipp_set_email_forwarding(tenantFilter, userPrincipalName,
+                          forwardingAddress?,
+                          deliverToBoth=true|false,
+                          disable=true|false)
+```
+
+Set `disable=true` to remove existing forwarding — this is the **first action** during BEC remediation. Set `forwardingAddress` to redirect a leaver's mail to their manager during transition.
+
+## Workflow patterns
+
+### BEC investigation — mailbox layer
+
+1. `cipp_list_mailbox_permissions` — capture current delegates before changes
+2. Check the BEC report from `cipp_bec_check` for forwarding rules and inbox rules
+3. `cipp_set_email_forwarding(disable=true)` — remove any forwarding the attacker added
+4. (Outside CIPP scope: review and remove malicious inbox rules via Graph or PowerShell)
+5. Document the original delegate list — restore legitimate ones after cleanup
+
+### Offboarding — mailbox handling
+
+If `cipp_offboard_user` is run with `convertToShared=true`, CIPP handles the mailbox conversion internally. For manual control:
+
+1. `cipp_set_out_of_office(enabled=true)` with a clear "no longer with the company" message
+2. `cipp_set_email_forwarding(forwardingAddress=manager@contoso.com, deliverToBoth=true)` to keep a paper trail while routing to the manager
+
+### Planned leave coverage
+
+```
+cipp_set_out_of_office(tenantFilter, userPrincipalName, enabled=true,
+                       internalMessage='Out until 2026-05-15. Contact teamlead@.',
+                       externalMessage='I am out of office. Please contact our team at...',
+                       startTime='2026-05-01T00:00:00Z',
+                       endTime='2026-05-15T00:00:00Z')
+```
+
+Scheduled OOO with start/end times is preferred over `enabled=true` without dates — it auto-disables on return.
+
+## Caveats
+
+- These tools are scoped to the mailbox-level operations CIPP exposes. Transport rules, mail flow, quarantine, and per-tenant Exchange settings require either CIPP UI workflows or direct Exchange Online PowerShell.
+- `cipp_set_email_forwarding(disable=true)` removes all forwarding — including legitimate ones. Capture state first.

--- a/msp-claude-plugins/cipp/cipp/skills/ops/SKILL.md
+++ b/msp-claude-plugins/cipp/cipp/skills/ops/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: "cipp-ops"
+description: "Use this skill when working with CIPP operational tooling — GDAP role and invite management, scheduled tasks, server health checks, version reporting, and CIPP application logs. Covers the meta-layer: keeping CIPP itself healthy and properly delegated to managed tenants."
+when_to_use: "When checking GDAP delegation status, managing scheduled CIPP tasks, verifying CIPP server health, or reading CIPP application logs"
+triggers:
+  - gdap
+  - granular delegated admin
+  - delegated admin
+  - cipp scheduled
+  - schedule task cipp
+  - cipp ping
+  - cipp version
+  - cipp logs
+  - cipp health
+---
+
+# CIPP Operations
+
+The meta-layer — tools for managing CIPP itself rather than the tenants it manages. GDAP for the delegation chain, scheduler for recurring jobs, and health/version/log endpoints for verifying CIPP is reachable and functioning.
+
+## GDAP
+
+### `cipp_list_gdap_roles`
+
+```
+cipp_list_gdap_roles()
+```
+
+Returns the GDAP (Granular Delegated Admin Privileges) role definitions available — the AAD roles your CSP relationship can grant to your MSP technicians per-tenant.
+
+### `cipp_list_gdap_invites`
+
+```
+cipp_list_gdap_invites()
+```
+
+Returns pending GDAP relationship invites that customers have not yet accepted. Stale invites > 14 days are usually customers who lost the email — re-send via the CIPP UI.
+
+GDAP is the modern replacement for AOBO/DAP. Each invite grants the MSP partner tenant a specific set of AAD roles in the customer tenant for a fixed duration. CIPP relies on active GDAP relationships for nearly every multi-tenant operation; broken GDAP = silent failures across the rest of the toolkit.
+
+## Scheduler
+
+### `cipp_list_scheduled_items`
+
+```
+cipp_list_scheduled_items()
+```
+
+Lists CIPP's scheduled tasks: recurring standards checks, BPA refreshes, alert evaluations, custom user-defined schedules.
+
+### `cipp_add_scheduled_item`
+
+```
+cipp_add_scheduled_item(name, command, parameters?, recurrence?, scheduledTime?)
+```
+
+Creates a new scheduled task in CIPP. Use cases:
+
+- Schedule a daily BPA refresh for a high-risk tenant
+- Schedule an end-of-quarter offboarding cleanup
+- Run a recurring CSP license reconciliation
+
+Pick `recurrence` deliberately — CIPP doesn't dedupe scheduled items, so re-running this tool with the same name creates a duplicate.
+
+## Health & diagnostics
+
+### `cipp_ping`
+
+```
+cipp_ping()
+```
+
+Liveness probe for the CIPP API. Returns immediately if CIPP is reachable. First call when troubleshooting "tools aren't working" — separates "MCP can't reach CIPP" from "CIPP can't reach Microsoft."
+
+### `cipp_get_version`
+
+```
+cipp_get_version()
+```
+
+Returns the deployed CIPP version (frontend + backend). Useful when reporting an issue to CIPP maintainers or comparing against the [release notes](https://github.com/KelvinTegelaar/CIPP/releases) for known regressions.
+
+### `cipp_list_logs`
+
+```
+cipp_list_logs(severity?, count?)
+```
+
+Application logs from the CIPP backend. Use for diagnosing failed background jobs, GDAP errors, or rate-limit hits against the Graph API.
+
+## Workflow patterns
+
+### Pre-flight check (before bulk operations)
+
+```
+ping = cipp_ping()
+version = cipp_get_version()
+gdap_invites = cipp_list_gdap_invites()
+```
+
+If any are unhealthy, halt the bulk operation. Bulk standards deployments or user creation against a CIPP with stale GDAP will silently fail or partially apply.
+
+### GDAP hygiene
+
+Run weekly:
+
+1. `cipp_list_gdap_invites` — chase pending > 14 days
+2. Compare `cipp_list_tenants` against expected onboarded list — gaps usually mean revoked GDAP
+3. `cipp_list_gdap_roles` — verify the MSP role template hasn't been altered (drift here breaks fine-grained access)
+
+### Diagnosing a failing tool call
+
+When any other CIPP tool returns an error:
+
+1. `cipp_ping` — is CIPP reachable at all?
+2. `cipp_get_version` — is it the version you think it is?
+3. `cipp_list_logs(severity='error', count=50)` — what does CIPP itself report?
+4. Check `cipp_list_gdap_invites` and the affected tenant in `cipp_list_tenants` — broken GDAP is the #1 cause of partial failures.
+
+## Caveats
+
+- `cipp_add_scheduled_item` doesn't validate the `command` parameter against CIPP's known job types — typos create scheduled items that fail silently. Verify with `cipp_list_scheduled_items` after creation.
+- `cipp_list_logs` is bounded by what CIPP itself retains — for long-term log retention, ship CIPP logs to an external SIEM via the CIPP integrations panel.

--- a/msp-claude-plugins/cipp/cipp/skills/security/SKILL.md
+++ b/msp-claude-plugins/cipp/cipp/skills/security/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: "cipp-security"
+description: "Use this skill when reviewing M365 conditional access policies and named locations through CIPP — auditing CA coverage, finding policies that exclude critical apps, listing trusted IP ranges, identifying tenants without baseline conditional access. Read-only surface focused on security posture review."
+when_to_use: "When auditing conditional access policies or named locations across managed tenants for security posture review"
+triggers:
+  - conditional access
+  - ca policy
+  - named locations
+  - trusted ips
+  - cipp security
+  - mfa enforcement
+  - security posture
+  - location based access
+---
+
+# CIPP Security — Conditional Access & Named Locations
+
+Read-only access to a tenant's Conditional Access policy graph and named-location list. Use as input to security posture reviews and to detect tenants drifting from MSP baseline policies. CIPP doesn't expose CA write operations through MCP — apply policy changes via CIPP standards or the CIPP UI.
+
+## Tools
+
+### `cipp_list_conditional_access_policies`
+
+```
+cipp_list_conditional_access_policies(tenantFilter='contoso.onmicrosoft.com')
+```
+
+Returns every CA policy with `displayName`, `state` (`enabled` / `disabled` / `enabledForReportingButNotEnforced`), `conditions` (users, apps, locations, platforms, sign-in risk), and `grantControls` (MFA, compliant device, terms of use, etc).
+
+### `cipp_list_named_locations`
+
+```
+cipp_list_named_locations(tenantFilter='contoso.onmicrosoft.com')
+```
+
+Returns named locations: IP ranges (trusted/untrusted) and country-based locations. These are the building blocks CA policies reference for location-based controls.
+
+## What to look for in a CA review
+
+| Finding | Why it matters |
+|---------|----------------|
+| Zero policies in `enabled` state | Tenant has no CA enforcement at all — a baseline `enabledForReportingButNotEnforced` doesn't block anything |
+| MFA not required for "All cloud apps" | A baseline policy is missing or scoped too narrowly |
+| Policies excluding the entire admin role | Common configuration mistake; admins should require *more* MFA, not less |
+| Trusted location includes home/coffee-shop IPs | Named-location bloat creates exception paths for attackers |
+| `legacy authentication` not blocked | Basic auth bypasses MFA entirely; should be blocked tenant-wide |
+| Reporting-only policies older than 30 days | Should have been promoted to `enabled` or removed |
+
+## Workflow patterns
+
+### Tenant CA baseline check
+
+```
+policies = cipp_list_conditional_access_policies(tenantFilter)
+enabled = [p for p in policies if p['state'] == 'enabled']
+mfa_for_all_apps = any(
+    p for p in enabled
+    if 'mfa' in p.get('grantControls', {}).get('builtInControls', [])
+    and 'All' in p.get('conditions', {}).get('applications', {}).get('includeApplications', [])
+)
+```
+
+If `mfa_for_all_apps` is false, the tenant lacks the baseline "MFA for everything" policy that every MSP should ship as a standard.
+
+### Portfolio drift detection
+
+Run `cipp_list_conditional_access_policies` per tenant and compare the policy fingerprint (display names + `state` + grant controls) against the MSP's golden baseline. Flag tenants where any baseline policy is missing or disabled.
+
+## Caveats
+
+- CA write operations (create/edit/delete) are not exposed via MCP. Use CIPP standards (`cipp_run_standards_check` and the standards UI) to deploy policy templates across tenants, or do it manually via the CIPP web UI.
+- Named locations are a **trust amplifier** — review them as carefully as policies. A misconfigured trusted IP range can quietly exempt entire networks from MFA.
+- `enabledForReportingButNotEnforced` looks like coverage in dashboards but enforces nothing. Always check `state == 'enabled'` for actual enforcement.

--- a/msp-claude-plugins/cipp/cipp/skills/standards/SKILL.md
+++ b/msp-claude-plugins/cipp/cipp/skills/standards/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: "cipp-standards"
+description: "Use this skill when working with CIPP Standards, Best Practice Analyser (BPA), and domain health checks — listing configured standards per tenant, triggering on-demand compliance checks, retrieving BPA results, checking SPF/DKIM/DMARC. The core surface for CIPP's tenant-baseline enforcement model."
+when_to_use: "When auditing standards compliance, running BPA reports, checking domain authentication health, or detecting tenants drifting from configured baselines"
+triggers:
+  - cipp standards
+  - bpa
+  - best practice analyser
+  - best practice analyzer
+  - run standards check
+  - domain health
+  - dmarc
+  - dkim
+  - spf
+  - tenant baseline
+  - compliance drift
+  - secure score
+---
+
+# CIPP Standards & BPA
+
+Standards are CIPP's mechanism for declaring "this is what every tenant we manage should look like" and continuously enforcing it. The Best Practice Analyser (BPA) is the read side — it shows you where current tenant state diverges from CIPP's recommended baseline. Domain health is a complementary check focused on email authentication.
+
+## Tools
+
+### `cipp_list_standards`
+
+```
+cipp_list_standards(tenantFilter='contoso.onmicrosoft.com')
+```
+
+Returns the list of standards configured for the tenant: which standards are enabled, what action each takes (`Report`, `Alert`, `Remediate`), and current compliance status. Use `tenantFilter='allTenants'` for a portfolio-wide view.
+
+### `cipp_run_standards_check`
+
+```
+cipp_run_standards_check(tenantFilter='contoso.onmicrosoft.com')
+```
+
+Triggers an on-demand standards evaluation. CIPP runs this on a schedule, but force a fresh run after deploying a new standard or remediating a finding to confirm the fix took.
+
+### `cipp_list_bpa`
+
+```
+cipp_list_bpa(tenantFilter='contoso.onmicrosoft.com')
+```
+
+Returns the latest Best Practice Analyser report — every CIPP-recommended check with `Pass`/`Fail`/`Warn` status across categories (Security, Identity, Mail, SharePoint, Teams, Intune). The most useful single call for tenant health.
+
+### `cipp_list_domain_health`
+
+```
+cipp_list_domain_health(tenantFilter='contoso.onmicrosoft.com')
+```
+
+Per-domain SPF, DKIM, DMARC, MX, and DNSSEC results. Run for any tenant where mail authentication is suspect or before/after migrating mail.
+
+## Standards model
+
+A "standard" in CIPP has three modes:
+
+| Mode | Behavior |
+|------|----------|
+| `Report` | Check only; show in BPA |
+| `Alert` | Check + raise alert when out of compliance |
+| `Remediate` | Check + auto-fix when out of compliance |
+
+The progression for an MSP rolling out a new baseline is typically `Report` → `Alert` → `Remediate` over weeks, with the longest dwell in `Alert` to validate that auto-remediation will be safe.
+
+## Workflow patterns
+
+### Tenant health snapshot
+
+```
+bpa = cipp_list_bpa(tenantFilter)
+fails = [check for check in bpa if check['status'] == 'Fail']
+domain = cipp_list_domain_health(tenantFilter)
+broken_dmarc = [d for d in domain if d.get('dmarcPass') is not True]
+```
+
+A tenant with > 5 BPA failures or any broken DMARC needs a remediation plan, not just a report.
+
+### Standards drift detection
+
+```
+all_tenants_standards = cipp_list_standards(tenantFilter='allTenants')
+```
+
+Compare the standards each tenant has enabled against the MSP's master baseline list. Tenants missing a baseline standard usually mean the standard was deployed *after* the tenant onboarded and never backfilled.
+
+### Pre-change validation
+
+Before you change a tenant's identity or mail config:
+
+1. `cipp_list_bpa` — capture current state
+2. Make the change
+3. `cipp_run_standards_check` to force a fresh evaluation
+4. `cipp_list_bpa` again — diff against pre-change capture
+
+## Domain health interpretation
+
+| Result | Meaning | Action |
+|--------|---------|--------|
+| SPF: missing | No SPF record at all | Add `v=spf1 include:spf.protection.outlook.com -all` |
+| SPF: too many lookups | Record exceeds 10-DNS-lookup limit | Flatten or consolidate `include:` directives |
+| DKIM: not configured | Default DKIM signing disabled | Enable in Defender / Exchange Admin |
+| DMARC: `p=none` | Reporting only, no enforcement | Move to `p=quarantine` after monitoring |
+| DMARC: missing | No DMARC record | Add `v=DMARC1; p=none; rua=mailto:dmarc@...` to start |
+
+## Caveats
+
+- BPA results reflect the last scheduled run; run `cipp_run_standards_check` for fresh data.
+- Standards `Remediate` mode can change tenant configuration without an additional confirmation — scope carefully and stage `Alert` first.
+- Domain health doesn't catch every email-auth issue (it doesn't validate ARC, BIMI, MTA-STS) — for full mail forensics, supplement with external tools.

--- a/msp-claude-plugins/cipp/cipp/skills/tenants/SKILL.md
+++ b/msp-claude-plugins/cipp/cipp/skills/tenants/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: "cipp-tenants"
+description: "Use this skill when working with CIPP tenants — listing managed M365 tenants, checking tenant details, identifying tenant ID/domain, and scoping operations to a specific tenant. The starting point for almost every CIPP workflow since most other tools require a tenant filter."
+when_to_use: "When listing managed M365 tenants, looking up tenant IDs/domains, or scoping operations across the MSP portfolio"
+triggers:
+  - cipp tenant
+  - list tenants
+  - m365 tenant
+  - tenant details
+  - which tenants
+  - all tenants
+  - cipp portfolio
+  - msp tenant list
+---
+
+# CIPP Tenants
+
+Tenants are the top-level scope in CIPP. Every operational tool — users, mailboxes, standards, security — takes a `tenantFilter` parameter that scopes the call to one tenant or to `allTenants`. Knowing how to enumerate tenants and resolve a friendly name to its tenant ID is the first step in almost every CIPP workflow.
+
+## Tools
+
+### `cipp_list_tenants`
+
+List every tenant CIPP manages. Returns a list of tenant objects with `customerId`, `defaultDomainName`, `displayName`, and onboarding status.
+
+```
+cipp_list_tenants()
+```
+
+Use this whenever a user refers to a client by name — the response gives you the `defaultDomainName` (or `customerId`) needed for `tenantFilter` on every other tool.
+
+### `cipp_get_tenant_details`
+
+Retrieve detailed information for one tenant: license count, domain list, GDAP relationship status, last refresh time.
+
+```
+cipp_get_tenant_details(tenantFilter='contoso.onmicrosoft.com')
+```
+
+Use `tenantFilter='allTenants'` to get a portfolio-wide aggregate — useful for fleet reports.
+
+## Identifying a tenant
+
+Most CIPP tools accept any of these in `tenantFilter`:
+
+| Format | Example | Notes |
+|--------|---------|-------|
+| Default domain | `contoso.onmicrosoft.com` | Most readable, recommended |
+| Custom domain | `contoso.com` | Works if CIPP has it cached |
+| Tenant GUID | `00000000-0000-0000-0000-000000000000` | Most stable but opaque |
+| `allTenants` | `allTenants` | Portfolio-wide; only some tools support it |
+
+When a user says "Acme", always run `cipp_list_tenants` first and resolve to the canonical `defaultDomainName` before calling other tools. Never guess the tenant identifier.
+
+## Common patterns
+
+**Resolve a friendly name → tenant filter**
+
+```
+tenants = cipp_list_tenants()
+acme = next(t for t in tenants if 'acme' in t['displayName'].lower())
+tenant_filter = acme['defaultDomainName']
+```
+
+**Audit which tenants are stale in CIPP cache**
+
+`cipp_get_tenant_details` returns `lastRefresh`. Tenants not refreshed in >24h often signal a broken GDAP relationship or revoked consent — flag them before running standards or BPA checks against them.
+
+## Failure modes
+
+- **`tenantFilter` not found** — the tenant exists in M365 but CIPP hasn't onboarded it. Trigger a tenant cache refresh in CIPP UI or check GDAP roles.
+- **Empty tenant list** — the API client has no tenant scope assigned. Check the role assigned to the API client in CIPP Settings → API Client Management.

--- a/msp-claude-plugins/cipp/cipp/skills/users/SKILL.md
+++ b/msp-claude-plugins/cipp/cipp/skills/users/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: "cipp-users"
+description: "Use this skill when working with CIPP-managed M365 users — creating accounts, editing properties, disabling, resetting passwords, resetting MFA, revoking sessions, full offboarding, BEC investigation, MFA status reporting, and listing user devices/groups. Covers the complete user lifecycle across multi-tenant M365 environments."
+when_to_use: "When creating, editing, disabling, offboarding, or auditing M365 users via CIPP — including password resets, MFA resets, session revocation, BEC checks, and MFA enrollment reports"
+triggers:
+  - cipp user
+  - create m365 user
+  - disable user
+  - offboard user
+  - reset password
+  - reset mfa
+  - revoke sessions
+  - bec check
+  - mfa status
+  - user devices
+  - user groups
+  - m365 offboarding
+  - business email compromise
+---
+
+# CIPP User Management
+
+User management is the highest-volume MSP workflow against CIPP. Every step of the M365 user lifecycle — onboarding, role changes, security incidents, offboarding — has a dedicated tool. Most calls require `tenantFilter`; resolve it via `cipp_list_tenants` before you start.
+
+## Tool surface
+
+### Listing & lookup
+
+```
+cipp_list_users(tenantFilter='contoso.onmicrosoft.com')
+cipp_list_mfa_users(tenantFilter='contoso.onmicrosoft.com')
+cipp_list_user_devices(tenantFilter=..., userId='upn-or-objectId')
+cipp_list_user_groups(tenantFilter=..., userId='upn-or-objectId')
+```
+
+`cipp_list_mfa_users` is the fastest way to find users without strong auth methods registered. Use it for security posture reviews and for bulk MFA enrollment campaigns.
+
+### Lifecycle
+
+```
+cipp_create_user(tenantFilter, displayName, userPrincipalName, mailNickname, password,
+                 firstName?, lastName?, jobTitle?, department?, usageLocation?)
+
+cipp_edit_user(tenantFilter, userId, displayName?, jobTitle?, department?, ...)
+
+cipp_disable_user(tenantFilter, userId)
+```
+
+`usageLocation` (ISO 2-letter country code) must be set before any license can be assigned — set it at create time even if licensing comes later.
+
+### Security actions
+
+```
+cipp_reset_password(tenantFilter, userId, password?)        # password optional → CIPP generates one
+cipp_reset_mfa(tenantFilter, userId)                        # clears all registered MFA methods
+cipp_revoke_sessions(tenantFilter, userId)                  # invalidates all active tokens
+cipp_bec_check(tenantFilter, userId)                        # BEC investigation report
+```
+
+`cipp_bec_check` runs a Business Email Compromise investigation: inbox rules, recent sign-in locations, MFA changes, mailbox forwarding rules, suspicious app consents. Always the first call when a user reports a phishing-related compromise — before disabling the account, while session telemetry is still live.
+
+### Full offboarding
+
+```
+cipp_offboard_user(tenantFilter, userId,
+                   convertToShared?, removeLicenses?,
+                   removeFromGroups?, forwardingAddress?,
+                   outOfOfficeMessage?, ...)
+```
+
+This single call wraps the canonical CIPP offboarding sequence: disable, revoke sessions, optional license reclaim, optional shared-mailbox conversion, optional forwarding, optional OOO message, group removal. Prefer this over chaining `disable_user` + `revoke_sessions` manually unless you need step-by-step control (in which case use the `user-offboarding-runner` agent).
+
+## Workflow patterns
+
+### Suspected BEC compromise
+
+1. `cipp_bec_check` — capture the forensic snapshot before changing anything
+2. `cipp_revoke_sessions` — kick the attacker out of all active sessions
+3. `cipp_reset_password` — generate a strong password, share via secure channel
+4. `cipp_reset_mfa` — clear attacker-registered methods; user re-enrolls
+5. Review the BEC report for inbox forwarding rules and remove them
+
+### Standard offboarding
+
+Use `cipp_offboard_user` with the org's policy defaults. For high-trust environments, do a dry-run review first:
+
+1. `cipp_list_user_groups` — note group memberships (audit trail)
+2. `cipp_list_user_devices` — flag company-owned devices for retrieval
+3. Check `cipp_list_mailbox_permissions` on the user's mailbox (delegates may exist)
+4. `cipp_offboard_user` with `convertToShared=true`, `removeLicenses=true`, `forwardingAddress=manager-upn`
+
+### MFA gap report
+
+```
+mfa_users = cipp_list_mfa_users(tenantFilter='allTenants')
+gaps = [u for u in mfa_users if not u.get('mfaRegistered')]
+```
+
+Use this monthly across the portfolio to drive MFA enforcement campaigns.
+
+## Identifying a user
+
+`userId` accepts either the Azure AD object GUID or the userPrincipalName. UPN is more readable; GUID is more stable across UPN changes. CIPP returns both — pick one and stay consistent within a workflow.

--- a/msp-claude-plugins/docs/scripts/generate-plugins.ts
+++ b/msp-claude-plugins/docs/scripts/generate-plugins.ts
@@ -60,6 +60,7 @@ function deriveVendor(sourcePath: string): string {
     huntress: 'Huntress',
     abnormal: 'Abnormal',
     blumira: 'Blumira',
+    cipp: 'CIPP',
     avanan: 'Avanan',
     proofpoint: 'Proofpoint',
     knowbe4: 'KnowBe4',
@@ -122,6 +123,7 @@ function deriveDisplayName(pluginJsonName: string | undefined, marketplaceName: 
     'betterstack': 'BetterStack',
     'm365': 'Microsoft 365',
     'rootly': 'Rootly',
+    'cipp': 'CIPP',
   };
 
   return nameMap[marketplaceName] ?? humanize(marketplaceName);

--- a/msp-claude-plugins/docs/src/data/plugins.ts
+++ b/msp-claude-plugins/docs/src/data/plugins.ts
@@ -322,6 +322,54 @@ export const plugins: Plugin[] = [
     compatibility: { claudeCode: true, claudeDesktop: true, validated: false }
   },
   {
+    id: 'cipp',
+    name: 'CIPP',
+    vendor: 'CIPP',
+    description: 'CIPP (CyberDrain Improved Partner Portal) - Microsoft 365 multi-tenant management for MSPs: tenants, users, mailboxes, conditional access, standards, BPA, licensing, GDAP, and alerts',
+    category: 'security',
+    maturity: 'production',
+    features: [
+      'Alert Handling',
+      'Groups',
+      'Licenses',
+      'Mailbox & Email',
+      'Ops',
+      'Security Posture',
+      'Standards',
+      'Tenants',
+      'User Management'
+    ],
+    skills: [
+      { name: 'alerts', description: 'Use this skill when working with CIPP alerts and audit logs — reviewing the queued alert backlog across tenants, investigating sign-in or admin activity in audit logs, correlating alerts with tenants.' },
+      { name: 'groups', description: 'Use this skill when listing or creating M365 groups in CIPP — security groups, distribution lists, M365 groups, mail-enabled security groups.' },
+      { name: 'licenses', description: 'Use this skill when working with M365 license assignments and CSP license inventory through CIPP — listing license usage per tenant, identifying unused licenses, surfacing license SKUs available for assignment, and reviewing CSP-level license commitments.' },
+      { name: 'mailboxes', description: 'Use this skill when working with Exchange Online mailboxes through CIPP — listing mailboxes, auditing mailbox permissions, configuring out-of-office auto-replies, and setting email forwarding.' },
+      { name: 'ops', description: 'Use this skill when working with CIPP operational tooling — GDAP role and invite management, scheduled tasks, server health checks, version reporting, and CIPP application logs.' },
+      { name: 'security', description: 'Use this skill when reviewing M365 conditional access policies and named locations through CIPP — auditing CA coverage, finding policies that exclude critical apps, listing trusted IP ranges, identifying tenants without baseline conditional access.' },
+      { name: 'standards', description: 'Use this skill when working with CIPP Standards, Best Practice Analyser (BPA), and domain health checks — listing configured standards per tenant, triggering on-demand compliance checks, retrieving BPA results, checking SPF/DKIM/DMARC.' },
+      { name: 'tenants', description: 'Use this skill when working with CIPP tenants — listing managed M365 tenants, checking tenant details, identifying tenant ID/domain, and scoping operations to a specific tenant.' },
+      { name: 'users', description: 'Use this skill when working with CIPP-managed M365 users — creating accounts, editing properties, disabling, resetting passwords, resetting MFA, revoking sessions, full offboarding, BEC investigation, MFA status reporting, and listing user devices/groups.' }
+    ],
+    agents: [
+      { name: 'security-posture-reviewer', description: 'Use this agent when an MSP security lead, vCISO, or service manager needs to sweep the M365 portfolio for security posture issues — Secure Score regressions, MFA enrollment gaps, conditional access drift, BPA failures, and broken domain authentication.' },
+      { name: 'user-offboarding-runner', description: 'Use this agent when an MSP technician, dispatcher, or HR-facing operator needs to run a complete M365 user offboarding through CIPP.' }
+    ],
+    commands: [
+      { name: '/offboard-user', description: 'Run the complete CIPP M365 offboarding workflow for a departing user — capture audit state, revoke access, handle mailbox, reclaim licenses' },
+      { name: '/secure-score-report', description: 'Generate a portfolio-wide M365 security posture report — Secure Score equivalents, MFA enrollment, conditional access coverage, and domain authentication across all managed tenants' },
+      { name: '/standards-drift', description: 'Find tenants that have drifted from the MSP\'s configured CIPP standards baseline — missing standards, standards in Report-only mode, recent compliance failures' },
+      { name: '/tenant-health', description: 'Quick health snapshot for a single tenant — BPA failures, conditional access enforcement, MFA gaps, domain authentication, standards compliance' }
+    ],
+    apiInfo: {
+      baseUrl: '',
+      auth: '',
+      rateLimit: '',
+      docsUrl: ''
+    },
+    path: 'cipp/cipp',
+    compatibility: { claudeCode: true, claudeDesktop: true, validated: false }
+  },
+  {
     id: 'connectwise-automate',
     name: 'ConnectWise Automate',
     vendor: 'ConnectWise',


### PR DESCRIPTION
## Summary

Adds the Claude plugin layer for **CIPP (CyberDrain Improved Partner Portal)** — the open-source M365 multi-tenant management platform widely used by MSPs. Complements the [`cipp-mcp`](https://github.com/wyre-technology/cipp-mcp) server (already built, 37 tools) by giving Claude the workflow knowledge to use those tools well.

Closes #24.

## What's in the plugin

- **9 skills** mirroring cipp-mcp's tool categories: `tenants`, `users`, `groups`, `mailboxes`, `security` (CA + named locations), `standards` (BPA + domain health), `licenses`, `alerts` (audit logs + queue), `ops` (GDAP + scheduler + health)
- **2 agents:**
  - `security-posture-reviewer` — sweeps the portfolio for Secure Score regressions, MFA gaps, CA drift, BPA failures, broken domain auth
  - `user-offboarding-runner` — orchestrates the full offboarding sequence with audit capture, posture-aware ordering (standard / termination / contractor), and a structured ticket-ready record
  - Each agent has a `<!-- TODO -->` block in its **Approach** section for hands-on MSP prose to be filled in
- **4 commands:** `/offboard-user`, `/tenant-health`, `/secure-score-report`, `/standards-drift`
- **plugin.json**, **README**, **.env.example** covering both bearer-token and OAuth client-credentials auth modes
- **Marketplace registration** in `.claude-plugin/marketplace.json` (alphabetical between `checkpoint-avanan` and `connectwise-automate`)
- **Vendor-map updates** in the docs generator so the site renders "CIPP" not "Cipp"

## Why two layers

The MCP server (cipp-mcp) is the typed tool surface. This plugin is the orientation layer — workflow knowledge, agent personas, and operational shortcuts. Every other vendor in this repo has both layers.

## Test plan

- [ ] `npx tsx docs/scripts/generate-plugins.ts` regenerates `plugins.ts` cleanly with CIPP entry
- [ ] CIPP appears in the docs site with correct vendor/name capitalization
- [ ] Skill descriptions trigger correctly for CIPP-themed prompts (manual smoke test)
- [ ] Agents resolve via `Task` tool with the right scope
- [ ] Aaron fills in the two agent `Approach` TODO blocks with hands-on MSP prose before merge