### PR TITLE
docs: split Skills/Agents/Commands into sidebar subsections

### DIFF
--- a/msp-claude-plugins/docs/src/components/Sidebar.astro
+++ b/msp-claude-plugins/docs/src/components/Sidebar.astro
@@ -42,6 +42,33 @@ const mcpCategoryLabels: Record<string, string> = {
 
 const mcpCategoryOrder = ['psa', 'rmm', 'documentation', 'security', 'accounting', 'network', 'sales'] as const;
 
+const skillCategories = [
+  { label: 'Ticket Management', slug: 'ticket-management' },
+  { label: 'Customer/Client Management', slug: 'customer-management' },
+  { label: 'Asset & Device Management', slug: 'asset-device-management' },
+  { label: 'Monitoring & Alerts', slug: 'monitoring-alerts' },
+  { label: 'Automation & Scripts', slug: 'automation-scripts' },
+  { label: 'API Patterns', slug: 'api-patterns' },
+];
+
+const agentCategories = [
+  { label: 'Auditing & Compliance', slug: 'auditing-compliance' },
+  { label: 'Health & Monitoring', slug: 'health-monitoring' },
+  { label: 'Incident & Service Desk', slug: 'incident-service-desk' },
+  { label: 'Client Lifecycle', slug: 'client-lifecycle' },
+  { label: 'Financial Operations', slug: 'financial-operations' },
+  { label: 'Documentation & Insights', slug: 'documentation-insights' },
+];
+
+const commandCategories = [
+  { label: 'Ticket Commands', slug: 'ticket-commands' },
+  { label: 'Asset & Device Commands', slug: 'asset-device-commands' },
+  { label: 'Automation Commands', slug: 'automation-commands' },
+  { label: 'Alert Commands', slug: 'alert-commands' },
+  { label: 'Documentation Commands', slug: 'documentation-commands' },
+  { label: 'Other Commands', slug: 'other-commands' },
+];
+
 const sidebarItems: SidebarItem[] = [
   {
     label: 'Getting Started',
@@ -104,8 +131,27 @@ const sidebarItems: SidebarItem[] = [
           })),
         ],
       },
-      { label: 'Skills', href: `${baseUrl}skills/` },
-      { label: 'Commands', href: `${baseUrl}commands/` },
+      {
+        label: 'Skills',
+        children: [
+          { label: 'Overview', href: `${baseUrl}skills/` },
+          ...skillCategories.map(c => ({ label: c.label, href: `${baseUrl}skills/#${c.slug}` })),
+        ],
+      },
+      {
+        label: 'Agents',
+        children: [
+          { label: 'Overview', href: `${baseUrl}agents/` },
+          ...agentCategories.map(c => ({ label: c.label, href: `${baseUrl}agents/#${c.slug}` })),
+        ],
+      },
+      {
+        label: 'Commands',
+        children: [
+          { label: 'Overview', href: `${baseUrl}commands/` },
+          ...commandCategories.map(c => ({ label: c.label, href: `${baseUrl}commands/#${c.slug}` })),
+        ],
+      },
     ]
   }
 ];

