### PR TITLE
chore: flip mcp.wyretechnology.com → mcp.wyre.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Then restart Claude Code. That's it.
 
-**Documentation:** [mcp.wyretechnology.com](https://mcp.wyretechnology.com)
+**Documentation:** [mcp.wyre.ai](https://mcp.wyre.ai)
 
 ---
 
@@ -100,12 +100,12 @@ Plus shared skills for MSP terminology, ticket triage, cross-vendor incident cor
 
 ### Hosted Gateway (Recommended)
 
-Use the [MCP Gateway](https://mcp.wyretechnology.com) to connect your MSP tools to Claude with zero infrastructure. OAuth 2.1 + PKCE authentication, encrypted credential storage, and all 33 vendors available immediately.
+Use the [MCP Gateway](https://mcp.wyre.ai) to connect your MSP tools to Claude with zero infrastructure. OAuth 2.1 + PKCE authentication, encrypted credential storage, and all 33 vendors available immediately.
 
 **Claude Code (CLI):**
 
 ```bash
-claude mcp add --transport http msp-mcp-gateway https://mcp.wyretechnology.com/v1/mcp
+claude mcp add --transport http msp-mcp-gateway https://mcp.wyre.ai/v1/mcp
 ```
 
 **Claude Desktop (macOS / Linux):**
@@ -122,13 +122,13 @@ irm https://raw.githubusercontent.com/wyre-technology/msp-claude-plugins/main/ms
 
 The installer scripts preserve your existing config, create a backup, and only append the gateway entry.
 
-[Get Started Free](https://mcp.wyretechnology.com/waitlist)
+[Get Started Free](https://mcp.wyre.ai/waitlist)
 
 ### Self-Hosted
 
 Run MCP servers yourself for full control. Each server is available as an npm package, Docker image, or MCPB bundle for Claude Desktop.
 
-See the [Getting Started guide](https://mcp.wyretechnology.com/getting-started/) for installation instructions.
+See the [Getting Started guide](https://mcp.wyre.ai/getting-started/) for installation instructions.
 
 ---
 

--- a/msp-claude-plugins/abnormal/abnormal-security/.env.example
+++ b/msp-claude-plugins/abnormal/abnormal-security/.env.example
@@ -8,5 +8,5 @@ ABNORMAL_API_TOKEN=your-api-token
 
 # MCP Server URL (optional)
 # Override to use a self-hosted gateway instead of the default hosted MCP server
-# Default: https://mcp.wyretechnology.com/v1/abnormal-security/mcp
-ABNORMAL_MCP_URL=https://mcp.wyretechnology.com/v1/abnormal-security/mcp
+# Default: https://mcp.wyre.ai/v1/abnormal-security/mcp
+ABNORMAL_MCP_URL=https://mcp.wyre.ai/v1/abnormal-security/mcp

--- a/msp-claude-plugins/abnormal/abnormal-security/README.md
+++ b/msp-claude-plugins/abnormal/abnormal-security/README.md
@@ -41,7 +41,7 @@ For project-specific configuration, use `.claude/settings.local.json` (gitignore
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `ABNORMAL_API_TOKEN` | Yes | | API token from Settings > Integrations > API |
-| `ABNORMAL_MCP_URL` | No | `https://mcp.wyretechnology.com/v1/abnormal-security/mcp` | MCP server URL -- override to use a self-hosted gateway |
+| `ABNORMAL_MCP_URL` | No | `https://mcp.wyre.ai/v1/abnormal-security/mcp` | MCP server URL -- override to use a self-hosted gateway |
 
 ## Self-Hosted Gateway
 
@@ -190,7 +190,7 @@ Abnormal Security enforces API rate limits:
 ### Connection Issues
 
 If the MCP server fails to connect:
-1. Verify network connectivity to `https://mcp.wyretechnology.com`
+1. Verify network connectivity to `https://mcp.wyre.ai`
 2. Check that your API token is valid
 3. Ensure the MCP Gateway service is running
 

--- a/msp-claude-plugins/abnormal/abnormal-security/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/abnormal/abnormal-security/skills/api-patterns/SKILL.md
@@ -51,7 +51,7 @@ Accept: application/json
 
 ```bash
 export ABNORMAL_API_TOKEN="your-api-token"
-export ABNORMAL_MCP_URL="https://mcp.wyretechnology.com/v1/abnormal-security/mcp"
+export ABNORMAL_MCP_URL="https://mcp.wyre.ai/v1/abnormal-security/mcp"
 ```
 
 ### MCP Gateway Headers

--- a/msp-claude-plugins/abnormal/abnormal/README.md
+++ b/msp-claude-plugins/abnormal/abnormal/README.md
@@ -31,11 +31,11 @@ To obtain an API token:
 
 ### Via MCP Gateway (Recommended)
 
-Use the [MCP Gateway](https://mcp.wyretechnology.com) to connect — paste your API token and you're done.
+Use the [MCP Gateway](https://mcp.wyre.ai) to connect — paste your API token and you're done.
 
 ### Self-Hosted (Docker)
 
-Run the Abnormal Security MCP server via Docker with the MCP Gateway self-hosted option. See the [MCP Gateway documentation](https://mcp.wyretechnology.com) for setup instructions.
+Run the Abnormal Security MCP server via Docker with the MCP Gateway self-hosted option. See the [MCP Gateway documentation](https://mcp.wyre.ai) for setup instructions.
 
 ### Claude Code CLI
 

--- a/msp-claude-plugins/avanan/avanan/README.md
+++ b/msp-claude-plugins/avanan/avanan/README.md
@@ -37,11 +37,11 @@ export AVANAN_REGION="us"  # us, eu, or ap
 
 ### Via MCP Gateway (Recommended)
 
-Use the [MCP Gateway](https://mcp.wyretechnology.com) to connect — paste your Client ID and Secret and select your region. The gateway handles token exchange and refresh automatically.
+Use the [MCP Gateway](https://mcp.wyre.ai) to connect — paste your Client ID and Secret and select your region. The gateway handles token exchange and refresh automatically.
 
 ### Self-Hosted (Docker)
 
-Run the Avanan MCP server via Docker with the MCP Gateway self-hosted option. See the [MCP Gateway documentation](https://mcp.wyretechnology.com) for setup instructions.
+Run the Avanan MCP server via Docker with the MCP Gateway self-hosted option. See the [MCP Gateway documentation](https://mcp.wyre.ai) for setup instructions.
 
 ### Claude Code CLI
 

--- a/msp-claude-plugins/betterstack/betterstack/README.md
+++ b/msp-claude-plugins/betterstack/betterstack/README.md
@@ -32,7 +32,7 @@ export BETTERSTACK_API_TOKEN="your-api-token"
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `BETTERSTACK_API_TOKEN` | Yes | | API token from Better Stack > API tokens |
-| `BETTERSTACK_MCP_URL` | No | `https://mcp.wyretechnology.com/v1/betterstack/mcp` | MCP server URL -- override to use a self-hosted gateway |
+| `BETTERSTACK_MCP_URL` | No | `https://mcp.wyre.ai/v1/betterstack/mcp` | MCP server URL -- override to use a self-hosted gateway |
 
 ## Self-Hosted Gateway
 
@@ -57,11 +57,11 @@ BETTERSTACK_MCP_URL=https://your-gateway-domain/v1/betterstack/mcp
 
 ### Via MCP Gateway (Recommended)
 
-Use the [MCP Gateway](https://mcp.wyretechnology.com) to connect -- paste your API token and you're done.
+Use the [MCP Gateway](https://mcp.wyre.ai) to connect -- paste your API token and you're done.
 
 ### Self-Hosted (Docker)
 
-Run the Better Stack MCP server via Docker with the MCP Gateway self-hosted option. See the [MCP Gateway documentation](https://mcp.wyretechnology.com) for setup instructions.
+Run the Better Stack MCP server via Docker with the MCP Gateway self-hosted option. See the [MCP Gateway documentation](https://mcp.wyre.ai) for setup instructions.
 
 ### Claude Code CLI
 
@@ -160,7 +160,7 @@ Better Stack enforces API rate limits:
 ### Connection Issues
 
 If the MCP server fails to connect:
-1. Verify network connectivity to `https://mcp.wyretechnology.com`
+1. Verify network connectivity to `https://mcp.wyre.ai`
 2. Check that your API token is valid
 3. Ensure the MCP Gateway service is running
 

--- a/msp-claude-plugins/blumira/blumira/README.md
+++ b/msp-claude-plugins/blumira/blumira/README.md
@@ -36,7 +36,7 @@ export BLUMIRA_JWT_TOKEN="your-jwt-token"
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `BLUMIRA_JWT_TOKEN` | Yes | | JWT token from Settings > API Access |
-| `BLUMIRA_MCP_URL` | No | `https://mcp.wyretechnology.com/v1/blumira/mcp` | MCP server URL — override to use a self-hosted gateway |
+| `BLUMIRA_MCP_URL` | No | `https://mcp.wyre.ai/v1/blumira/mcp` | MCP server URL — override to use a self-hosted gateway |
 
 ## Self-Hosted Gateway
 
@@ -61,7 +61,7 @@ BLUMIRA_MCP_URL=https://your-gateway-domain/v1/blumira/mcp
 
 ### Via MCP Gateway (Recommended)
 
-Use the [MCP Gateway](https://mcp.wyretechnology.com) to connect — just paste your JWT token and you're done.
+Use the [MCP Gateway](https://mcp.wyre.ai) to connect — just paste your JWT token and you're done.
 
 ### Self-Hosted (Docker)
 
@@ -72,7 +72,7 @@ Add to your MCP configuration:
   "mcpServers": {
     "blumira": {
       "type": "http",
-      "url": "https://mcp.wyretechnology.com/v1/blumira/mcp",
+      "url": "https://mcp.wyre.ai/v1/blumira/mcp",
       "headers": {
         "X-Blumira-JWT-Token": "${BLUMIRA_JWT_TOKEN}"
       }

--- a/msp-claude-plugins/domotz/domotz/README.md
+++ b/msp-claude-plugins/domotz/domotz/README.md
@@ -34,7 +34,7 @@ export DOMOTZ_REGION="us-east-1"
 |----------|----------|---------|-------------|
 | `DOMOTZ_API_KEY` | Yes | | API key from User Menu > API Keys |
 | `DOMOTZ_REGION` | No | `us-east-1` | API region (`us-east-1` or `eu-central-1`) |
-| `DOMOTZ_MCP_URL` | No | `https://mcp.wyretechnology.com/v1/domotz/mcp` | MCP server URL -- override to use a self-hosted gateway |
+| `DOMOTZ_MCP_URL` | No | `https://mcp.wyre.ai/v1/domotz/mcp` | MCP server URL -- override to use a self-hosted gateway |
 
 ## Self-Hosted Gateway
 
@@ -59,11 +59,11 @@ DOMOTZ_MCP_URL=https://your-gateway-domain/v1/domotz/mcp
 
 ### Via MCP Gateway (Recommended)
 
-Use the [MCP Gateway](https://mcp.wyretechnology.com) to connect -- paste your API key and select your region, and you're done.
+Use the [MCP Gateway](https://mcp.wyre.ai) to connect -- paste your API key and select your region, and you're done.
 
 ### Self-Hosted (Docker)
 
-Run the Domotz MCP server via Docker with the MCP Gateway self-hosted option. See the [MCP Gateway documentation](https://mcp.wyretechnology.com) for setup instructions.
+Run the Domotz MCP server via Docker with the MCP Gateway self-hosted option. See the [MCP Gateway documentation](https://mcp.wyre.ai) for setup instructions.
 
 ### Claude Code CLI
 
@@ -170,7 +170,7 @@ Domotz enforces API rate limits:
 ### Connection Issues
 
 If the MCP server fails to connect:
-1. Verify network connectivity to `https://mcp.wyretechnology.com`
+1. Verify network connectivity to `https://mcp.wyre.ai`
 2. Check that your API credentials are valid
 3. Ensure the MCP Gateway service is running
 

--- a/msp-claude-plugins/hubspot/hubspot/README.md
+++ b/msp-claude-plugins/hubspot/hubspot/README.md
@@ -36,7 +36,7 @@ export HUBSPOT_CLIENT_SECRET="your-client-secret"
 
 ### Via MCP Gateway (Recommended)
 
-Use the [MCP Gateway](https://mcp.wyretechnology.com) to connect -- just paste your OAuth credentials and you're done.
+Use the [MCP Gateway](https://mcp.wyre.ai) to connect -- just paste your OAuth credentials and you're done.
 
 ### Self-Hosted (Claude Desktop)
 

--- a/msp-claude-plugins/huntress/huntress/README.md
+++ b/msp-claude-plugins/huntress/huntress/README.md
@@ -34,7 +34,7 @@ export HUNTRESS_API_SECRET="your-api-secret"
 |----------|----------|---------|-------------|
 | `HUNTRESS_API_KEY` | Yes | | API key from Settings > API Credentials |
 | `HUNTRESS_API_SECRET` | Yes | | API secret from Settings > API Credentials |
-| `HUNTRESS_MCP_URL` | No | `https://mcp.wyretechnology.com/v1/huntress/mcp` | MCP server URL — override to use a self-hosted gateway |
+| `HUNTRESS_MCP_URL` | No | `https://mcp.wyre.ai/v1/huntress/mcp` | MCP server URL — override to use a self-hosted gateway |
 
 ## Self-Hosted Gateway
 
@@ -59,11 +59,11 @@ HUNTRESS_MCP_URL=https://your-gateway-domain/v1/huntress/mcp
 
 ### Via MCP Gateway (Recommended)
 
-Use the [MCP Gateway](https://mcp.wyretechnology.com) to connect — paste your API key and secret and you're done.
+Use the [MCP Gateway](https://mcp.wyre.ai) to connect — paste your API key and secret and you're done.
 
 ### Self-Hosted (Docker)
 
-Run the Huntress MCP server via Docker with the MCP Gateway self-hosted option. See the [MCP Gateway documentation](https://mcp.wyretechnology.com) for setup instructions.
+Run the Huntress MCP server via Docker with the MCP Gateway self-hosted option. See the [MCP Gateway documentation](https://mcp.wyre.ai) for setup instructions.
 
 ### Claude Code CLI
 
@@ -159,7 +159,7 @@ Huntress enforces a rate limit of 60 requests per minute:
 ### Connection Issues
 
 If the MCP server fails to connect:
-1. Verify network connectivity to `https://mcp.wyretechnology.com`
+1. Verify network connectivity to `https://mcp.wyre.ai`
 2. Check that your API credentials are valid
 3. Ensure the MCP Gateway service is running
 

--- a/msp-claude-plugins/ironscales/ironscales/README.md
+++ b/msp-claude-plugins/ironscales/ironscales/README.md
@@ -33,11 +33,11 @@ To obtain credentials:
 
 ### Via MCP Gateway (Recommended)
 
-Use the [MCP Gateway](https://mcp.wyretechnology.com) to connect — enter your API key and Company ID.
+Use the [MCP Gateway](https://mcp.wyre.ai) to connect — enter your API key and Company ID.
 
 ### Self-Hosted (Docker)
 
-Run the Ironscales MCP server via Docker with the MCP Gateway self-hosted option. See the [MCP Gateway documentation](https://mcp.wyretechnology.com) for setup instructions.
+Run the Ironscales MCP server via Docker with the MCP Gateway self-hosted option. See the [MCP Gateway documentation](https://mcp.wyre.ai) for setup instructions.
 
 ### Claude Code CLI
 

--- a/msp-claude-plugins/knowbe4/knowbe4/README.md
+++ b/msp-claude-plugins/knowbe4/knowbe4/README.md
@@ -34,11 +34,11 @@ export KNOWBE4_REGION="us"  # or "eu"
 
 ### Via MCP Gateway (Recommended)
 
-Use the [MCP Gateway](https://mcp.wyretechnology.com) to connect — paste your API key and select your region and you're done.
+Use the [MCP Gateway](https://mcp.wyre.ai) to connect — paste your API key and select your region and you're done.
 
 ### Self-Hosted (Docker)
 
-Run the KnowBe4 MCP server via Docker with the MCP Gateway self-hosted option. See the [MCP Gateway documentation](https://mcp.wyretechnology.com) for setup instructions.
+Run the KnowBe4 MCP server via Docker with the MCP Gateway self-hosted option. See the [MCP Gateway documentation](https://mcp.wyre.ai) for setup instructions.
 
 ### Claude Code CLI
 

--- a/msp-claude-plugins/mimecast/mimecast/README.md
+++ b/msp-claude-plugins/mimecast/mimecast/README.md
@@ -47,11 +47,11 @@ Mimecast operates regional API endpoints. Use the region matching your Mimecast 
 
 ### Via MCP Gateway (Recommended)
 
-Use the [MCP Gateway](https://mcp.wyretechnology.com) to connect — enter your Client ID, Client Secret, and select your region.
+Use the [MCP Gateway](https://mcp.wyre.ai) to connect — enter your Client ID, Client Secret, and select your region.
 
 ### Self-Hosted (Docker)
 
-Run the Mimecast MCP server via Docker with the MCP Gateway self-hosted option. See the [MCP Gateway documentation](https://mcp.wyretechnology.com) for setup instructions.
+Run the Mimecast MCP server via Docker with the MCP Gateway self-hosted option. See the [MCP Gateway documentation](https://mcp.wyre.ai) for setup instructions.
 
 ### Claude Code CLI
 

--- a/msp-claude-plugins/pagerduty/pagerduty/README.md
+++ b/msp-claude-plugins/pagerduty/pagerduty/README.md
@@ -32,7 +32,7 @@ export PAGERDUTY_API_TOKEN="your-api-token"
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `PAGERDUTY_API_TOKEN` | Yes | | User API Token from My Profile > User Settings > API Access |
-| `PAGERDUTY_MCP_URL` | No | `https://mcp.wyretechnology.com/v1/pagerduty/mcp` | MCP server URL -- override to use a self-hosted gateway |
+| `PAGERDUTY_MCP_URL` | No | `https://mcp.wyre.ai/v1/pagerduty/mcp` | MCP server URL -- override to use a self-hosted gateway |
 
 ## Self-Hosted Gateway
 
@@ -57,11 +57,11 @@ PAGERDUTY_MCP_URL=https://your-gateway-domain/v1/pagerduty/mcp
 
 ### Via MCP Gateway (Recommended)
 
-Use the [MCP Gateway](https://mcp.wyretechnology.com) to connect -- paste your API token and you're done.
+Use the [MCP Gateway](https://mcp.wyre.ai) to connect -- paste your API token and you're done.
 
 ### Self-Hosted (Docker)
 
-Run the PagerDuty MCP server via Docker with the MCP Gateway self-hosted option. See the [MCP Gateway documentation](https://mcp.wyretechnology.com) for setup instructions.
+Run the PagerDuty MCP server via Docker with the MCP Gateway self-hosted option. See the [MCP Gateway documentation](https://mcp.wyre.ai) for setup instructions.
 
 ### Claude Code CLI
 
@@ -161,7 +161,7 @@ PagerDuty enforces rate limits (varies by endpoint, typically 960 requests/minut
 ### Connection Issues
 
 If the MCP server fails to connect:
-1. Verify network connectivity to `https://mcp.wyretechnology.com`
+1. Verify network connectivity to `https://mcp.wyre.ai`
 2. Check that your API token is valid
 3. Ensure the MCP Gateway service is running
 4. For EU accounts, verify the correct region URL is configured

--- a/msp-claude-plugins/pandadoc/pandadoc/README.md
+++ b/msp-claude-plugins/pandadoc/pandadoc/README.md
@@ -33,7 +33,7 @@ export PANDADOC_API_KEY="your-api-key"
 
 ### Via MCP Gateway (Recommended)
 
-Use the [MCP Gateway](https://mcp.wyretechnology.com) to connect -- just paste your API key and you're done.
+Use the [MCP Gateway](https://mcp.wyre.ai) to connect -- just paste your API key and you're done.
 
 ### Self-Hosted (Claude Desktop)
 

--- a/msp-claude-plugins/pax8/pax8/README.md
+++ b/msp-claude-plugins/pax8/pax8/README.md
@@ -33,7 +33,7 @@ export PAX8_MCP_TOKEN="your-mcp-token"
 
 ### Via MCP Gateway (Recommended)
 
-Use the [MCP Gateway](https://mcp.wyretechnology.com) to connect — just paste your MCP token and you're done.
+Use the [MCP Gateway](https://mcp.wyre.ai) to connect — just paste your MCP token and you're done.
 
 ### Self-Hosted (Claude Desktop)
 

--- a/msp-claude-plugins/proofpoint/proofpoint/README.md
+++ b/msp-claude-plugins/proofpoint/proofpoint/README.md
@@ -40,11 +40,11 @@ export PROOFPOINT_REGION="us1"  # us1, us2, us3, us4, uk1, eu1
 
 ### Via MCP Gateway (Recommended)
 
-Use the [MCP Gateway](https://mcp.wyretechnology.com) to connect — paste your service principal and secret and you're done.
+Use the [MCP Gateway](https://mcp.wyre.ai) to connect — paste your service principal and secret and you're done.
 
 ### Self-Hosted (Docker)
 
-Run the Proofpoint MCP server via Docker with the MCP Gateway self-hosted option. See the [MCP Gateway documentation](https://mcp.wyretechnology.com) for setup instructions.
+Run the Proofpoint MCP server via Docker with the MCP Gateway self-hosted option. See the [MCP Gateway documentation](https://mcp.wyre.ai) for setup instructions.
 
 ### Claude Code CLI
 

--- a/msp-claude-plugins/rootly/rootly/README.md
+++ b/msp-claude-plugins/rootly/rootly/README.md
@@ -31,7 +31,7 @@ export ROOTLY_API_TOKEN="your-api-token"
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `ROOTLY_API_TOKEN` | Yes | | API token from Account > Manage API Keys |
-| `ROOTLY_MCP_URL` | No | `https://mcp.wyretechnology.com/v1/rootly/mcp` | MCP server URL -- override to use a self-hosted gateway |
+| `ROOTLY_MCP_URL` | No | `https://mcp.wyre.ai/v1/rootly/mcp` | MCP server URL -- override to use a self-hosted gateway |
 
 ## Self-Hosted Gateway
 
@@ -56,7 +56,7 @@ ROOTLY_MCP_URL=https://your-gateway-domain/v1/rootly/mcp
 
 ### Via MCP Gateway (Recommended)
 
-Use the [MCP Gateway](https://mcp.wyretechnology.com) to connect -- paste your API token and you're done.
+Use the [MCP Gateway](https://mcp.wyre.ai) to connect -- paste your API token and you're done.
 
 ### Direct Connection
 
@@ -159,7 +159,7 @@ If you encounter HTTP 429 responses:
 ### Connection Issues
 
 If the MCP server fails to connect:
-1. Verify network connectivity to `https://mcp.wyretechnology.com`
+1. Verify network connectivity to `https://mcp.wyre.ai`
 2. Check that your API token is valid
 3. Ensure the MCP Gateway service is running
 

--- a/msp-claude-plugins/runzero/runzero/README.md
+++ b/msp-claude-plugins/runzero/runzero/README.md
@@ -32,7 +32,7 @@ export RUNZERO_API_TOKEN="your-account-api-token"
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `RUNZERO_API_TOKEN` | Yes | | Account API Token from Account > API Keys |
-| `RUNZERO_MCP_URL` | No | `https://mcp.wyretechnology.com/v1/runzero/mcp` | MCP server URL — override to use a self-hosted gateway |
+| `RUNZERO_MCP_URL` | No | `https://mcp.wyre.ai/v1/runzero/mcp` | MCP server URL — override to use a self-hosted gateway |
 
 ## Self-Hosted Gateway
 
@@ -57,11 +57,11 @@ RUNZERO_MCP_URL=https://your-gateway-domain/v1/runzero/mcp
 
 ### Via MCP Gateway (Recommended)
 
-Use the [MCP Gateway](https://mcp.wyretechnology.com) to connect — paste your API token and you're done.
+Use the [MCP Gateway](https://mcp.wyre.ai) to connect — paste your API token and you're done.
 
 ### Self-Hosted (Docker)
 
-Run the RunZero MCP server via Docker with the MCP Gateway self-hosted option. See the [MCP Gateway documentation](https://mcp.wyretechnology.com) for setup instructions.
+Run the RunZero MCP server via Docker with the MCP Gateway self-hosted option. See the [MCP Gateway documentation](https://mcp.wyre.ai) for setup instructions.
 
 ### Claude Code CLI
 
@@ -160,7 +160,7 @@ RunZero enforces API rate limits:
 ### Connection Issues
 
 If the MCP server fails to connect:
-1. Verify network connectivity to `https://mcp.wyretechnology.com`
+1. Verify network connectivity to `https://mcp.wyre.ai`
 2. Check that your API token is valid
 3. Ensure the MCP Gateway service is running
 

--- a/msp-claude-plugins/scripts/install-gateway.ps1
+++ b/msp-claude-plugins/scripts/install-gateway.ps1
@@ -12,7 +12,7 @@
 
 $ErrorActionPreference = "Stop"
 
-$GatewayUrl = if ($env:GATEWAY_URL) { $env:GATEWAY_URL } else { "https://mcp.wyretechnology.com/v1/mcp" }
+$GatewayUrl = if ($env:GATEWAY_URL) { $env:GATEWAY_URL } else { "https://mcp.wyre.ai/v1/mcp" }
 $Scope      = if ($env:SCOPE) { $env:SCOPE } else { "project" }
 $McpName    = "msp-mcp-gateway"
 
@@ -124,7 +124,7 @@ if ($InstalledAny) {
     Write-Success "Done! Next steps:"
     Write-Host "    1. Restart Claude Code / Claude Desktop"
     Write-Host "    2. Complete OAuth when prompted"
-    Write-Host "    3. Connect vendors at https://mcp.wyretechnology.com"
+    Write-Host "    3. Connect vendors at https://mcp.wyre.ai"
 } else {
     Write-Error2 "Neither Claude Code nor Claude Desktop was detected."
     Write-Host "    Install Claude Code:    https://docs.anthropic.com/en/docs/claude-code"

--- a/msp-claude-plugins/scripts/install-gateway.sh
+++ b/msp-claude-plugins/scripts/install-gateway.sh
@@ -13,7 +13,7 @@
 
 set -euo pipefail
 
-GATEWAY_URL="${GATEWAY_URL:-https://mcp.wyretechnology.com/v1/mcp}"
+GATEWAY_URL="${GATEWAY_URL:-https://mcp.wyre.ai/v1/mcp}"
 SCOPE="${SCOPE:-project}"
 MCP_NAME="msp-mcp-gateway"
 
@@ -143,7 +143,7 @@ if [ "$installed_any" = true ]; then
   info "Done! Next steps:"
   printf "  1. Restart Claude Code / Claude Desktop\n"
   printf "  2. Complete OAuth when prompted\n"
-  printf "  3. Connect vendors at https://mcp.wyretechnology.com\n"
+  printf "  3. Connect vendors at https://mcp.wyre.ai\n"
 else
   error "Neither Claude Code nor Claude Desktop was detected."
   printf "  Install Claude Code:    https://docs.anthropic.com/en/docs/claude-code\n"

--- a/msp-claude-plugins/sentinelone/sentinelone/README.md
+++ b/msp-claude-plugins/sentinelone/sentinelone/README.md
@@ -53,7 +53,7 @@ export SENTINELONE_BASE_URL="https://your-console.sentinelone.net"
 
 ### Via MCP Gateway (Recommended)
 
-Use the [MCP Gateway](https://mcp.wyretechnology.com) to connect -- just paste your Service User token and console URL and you're done.
+Use the [MCP Gateway](https://mcp.wyre.ai) to connect -- just paste your Service User token and console URL and you're done.
 
 ### Self-Hosted (Claude Desktop)
 

--- a/msp-claude-plugins/sherweb/sherweb/README.md
+++ b/msp-claude-plugins/sherweb/sherweb/README.md
@@ -35,7 +35,7 @@ export SHERWEB_MCP_URL="https://your-sherweb-mcp-url"
 
 ### Via MCP Gateway (Recommended)
 
-Use the [MCP Gateway](https://mcp.wyretechnology.com) to connect -- configure your Sherweb credentials and you're done.
+Use the [MCP Gateway](https://mcp.wyre.ai) to connect -- configure your Sherweb credentials and you're done.
 
 ### Self-Hosted
 

--- a/msp-claude-plugins/spamtitan/spamtitan/README.md
+++ b/msp-claude-plugins/spamtitan/spamtitan/README.md
@@ -33,11 +33,11 @@ export SPAMTITAN_BASE_URL="https://your-spamtitan-instance.com"  # for self-host
 
 ### Via MCP Gateway (Recommended)
 
-Use the [MCP Gateway](https://mcp.wyretechnology.com) to connect — paste your API key and you're done.
+Use the [MCP Gateway](https://mcp.wyre.ai) to connect — paste your API key and you're done.
 
 ### Self-Hosted (Docker)
 
-Run the SpamTitan MCP server via Docker with the MCP Gateway self-hosted option. See the [MCP Gateway documentation](https://mcp.wyretechnology.com) for setup instructions.
+Run the SpamTitan MCP server via Docker with the MCP Gateway self-hosted option. See the [MCP Gateway documentation](https://mcp.wyre.ai) for setup instructions.
 
 ### Claude Code CLI
 
@@ -109,7 +109,7 @@ If you see "401 Unauthorized":
 ### Connection Issues
 
 If the MCP server fails to connect:
-1. Verify network connectivity to `https://mcp.wyretechnology.com`
+1. Verify network connectivity to `https://mcp.wyre.ai`
 2. Check that your API credentials are valid
 3. Ensure the MCP Gateway service is running
 

--- a/msp-claude-plugins/wyre-gateway/.mcp.json
+++ b/msp-claude-plugins/wyre-gateway/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "msp-mcp-gateway": {
       "type": "http",
-      "url": "https://mcp.wyretechnology.com/v1/mcp"
+      "url": "https://mcp.wyre.ai/v1/mcp"
     }
   }
 }

--- a/msp-claude-plugins/wyre-gateway/README.md
+++ b/msp-claude-plugins/wyre-gateway/README.md
@@ -19,7 +19,7 @@ This plugin provides access to:
 
 ## Prerequisites
 
-1. A Wyre Technology account at [mcp.wyretechnology.com](https://mcp.wyretechnology.com)
+1. A Wyre Technology account at [mcp.wyre.ai](https://mcp.wyre.ai)
 2. At least one vendor connected through the gateway
 
 ## Connecting Vendors
@@ -27,13 +27,13 @@ This plugin provides access to:
 Each vendor must be connected individually through the gateway's connect page:
 
 ```
-https://mcp.wyretechnology.com/connect/{vendor}
+https://mcp.wyre.ai/connect/{vendor}
 ```
 
 For example:
-- `https://mcp.wyretechnology.com/connect/itglue` - Connect IT Glue
-- `https://mcp.wyretechnology.com/connect/autotask` - Connect Autotask
-- `https://mcp.wyretechnology.com/connect/datto-rmm` - Connect Datto RMM
+- `https://mcp.wyre.ai/connect/itglue` - Connect IT Glue
+- `https://mcp.wyre.ai/connect/autotask` - Connect Autotask
+- `https://mcp.wyre.ai/connect/datto-rmm` - Connect Datto RMM
 
 Once connected, the vendor's tools are immediately available through the gateway.
 
@@ -41,14 +41,14 @@ Once connected, the vendor's tools are immediately available through the gateway
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `WYRE_GATEWAY_URL` | No | `https://mcp.wyretechnology.com/v1/mcp` | Gateway MCP endpoint URL |
+| `WYRE_GATEWAY_URL` | No | `https://mcp.wyre.ai/v1/mcp` | Gateway MCP endpoint URL |
 
 ## Installation
 
 ### Claude Code (CLI)
 
 ```bash
-claude mcp add --transport http msp-mcp-gateway https://mcp.wyretechnology.com/v1/mcp
+claude mcp add --transport http msp-mcp-gateway https://mcp.wyre.ai/v1/mcp
 ```
 
 Claude Code will open a browser for OAuth authentication on first use. No API keys or headers needed.
@@ -56,7 +56,7 @@ Claude Code will open a browser for OAuth authentication on first use. No API ke
 To install for all projects instead of just the current one:
 
 ```bash
-claude mcp add --transport http --scope user msp-mcp-gateway https://mcp.wyretechnology.com/v1/mcp
+claude mcp add --transport http --scope user msp-mcp-gateway https://mcp.wyre.ai/v1/mcp
 ```
 
 ### Claude.ai (web)
@@ -64,13 +64,13 @@ claude mcp add --transport http --scope user msp-mcp-gateway https://mcp.wyretec
 Go to **Settings → Connectors** and add a custom connector pointing to:
 
 ```
-https://mcp.wyretechnology.com/v1/mcp
+https://mcp.wyre.ai/v1/mcp
 ```
 
 ### After installing
 
 1. Complete OAuth authentication when prompted
-2. Connect your vendors at `https://mcp.wyretechnology.com/connect/{vendor}`
+2. Connect your vendors at `https://mcp.wyre.ai/connect/{vendor}`
 3. All connected vendor tools appear automatically
 
 No API keys or headers are needed — authentication is handled via OAuth Bearer token automatically.
@@ -136,13 +136,13 @@ If your Wyre account belongs to a team or organization, vendor connections are s
 
 ### OAuth prompt doesn't appear
 
-1. Ensure `WYRE_GATEWAY_URL` is set correctly (default: `https://mcp.wyretechnology.com/v1/mcp`)
+1. Ensure `WYRE_GATEWAY_URL` is set correctly (default: `https://mcp.wyre.ai/v1/mcp`)
 2. Try disconnecting and reconnecting the plugin
 
 ### No tools available after connecting
 
-1. Verify you've connected at least one vendor at `https://mcp.wyretechnology.com/connect/{vendor}`
-2. Check your connection status at `https://mcp.wyretechnology.com`
+1. Verify you've connected at least one vendor at `https://mcp.wyre.ai/connect/{vendor}`
+2. Check your connection status at `https://mcp.wyre.ai`
 
 ### Tool call errors
 


### PR DESCRIPTION
Sweep replaces the old hostname across all READMEs, install scripts, .mcp.json, and .env.example so anyone reading the repo lands on the canonical mcp.wyre.ai URL. 27 files, 74 replacements, no content changes.