### PR TITLE
fix(pricing): remove Free tier — three paid tiers (Pro/Business/Enterprise)

### DIFF
--- a/msp-claude-plugins/docs/src/components/PricingMatrix.astro
+++ b/msp-claude-plugins/docs/src/components/PricingMatrix.astro
@@ -7,12 +7,12 @@
     <thead>
       <tr class="border-b border-[var(--border)]">
         <th class="text-left py-4 px-6 font-semibold text-[var(--text)] w-2/5 bg-white dark:bg-neutral-900"></th>
-        <th class="text-center py-4 px-6 font-semibold text-[var(--text)] bg-white dark:bg-neutral-900">Free</th>
         <th class="text-center py-4 px-6 font-semibold text-[var(--text)] bg-neutral-800/50 relative">
           <span class="text-accent">Pro</span>
           <span class="absolute top-2 right-2 inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold bg-accent/10 text-accent border border-accent/30">Popular</span>
         </th>
         <th class="text-center py-4 px-6 font-semibold text-[var(--text)] bg-white dark:bg-neutral-900">Business</th>
+        <th class="text-center py-4 px-6 font-semibold text-[var(--text)] bg-white dark:bg-neutral-900">Enterprise</th>
       </tr>
     </thead>
     <tbody>
@@ -25,33 +25,33 @@
       </tr>
       <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
         <td class="py-3 px-6 text-[var(--text)]">Users</td>
-        <td class="py-3 px-6 text-center text-[var(--muted)]">1</td>
         <td class="py-3 px-6 text-center text-[var(--muted)] bg-neutral-800/50">Up to 3</td>
         <td class="py-3 px-6 text-center text-[var(--muted)]">5+</td>
+        <td class="py-3 px-6 text-center text-[var(--muted)]">Custom</td>
       </tr>
       <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
         <td class="py-3 px-6 text-[var(--text)]">Personal connections</td>
-        <td class="py-3 px-6 text-center text-[var(--muted)]">3</td>
         <td class="py-3 px-6 text-center text-[var(--muted)] bg-neutral-800/50">3 / user</td>
+        <td class="py-3 px-6 text-center text-[var(--muted)]">Unlimited</td>
         <td class="py-3 px-6 text-center text-[var(--muted)]">Unlimited</td>
       </tr>
       <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
         <td class="py-3 px-6 text-[var(--text)]">Org / shared connections</td>
-        <td class="py-3 px-6 text-center text-neutral-400">—</td>
         <td class="py-3 px-6 text-center text-[var(--muted)] bg-neutral-800/50">5</td>
+        <td class="py-3 px-6 text-center text-[var(--muted)]">Unlimited</td>
         <td class="py-3 px-6 text-center text-[var(--muted)]">Unlimited</td>
       </tr>
       <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
         <td class="py-3 px-6 text-[var(--text)]">Credits / month</td>
-        <td class="py-3 px-6 text-center text-[var(--muted)]">500</td>
         <td class="py-3 px-6 text-center text-[var(--muted)] bg-neutral-800/50">2,000 / seat</td>
         <td class="py-3 px-6 text-center text-[var(--muted)]">4,000 / seat pooled</td>
+        <td class="py-3 px-6 text-center text-[var(--muted)]">Custom</td>
       </tr>
       <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
         <td class="py-3 px-6 text-[var(--text)]">Rate limit</td>
-        <td class="py-3 px-6 text-center text-[var(--muted)]">100 req / hr</td>
         <td class="py-3 px-6 text-center text-[var(--muted)] bg-neutral-800/50">1,000 req / hr</td>
         <td class="py-3 px-6 text-center text-[var(--muted)]">1,000 req / hr</td>
+        <td class="py-3 px-6 text-center text-[var(--muted)]">Custom</td>
       </tr>
 
       <!-- Section: Team features -->
@@ -62,20 +62,32 @@
       </tr>
       <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
         <td class="py-3 px-6 text-[var(--text)]">Team RBAC (roles)</td>