--- a/msp-claude-plugins/docs/src/pages/agents/index.astro
+++ b/msp-claude-plugins/docs/src/pages/agents/index.astro
@@ -1,0 +1,131 @@
+---
+import DocsLayout from '@/layouts/DocsLayout.astro';
+import { plugins } from '@/data/plugins';
+
+const baseUrl = import.meta.env.BASE_URL;
+
+const matchAgent = (name: string, patterns: (string | RegExp)[]) =>
+  patterns.some(p => typeof p === 'string' ? name.includes(p) : p.test(name));
+
+const agentCategories = [
+  {
+    name: 'Auditing & Compliance',
+    slug: 'auditing-compliance',
+    description: 'Agents that audit configurations, identities, devices, and surface compliance gaps.',
+    patterns: ['auditor', 'compliance-reporter', 'hardening']
+  },
+  {
+    name: 'Health & Monitoring',
+    slug: 'health-monitoring',
+    description: 'Agents that watch backups, automation, uptime, and overall customer health.',
+    patterns: ['health', 'uptime', 'monitor']
+  },
+  {
+    name: 'Incident & Service Desk',
+    slug: 'incident-service-desk',
+    description: 'Agents that triage alerts, drive incidents, and run service desk operations.',
+    patterns: ['incident', 'soc-alert', 'service-desk', 'change-detective']
+  },
+  {
+    name: 'Client Lifecycle',
+    slug: 'client-lifecycle',
+    description: 'Agents that handle onboarding, contracts, and renewal tracking.',
+    patterns: ['onboarding', 'contract', 'renewal']
+  },
+  {
+    name: 'Financial Operations',
+    slug: 'financial-operations',
+    description: 'Agents focused on billing, licensing, margins, and procurement.',
+    patterns: ['billing', 'license', 'margin', 'procurement']
+  },
+  {
+    name: 'Documentation & Insights',
+    slug: 'documentation-insights',
+    description: 'Agents that link assets to documentation and surface optimization opportunities.',
+    patterns: ['documentation-linker', 'opportunity']
+  }
+].map(cat => ({
+  ...cat,
+  agents: plugins.flatMap(p =>
+    p.agents
+      .filter(a => matchAgent(a.name, cat.patterns))
+      .map(a => ({ ...a, plugin: p }))
+  )
+}));
+
+const allAgents = plugins.flatMap(p =>
+  p.agents.map(a => ({ ...a, plugin: p }))
+);
+---
+
+<DocsLayout title="Agents Reference">
+  <h1>Agents Reference</h1>
+
+  <p class="lead text-lg text-[var(--muted)] mb-8">
+    Agents are specialized subagents that perform multi-step MSP workflows
+    autonomously. There are {allAgents.length} agents across all plugins.
+  </p>
+
+  <h2>What are Agents?</h2>
+
+  <p>
+    Agents combine skills, commands, and domain knowledge to execute
+    higher-level tasks — auditing a tenant, reconciling billing, triaging an
+    alert — without you walking Claude through every step. Each agent is scoped
+    to a clear role and a focused set of tools.
+  </p>
+
+  <pre><code class="language-text">/agent identity-auditor "Audit Acme Corp's M365 tenant"</code></pre>
+
+  <h2>Agents by Category</h2>
+
+  {agentCategories.filter(cat => cat.agents.length > 0).map(category => (
+    <div class="mb-8">
+      <h3 id={category.slug}>{category.name}</h3>
+      <p class="text-[var(--muted)]">{category.description}</p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Agent</th>
+            <th>Plugin</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {category.agents.map(agent => (
+            <tr>
+              <td><code>{agent.name}</code></td>
+              <td><a href={`${baseUrl}plugins/${agent.plugin.id}/`}>{agent.plugin.name}</a></td>
+              <td>{agent.description}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  ))}
+
+  <h2>All Agents by Plugin</h2>
+
+  {plugins.filter(p => p.agents.length > 0).map(plugin => (
+    <div class="mb-8">
+      <h3><a href={`${baseUrl}plugins/${plugin.id}/`}>{plugin.name}</a></h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Agent</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {plugin.agents.map(agent => (
+            <tr>
+              <td><code>{agent.name}</code></td>
+              <td>{agent.description}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  ))}
+</DocsLayout>

--- a/msp-claude-plugins/docs/src/pages/commands/index.astro
+++ b/msp-claude-plugins/docs/src/pages/commands/index.astro
@@ -8,6 +8,7 @@ const baseUrl = import.meta.env.BASE_URL;
 const commandCategories = [
   {
     name: 'Ticket Commands',
+    slug: 'ticket-commands',
     description: 'Commands for creating and searching service tickets.',
     commands: plugins.flatMap(p =>
       p.commands
@@ -17,6 +18,7 @@ const commandCategories = [
   },
   {
     name: 'Asset & Device Commands',
+    slug: 'asset-device-commands',
     description: 'Commands for looking up assets, devices, and running automation.',
     commands: plugins.flatMap(p =>
       p.commands
@@ -33,6 +35,7 @@ const commandCategories = [
   },
   {
     name: 'Automation Commands',
+    slug: 'automation-commands',
     description: 'Commands for running scripts, jobs, and automation tasks.',
     commands: plugins.flatMap(p =>
       p.commands
@@ -46,6 +49,7 @@ const commandCategories = [
   },
   {
     name: 'Alert Commands',
+    slug: 'alert-commands',
     description: 'Commands for managing and resolving alerts.',
     commands: plugins.flatMap(p =>
       p.commands
@@ -55,6 +59,7 @@ const commandCategories = [
   },
   {
     name: 'Documentation Commands',
+    slug: 'documentation-commands',
     description: 'Commands for searching docs, passwords, and organizations.',
     commands: plugins.flatMap(p =>
       p.commands
@@ -69,6 +74,7 @@ const commandCategories = [
   },
   {
     name: 'Other Commands',
+    slug: 'other-commands',
     description: 'Time entries, projects, accounts, and other operations.',
     commands: plugins.flatMap(p =>
       p.commands
@@ -115,7 +121,7 @@ const allCommands = plugins.flatMap(p =>
 
   {commandCategories.filter(cat => cat.commands.length > 0).map(category => (
     <div class="mb-8">
-      <h3>{category.name}</h3>
+      <h3 id={category.slug}>{category.name}</h3>
       <p class="text-[var(--muted)]">{category.description}</p>
 
       <table>

--- a/msp-claude-plugins/docs/src/pages/skills/index.astro
+++ b/msp-claude-plugins/docs/src/pages/skills/index.astro
@@ -8,6 +8,7 @@ const baseUrl = import.meta.env.BASE_URL;
 const skillCategories = [
   {
     name: 'Ticket Management',
+    slug: 'ticket-management',
     description: 'Skills for creating, searching, and managing service tickets.',
     skills: plugins.flatMap(p =>
       p.skills
@@ -17,6 +18,7 @@ const skillCategories = [
   },
   {
     name: 'Customer/Client Management',
+    slug: 'customer-management',
     description: 'Skills for managing customers, companies, contacts, and organizations.',
     skills: plugins.flatMap(p =>
       p.skills
@@ -26,6 +28,7 @@ const skillCategories = [
   },
   {
     name: 'Asset & Device Management',
+    slug: 'asset-device-management',
     description: 'Skills for managing devices, computers, configurations, and assets.',
     skills: plugins.flatMap(p =>
       p.skills
@@ -35,6 +38,7 @@ const skillCategories = [
   },
   {
     name: 'Monitoring & Alerts',
+    slug: 'monitoring-alerts',
     description: 'Skills for alert handling, monitoring, and device status.',
     skills: plugins.flatMap(p =>
       p.skills
@@ -44,6 +48,7 @@ const skillCategories = [
   },
   {
     name: 'Automation & Scripts',
+    slug: 'automation-scripts',
     description: 'Skills for running scripts, jobs, and automation workflows.',
     skills: plugins.flatMap(p =>
       p.skills
@@ -53,6 +58,7 @@ const skillCategories = [
   },
   {
     name: 'API Patterns',
+    slug: 'api-patterns',
     description: 'Skills covering authentication, pagination, rate limiting, and error handling.',
     skills: plugins.flatMap(p =>
       p.skills
@@ -95,7 +101,7 @@ What ticket statuses are available?</code></pre>
 
   {skillCategories.filter(cat => cat.skills.length > 0).map(category => (
     <div class="mb-8">
-      <h3>{category.name}</h3>
+      <h3 id={category.slug}>{category.name}</h3>
       <p class="text-[var(--muted)]">{category.description}</p>
 
       <table>


### PR DESCRIPTION
## Summary
- New **Agents** reference page (`/agents/`) with 6 categories pattern-matched against agent names — replaces the "All Agents (coming soon)" placeholder in the sidebar.
- Slugged anchor IDs on category headers in Skills and Commands index pages so categories are linkable from anywhere.
- Sidebar `Plugins → Components → All Agents` now points to the new page.

Scoped down from initial proposal to respect the IA restructure in #65 — the sidebar stays flat under Components rather than re-introducing per-category subsections.

## Test plan
- [ ] `/agents/` renders with categorized + per-plugin tables
- [ ] Sidebar Plugins → Components → All Agents links to `/agents/`
- [ ] `/skills/#ticket-management` and `/commands/#ticket-commands` (etc.) anchor-jump correctly