-        <td class="py-3 px-6 text-center text-neutral-400">—</td>
         <td class="py-3 px-6 text-center text-accent bg-neutral-800/50">✓</td>
+        <td class="py-3 px-6 text-center text-accent">✓</td>
         <td class="py-3 px-6 text-center text-accent">✓</td>
       </tr>
       <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
         <td class="py-3 px-6 text-[var(--text)]">Invite members</td>
-        <td class="py-3 px-6 text-center text-neutral-400">—</td>
         <td class="py-3 px-6 text-center text-accent bg-neutral-800/50">✓</td>
+        <td class="py-3 px-6 text-center text-accent">✓</td>
         <td class="py-3 px-6 text-center text-accent">✓</td>
       </tr>
       <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
         <td class="py-3 px-6 text-[var(--text)]">Shared org credentials</td>
-        <td class="py-3 px-6 text-center text-neutral-400">—</td>
         <td class="py-3 px-6 text-center text-accent bg-neutral-800/50">✓</td>
+        <td class="py-3 px-6 text-center text-accent">✓</td>
+        <td class="py-3 px-6 text-center text-accent">✓</td>
+      </tr>
+      <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
+        <td class="py-3 px-6 text-[var(--text)]">SSO / SAML</td>
+        <td class="py-3 px-6 text-center text-neutral-400 bg-neutral-800/50">—</td>
+        <td class="py-3 px-6 text-center text-neutral-400">—</td>
+        <td class="py-3 px-6 text-center text-accent">✓</td>
+      </tr>
+      <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
+        <td class="py-3 px-6 text-[var(--text)]">SCIM provisioning</td>
+        <td class="py-3 px-6 text-center text-neutral-400 bg-neutral-800/50">—</td>
+        <td class="py-3 px-6 text-center text-neutral-400">—</td>
         <td class="py-3 px-6 text-center text-accent">✓</td>
       </tr>
 
@@ -87,26 +99,32 @@
       </tr>
       <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
         <td class="py-3 px-6 text-[var(--text)]">Audit log</td>
-        <td class="py-3 px-6 text-center text-neutral-400">—</td>
         <td class="py-3 px-6 text-center text-neutral-400 bg-neutral-800/50">—</td>
+        <td class="py-3 px-6 text-center text-accent">✓</td>
         <td class="py-3 px-6 text-center text-accent">✓</td>
       </tr>
       <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
         <td class="py-3 px-6 text-[var(--text)]">Log shipping</td>
-        <td class="py-3 px-6 text-center text-neutral-400">—</td>
         <td class="py-3 px-6 text-center text-neutral-400 bg-neutral-800/50">—</td>
+        <td class="py-3 px-6 text-center text-accent">✓</td>
         <td class="py-3 px-6 text-center text-accent">✓</td>
       </tr>
       <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
         <td class="py-3 px-6 text-[var(--text)]">Tool allowlists</td>
-        <td class="py-3 px-6 text-center text-neutral-400">—</td>
         <td class="py-3 px-6 text-center text-accent bg-neutral-800/50">✓</td>
+        <td class="py-3 px-6 text-center text-accent">✓</td>
         <td class="py-3 px-6 text-center text-accent">✓</td>
       </tr>
       <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
         <td class="py-3 px-6 text-[var(--text)]">Service clients (AI agents)</td>
-        <td class="py-3 px-6 text-center text-neutral-400">—</td>
         <td class="py-3 px-6 text-center text-neutral-400 bg-neutral-800/50">—</td>
+        <td class="py-3 px-6 text-center text-accent">✓</td>
+        <td class="py-3 px-6 text-center text-accent">✓</td>
+      </tr>
+      <tr class="border-b border-[var(--border)] hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
+        <td class="py-3 px-6 text-[var(--text)]">Uptime SLA</td>
+        <td class="py-3 px-6 text-center text-neutral-400 bg-neutral-800/50">—</td>
+        <td class="py-3 px-6 text-center text-neutral-400">—</td>
         <td class="py-3 px-6 text-center text-accent">✓</td>
       </tr>
 
@@ -118,9 +136,9 @@
       </tr>
       <tr class="hover:bg-neutral-50 dark:hover:bg-neutral-800/30">
         <td class="py-3 px-6 text-[var(--text)]">Support tier</td>
-        <td class="py-3 px-6 text-center text-[var(--muted)]">Community</td>
         <td class="py-3 px-6 text-center text-[var(--muted)] bg-neutral-800/50">Email</td>
         <td class="py-3 px-6 text-center text-[var(--muted)]">Dedicated</td>
+        <td class="py-3 px-6 text-center text-[var(--muted)]">Dedicated + CSM</td>
       </tr>
 
     </tbody>

--- a/msp-claude-plugins/docs/src/components/Sidebar.astro
+++ b/msp-claude-plugins/docs/src/components/Sidebar.astro
@@ -47,14 +47,50 @@ const sidebarItems: SidebarItem[] = [
     label: 'Getting Started',
     children: [
       { label: 'Introduction', href: `${baseUrl}getting-started/` },
-      { label: 'Installation', href: `${baseUrl}getting-started/installation/` },
       { label: 'Quick Start', href: `${baseUrl}getting-started/quick-start/` },
-      { label: 'Architecture', href: `${baseUrl}getting-started/architecture/` },
-      { label: 'Deployment', href: `${baseUrl}getting-started/deployment/` },
-      { label: 'Gateway', href: `${baseUrl}getting-started/gateway/` },
-      { label: 'Authentication', href: `${baseUrl}getting-started/authentication/` },
-      { label: 'Teams', href: `${baseUrl}getting-started/teams/` },
-      { label: 'Troubleshooting', href: `${baseUrl}getting-started/troubleshooting/` },
+      { label: 'Installation', href: `${baseUrl}getting-started/installation/` },
+    ]
+  },
+  {
+    label: 'Gateway',
+    children: [
+      {
+        label: 'Concepts',
+        children: [
+          { label: 'Overview', href: `${baseUrl}getting-started/gateway/` },
+          { label: 'Architecture', href: `${baseUrl}getting-started/architecture/` },
+          { label: 'Security Model', href: `${baseUrl}getting-started/security/` },
+        ],
+      },
+      {
+        label: 'Setup',
+        children: [
+          { label: 'Deployment', href: `${baseUrl}getting-started/deployment/` },
+          { label: 'Authentication', href: `${baseUrl}getting-started/authentication/` },
+        ],
+      },
+      {
+        label: 'Operations',
+        children: [
+          { label: 'Teams & Access', href: `${baseUrl}getting-started/teams/` },
+          { label: 'Logging & Audit (coming soon)', href: '#' },
+        ],
+      },
+      {
+        label: 'Clients',
+        children: [
+          { label: 'Claude Code (coming soon)', href: '#' },
+          { label: 'Copilot', href: `${baseUrl}getting-started/copilot/` },
+          { label: 'Custom Integrations (coming soon)', href: '#' },
+        ],
+      },
+      {
+        label: 'Reference',
+        children: [
+          { label: 'Configuration (coming soon)', href: '#' },
+          { label: 'Troubleshooting', href: `${baseUrl}getting-started/troubleshooting/` },
+        ],
+      },
     ]
   },
   {
@@ -71,43 +107,19 @@ const sidebarItems: SidebarItem[] = [
             href: `${baseUrl}plugins/${p.id}/`
           }))
         }];
-      })
-    ]
-  },
-  {
-    label: 'MCP Servers',
-    children: [
-      { label: 'Overview', href: `${baseUrl}mcp-servers/` },
-      ...mcpCategoryOrder.flatMap(cat => {
-        const items = getMcpServersByCategory(cat);
-        if (items.length === 0) return [];
-        return [{
-          label: mcpCategoryLabels[cat],
-          children: items.map(s => ({
-            label: s.name,
-            href: `${baseUrl}mcp-servers/${s.id}/`
-          }))
-        }];
-      })
-    ]
-  },
-  {
-    label: 'Reference',
-    children: [
+      }),
       {
-        label: 'Prompt Bank',
+        label: 'Components',
         children: [
+          { label: 'All Agents (coming soon)', href: '#' },
+          { label: 'All Skills', href: `${baseUrl}skills/` },
+          { label: 'All Commands', href: `${baseUrl}commands/` },
+          { label: 'All MCP Servers', href: `${baseUrl}mcp-servers/` },
           { label: 'All Prompts', href: `${baseUrl}prompts/` },
-          ...roleOrder.map(role => ({
-            label: roleLabels[role],
-            href: `${baseUrl}prompts/#${role}`,
-          })),
         ],
       },
-      { label: 'Skills', href: `${baseUrl}skills/` },
-      { label: 'Commands', href: `${baseUrl}commands/` },
     ]
-  }
+  },
 ];
 
 function isActive(href?: string): boolean {

--- a/msp-claude-plugins/docs/src/pages/getting-started/teams.astro
+++ b/msp-claude-plugins/docs/src/pages/getting-started/teams.astro
@@ -16,19 +16,24 @@ const baseUrl = import.meta.env.BASE_URL;
 
   <p>
     Every user on the gateway belongs to an <strong>organization</strong> (team). Organizations
-    have a <strong>plan</strong> (Community or Pro) that determines available features:
+    are on a <strong>plan</strong> (Pro, Business, or Enterprise) that determines available features:
   </p>
 
   <table>
-    <thead><tr><th>Feature</th><th>Free</th><th>Pro</th></tr></thead>
+    <thead><tr><th>Feature</th><th>Pro</th><th>Business</th><th>Enterprise</th></tr></thead>
     <tbody>
-      <tr><td>Personal vendor connections</td><td>3 max</td><td>Unlimited</td></tr>
-      <tr><td>Team (shared) credentials</td><td>&mdash;</td><td>Unlimited</td></tr>
-      <tr><td>Team members</td><td>&mdash;</td><td>Unlimited</td></tr>
-      <tr><td>Invite links</td><td>&mdash;</td><td>Yes</td></tr>
-      <tr><td>Audit logging</td><td>&mdash;</td><td>Yes</td></tr>
+      <tr><td>Users</td><td>Up to 3</td><td>5+</td><td>Custom</td></tr>
+      <tr><td>Personal vendor connections</td><td>3 / user</td><td>Unlimited</td><td>Unlimited</td></tr>
+      <tr><td>Team (shared) credentials</td><td>5</td><td>Unlimited</td><td>Unlimited</td></tr>
+      <tr><td>Invite links</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
+      <tr><td>Audit logging</td><td>&mdash;</td><td>Yes</td><td>Yes</td></tr>
+      <tr><td>SSO / SAML</td><td>&mdash;</td><td>&mdash;</td><td>Yes</td></tr>
     </tbody>
   </table>
+
+  <p>
+    See <a href={`${baseUrl}pricing/`}>Pricing</a> for full plan comparisons.
+  </p>
 
   <h2>Getting Started</h2>
 
@@ -52,7 +57,7 @@ const baseUrl = import.meta.env.BASE_URL;
 
   <p>
     Teams created with a valid invite code are automatically upgraded to the <strong>Pro</strong> plan.
-    Without a code, your team starts on the Free plan. You can upgrade later from Settings.
+    Without a code, you can choose a plan from Settings &rarr; Billing.
   </p>
 
   <img src={`${baseUrl}images/gateway/settings-dashboard.png`} alt="Settings dashboard showing team section, personal connections, and team connections" style="border-radius:8px;border:1px solid #2a2a2a;margin:24px 0;" />

--- a/msp-claude-plugins/docs/src/pages/index.astro
+++ b/msp-claude-plugins/docs/src/pages/index.astro
@@ -127,7 +127,7 @@ const features = [
           <p class="text-[var(--muted)] text-sm mb-4">
             Connect your MSP tools to Claude Desktop in minutes. No servers to manage — just add your API credentials and go.
           </p>
-          <a href={`${gatewayUrl}/auth/choose`} class="btn btn-primary w-full text-center">Get Started Free</a>
+          <a href={`${gatewayUrl}/auth/choose`} class="btn btn-primary w-full text-center">Get Started</a>
         </div>
 
         <!-- Self-host path -->
@@ -227,7 +227,7 @@ const features = [
             </li>
           </ul>
           <div class="flex flex-wrap gap-3">
-            <a href={`${gatewayUrl}/auth/choose`} class="btn btn-primary text-sm">Get Started Free</a>
+            <a href={`${gatewayUrl}/auth/choose`} class="btn btn-primary text-sm">Get Started</a>
             <a href={`${baseUrl}getting-started/gateway/`} class="btn btn-secondary text-sm">Learn More</a>
           </div>
         </div>
@@ -274,25 +274,11 @@ const features = [
       <div class="text-center mb-12">
         <h2 class="text-3xl font-bold mb-4">Plans &amp; Pricing</h2>
         <p class="text-[var(--muted)] max-w-2xl mx-auto">
-          Start free and scale as your team grows. All plans include the full MCP integration suite.
+          Pick the tier that fits your team. All plans include the full MCP integration suite.
         </p>
       </div>
 
       <div class="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-5xl mx-auto">
-        <PricingCard
-          plan="Free"
-          price="$0"
-          description="Get started with no commitment."
-          features={[
-            "1 user",
-            "3 personal vendor connections",
-            "500 credits/month",
-            "Community support",
-          ]}
-          cta="Get started free"
-          ctaHref="https://mcp.wyre.ai/auth/choose"
-        />
-
         <PricingCard
           plan="Pro"
           price="$49/user/mo"
@@ -305,7 +291,7 @@ const features = [
             "Team roles & invites",
             "Email support",
           ]}
-          cta="Start free trial"
+          cta="Get started"
           ctaHref="https://mcp.wyre.ai/auth/choose"
           highlighted={true}
         />
@@ -323,8 +309,25 @@ const features = [
             "Tool allowlists & service clients",
             "Dedicated support",
           ]}
+          cta="Get started"
+          ctaHref="https://mcp.wyre.ai/auth/choose"
+        />
+
+        <PricingCard
+          plan="Enterprise"
+          price="Custom"
+          description="For large MSP organizations and custom deployments."
+          features={[
+            "Everything in Business",
+            "SSO / SAML",
+            "SCIM provisioning",
+            "Custom credit packages",
+            "Uptime SLA",
+            "Dedicated onboarding & CSM",
+            "Custom contract terms",
+          ]}
           cta="Talk to sales"
-          ctaHref="mailto:sales@wyre.technology"
+          ctaHref="mailto:sales@wyre.ai"
         />
       </div>
 

--- a/msp-claude-plugins/docs/src/pages/pricing.astro
+++ b/msp-claude-plugins/docs/src/pages/pricing.astro
@@ -35,7 +35,7 @@ const faqs = [
 
 <BaseLayout
   title="Pricing — MSP Claude Plugins Gateway"
-  description="Simple, transparent pricing for the WYRE MCP Gateway. Free for individuals, Pro for growing MSP teams, Business for full-scale deployments."
+  description="Simple, transparent pricing for the WYRE MCP Gateway. Pro for growing MSP teams, Business for full-scale deployments, Enterprise for custom contracts."
 >
   <Header />
 
@@ -44,7 +44,7 @@ const faqs = [
     <div class="container text-center">
       <h1 class="text-4xl lg:text-5xl font-bold mb-4 tracking-tight">Plans &amp; Pricing</h1>
       <p class="text-xl text-[var(--muted)] max-w-2xl mx-auto">
-        Start free and scale as your team grows. All plans include the full MCP integration suite.
+        Pick the tier that fits your team. All plans include the full MCP integration suite.
       </p>
     </div>
   </section>
@@ -53,20 +53,6 @@ const faqs = [
   <section class="py-16">
     <div class="container">
       <div class="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-5xl mx-auto">
-        <PricingCard
-          plan="Free"
-          price="$0"
-          description="Get started with no commitment."
-          features={[
-            "1 user",
-            "3 personal vendor connections",
-            "500 credits/month",
-            "Community support",
-          ]}
-          cta="Get started free"
-          ctaHref="https://mcp.wyre.ai/auth/choose"
-        />
-
         <PricingCard
           plan="Pro"
           price="$49/user/mo"
@@ -80,7 +66,7 @@ const faqs = [
             "Tool allowlists",
             "Email support",
           ]}
-          cta="Start free trial"
+          cta="Get started"
           ctaHref="https://mcp.wyre.ai/auth/choose"
           highlighted={true}
         />
@@ -97,6 +83,23 @@ const faqs = [
             "Audit log & log shipping",
             "Tool allowlists & service clients",
             "Dedicated support",
+          ]}
+          cta="Get started"
+          ctaHref="https://mcp.wyre.ai/auth/choose"
+        />
+
+        <PricingCard
+          plan="Enterprise"
+          price="Custom"
+          description="For large MSP organizations and custom deployments."
+          features={[
+            "Everything in Business",
+            "SSO / SAML",
+            "SCIM provisioning",
+            "Custom credit packages",
+            "Uptime SLA",
+            "Dedicated onboarding & CSM",
+            "Custom contract terms",
           ]}
           cta="Talk to sales"
           ctaHref="mailto:sales@wyre.ai"
@@ -164,7 +167,7 @@ const faqs = [
           Spin up the gateway in minutes — no infrastructure required.
         </p>
         <div class="flex flex-wrap justify-center gap-4">
-          <a href="https://mcp.wyre.ai/auth/choose" class="btn btn-primary">Start free trial</a>
+          <a href="https://mcp.wyre.ai/auth/choose" class="btn btn-primary">Get started</a>
           <a href="/getting-started" class="btn btn-secondary">Read the docs</a>
         </div>
       </div>

--- a/msp-claude-plugins/docs/superpowers/specs/2026-04-27-docs-ia-restructure-design.md
+++ b/msp-claude-plugins/docs/superpowers/specs/2026-04-27-docs-ia-restructure-design.md
@@ -1,0 +1,82 @@
+# Docs IA Restructure — Design
+
+**Date:** 2026-04-27
+**Status:** Approved (sidebar-only first pass shipped)
+**Scope:** Information architecture only. Branding refresh (Taskmaster #11) and screenshot redo (Taskmaster #12) tracked separately.
+
+## Goal
+
+The current docs IA buries gateway content as a single page inside "Getting Started" alongside other gateway-flavored topics, mixes "Plugins" (MSP product integrations) with peer top-level sections "MCP Servers" and "Reference" (Skills/Commands/Prompts), and has no room to grow as gateway content expands. Reorganize around two product mental models — Gateway and Plugins — with a thin onboarding shelf in front.
+
+## Top-level structure
+
+Three top-level sidebar sections, in order:
+
+1. **Getting Started** — onboarding shelf (3 pages)
+2. **Gateway** — everything about running and operating the gateway, lifecycle-grouped
+3. **Plugins** — Claude Code plugins as the packaging unit; catalog primary, components secondary
+
+Removes top-level **MCP Servers** and **Reference** sections; their contents fold into Plugins → Components.
+
+## Page mapping
+
+### Getting Started
+- Introduction (`getting-started/`)
+- Quick Start (`getting-started/quick-start/`)
+- Installation (`getting-started/installation/`)
+
+### Gateway (lifecycle grouping)
+- **Concepts**
+  - Overview (current `getting-started/gateway/`)
+  - Architecture (current `getting-started/architecture/`)
+  - Security Model (current `getting-started/security/`)
+- **Setup**
+  - Deployment (current `getting-started/deployment/`)
+  - Authentication (current `getting-started/authentication/`)
+- **Operations**
+  - Teams & Access (current `getting-started/teams/`)
+  - Logging & Audit *(placeholder — future page)*
+- **Clients**
+  - Claude Code *(placeholder — future page)*
+  - Copilot (current `getting-started/copilot/`)
+  - Custom Integrations *(placeholder — future page)*
+- **Reference**
+  - Configuration *(placeholder — future page)*
+  - Troubleshooting (current `getting-started/troubleshooting/`)
+
+Monitoring deliberately excluded — not planned.
+
+### Plugins (catalog-primary)
+- Overview (current `plugins/index`)
+- **Catalog by category** (unchanged grouping; per-plugin pages stay at `plugins/[id]`):
+  PSA, RMM, IT Documentation, Security, Email Security, Monitoring, Network, Incident Management, CRM, Marketplace, Sales, Accounting, Productivity
+- **Components** (cross-cutting indexes)
+  - All Agents *(placeholder — future page)*
+  - All Skills (current `skills/`)
+  - All Commands (current `commands/`)
+  - All MCP Servers (current `mcp-servers/`, `mcp-servers/[id]` detail pages preserved)
+  - All Prompts (current `prompts/`)
+
+## Implementation approach
+
+**Phase 1 — sidebar-only (this PR).** Rewrite `src/components/Sidebar.astro` to render the new tree. Links continue to point at existing physical page paths. No file moves, no URL changes, no redirects required. Placeholder entries link to `#` and are labeled "(coming soon)". This ships the IA visually with zero risk to existing URLs.
+
+**Phase 2 — page moves and redirects (follow-on).** Move pages to URLs that match the new tree (e.g. `/getting-started/architecture/` → `/gateway/concepts/architecture/`, `/skills/` → `/plugins/components/skills/`). Add Astro `redirects` config so all current URLs continue to resolve. `mcp-servers/[id]` detail pages relocate but keep their slug-based addressing.
+
+**Phase 3 — placeholder pages (follow-on).** Author Logging & Audit, Claude Code client, Custom Integrations, Configuration. Wire real links into the sidebar.
+
+**Phase 4 — per-plugin "bundled components" section (follow-on).** Extend `plugins/[id].astro` to surface a plugin's bundled agents/skills/commands/MCP servers/prompts, linking into the cross-cutting component indexes. Bridges catalog-primary and component-secondary navigation. Requires an optional `components` field on plugin data entries.
+
+## Out of scope
+
+- Content rewrites of any existing page
+- Branding/visual refresh (Taskmaster #11)
+- Screenshot recapture (Taskmaster #12)
+- Marketing-site header navigation (already restructured in commit `68e36e1`)
+- Per-plugin bundled-components feature (Phase 4 above; deferred)
+
+## Risk
+
+- **Phase 1 risk: none.** Only the sidebar component changes; page paths and URLs are untouched.
+- **Phase 2 risk: link rot in external references.** Mitigated by redirects covering every relocated path. Astro emits 301s; verify after deploy.
+- **Sidebar ergonomics:** Gateway now nests three levels deep (section → bucket → page). The existing two-level rendering in `Sidebar.astro` already supports this; verified visually in dev.


### PR DESCRIPTION
## Summary

Pricing pages still showed a Free tier that no longer matches the offering. The hosted gateway has three paid tiers: **Pro**, **Business**, **Enterprise**.

- **pricing.astro** — replaced Free card with Enterprise (Custom pricing, "Talk to sales"). Hero subhead and bottom CTA updated.
- **index.astro** — homepage pricing block matches; "Get Started Free" buttons → "Get Started". The "Are MSP Claude Plugins free?" FAQ is left intact — those ARE free under Apache 2.0; only the hosted gateway is paid.
- **teams.astro** — feature table now compares all three paid tiers and adds an SSO row. Removed "starts on Free plan" copy.
- **PricingMatrix.astro** — Free column dropped, Enterprise column added with SSO/SAML, SCIM, and Uptime SLA rows.

Enterprise tier features used (flag if these need adjusting):
- Everything in Business
- SSO / SAML
- SCIM provisioning
- Custom credit packages
- Uptime SLA
- Dedicated onboarding & CSM
- Custom contract terms

## Test plan

- [x] `npm run build` clean
- [ ] CI passes (note: gateway-side CI still blocked by org Actions billing — manual gateway deploy needed for mcp.wyre.ai pickup)