### PR TITLE
feat(kaseya): scaffold 6 plugins for the rest of the Kaseya portfolio

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -464,6 +464,54 @@
         "zero-trust",
         "application-control"
       ]
+    },
+    {
+      "name": "kaseya-vsa",
+      "source": "./msp-claude-plugins/kaseya/kaseya-vsa",
+      "description": "Kaseya VSA - endpoint monitoring, patch management, agent procedures, remote control (scaffolding)",
+      "version": "0.1.0",
+      "category": "rmm",
+      "tags": ["kaseya", "vsa", "rmm", "patch-management", "msp", "scaffolding"]
+    },
+    {
+      "name": "datto-bcdr",
+      "source": "./msp-claude-plugins/kaseya/datto-bcdr",
+      "description": "Datto BCDR (SIRIS / Alto) - backup status, screenshot verification, recovery points (scaffolding)",
+      "version": "0.1.0",
+      "category": "bcdr",
+      "tags": ["kaseya", "datto", "bcdr", "backup", "siris", "alto", "msp", "scaffolding"]
+    },
+    {
+      "name": "kaseya-bms",
+      "source": "./msp-claude-plugins/kaseya/kaseya-bms",
+      "description": "Kaseya BMS PSA - tickets, accounts, contracts, time entries, billing (scaffolding)",
+      "version": "0.1.0",
+      "category": "psa",
+      "tags": ["kaseya", "bms", "psa", "tickets", "msp", "scaffolding"]
+    },
+    {
+      "name": "datto-saas-protection",
+      "source": "./msp-claude-plugins/kaseya/datto-saas-protection",
+      "description": "Datto SaaS Protection (Backupify) - M365 / Google Workspace cloud-to-cloud backup (scaffolding)",
+      "version": "0.1.0",
+      "category": "bcdr",
+      "tags": ["kaseya", "datto", "backupify", "saas-backup", "m365", "msp", "scaffolding"]
+    },
+    {
+      "name": "unitrends",
+      "source": "./msp-claude-plugins/kaseya/unitrends",
+      "description": "Unitrends - appliances, backup jobs, recovery points, replication, alerts (scaffolding)",
+      "version": "0.1.0",
+      "category": "bcdr",
+      "tags": ["kaseya", "unitrends", "backup", "bcdr", "msp", "scaffolding"]
+    },
+    {
+      "name": "spanning",
+      "source": "./msp-claude-plugins/kaseya/spanning",
+      "description": "Spanning Cloud Backup - SaaS backup for M365 / Google Workspace / Salesforce (scaffolding)",
+      "version": "0.1.0",
+      "category": "bcdr",
+      "tags": ["kaseya", "spanning", "saas-backup", "m365", "salesforce", "msp", "scaffolding"]
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sherweb plugin (marketplace): 4 skills + 4 commands for billing, customers, subscriptions, API patterns
 - New `email-security` plugin category in marketplace.json
 
+#### Kaseya Portfolio Expansion — 6 New Plugin Scaffolds (`kaseya/`)
+- **kaseya-vsa** (`kaseya/kaseya-vsa/`) — RMM. API patterns skill covers two-step token auth, Kaseya One SSO bridging, OData pagination, response envelope semantics
+- **datto-bcdr** (`kaseya/datto-bcdr/`) — Backup/DR. API patterns skill covers HMAC-SHA256 request signing, screenshot verification retrieval, recovery point queries
+- **kaseya-bms** (`kaseya/kaseya-bms/`) — PSA. API patterns skill covers tenant subdomain routing, API token vs Kaseya One JWT, ticket workflow gotchas
+- **datto-saas-protection** (`kaseya/datto-saas-protection/`) — SaaS backup (M365 / Google Workspace). API patterns skill covers region selection (US/EU), seat hierarchy, async restore polling
+- **unitrends** (`kaseya/unitrends/`) — Backup. API patterns skill covers session-token login, appliance/asset hierarchy, MSP Console drift, self-signed cert handling
+- **spanning** (`kaseya/spanning/`) — SaaS backup (M365 / GWS / Salesforce). API patterns skill covers per-platform URL bases, admin-email + token auth, Salesforce object ID quirks
+- All plugins are version `0.1.0` and tagged `scaffolding` — content is reference documentation; matching MCP servers (`*-mcp`) and SDKs (`node-*`) are in development
+- Registered in `.claude-plugin/marketplace.json` under categories `rmm`, `psa`, and `bcdr` (new category for backup/disaster-recovery products)
+
 #### Kaseya Autotask Plugin (`kaseya/autotask/`) - v0.2.0
 - **Expenses Skill** - Expense report and expense item management, approval workflow (New/Submitted/Approved/Paid/Rejected/InReview), billable vs reimbursable tracking, picklist discovery for categories and payment types
 - **Quotes Skill** - Quote creation and line item management, product/service/service bundle linking, discount structures (unit, line, percentage), optional items, opportunity integration

--- a/msp-claude-plugins/kaseya/datto-bcdr/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/kaseya/datto-bcdr/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "datto-bcdr",
+  "version": "0.1.0",
+  "description": "Claude plugins for Datto BCDR (SIRIS / Alto) - backup status, screenshot verification, virtualization, recovery point management",
+  "author": {
+    "name": "MSP Claude Plugins Community"
+  },
+  "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
+  "repository": "https://github.com/wyre-technology/msp-claude-plugins",
+  "license": "Apache-2.0"
+}

--- a/msp-claude-plugins/kaseya/datto-bcdr/README.md
+++ b/msp-claude-plugins/kaseya/datto-bcdr/README.md
@@ -1,0 +1,29 @@
+# Datto BCDR Plugin
+
+Claude Code skills for working with the Datto BCDR (Backup, Continuity, Disaster Recovery) platform — SIRIS, Alto, and the Datto Backup Portal API.
+
+## Status
+
+**Scaffolding** — skill content is in place; the matching MCP server (`datto-bcdr-mcp`) and SDK (`node-datto-bcdr`) are in development.
+
+## Capabilities (planned)
+
+- Backup status: agents, schedules, last successful backup
+- Screenshot verification: list & retrieve hourly verification screenshots
+- Recovery points: list, mount, file-level recovery
+- Virtualization: local virtualization status, off-site VM start
+- Off-site sync: status, queue depth, last sync time
+- Alerts & escalations from the Backup Portal
+- Device inventory: SIRIS / Alto appliance fleet view
+
+## Authentication
+
+Datto BCDR uses a public/private key pair issued from the Datto Partner Portal (`portal.dattobackup.com`). Each request signs a timestamp + body with HMAC-SHA256. See `skills/api-patterns/SKILL.md`.
+
+## Skills
+
+- `api-patterns` — HMAC auth, pagination, error handling
+
+## License
+
+Apache-2.0

--- a/msp-claude-plugins/kaseya/datto-bcdr/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/kaseya/datto-bcdr/skills/api-patterns/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: "Datto BCDR API Patterns"
+when_to_use: "When working with the Datto BCDR / SIRIS / Alto Backup Portal API — auth, pagination, screenshot retrieval, recovery point queries"
+description: >
+  Use this skill when integrating with the Datto BCDR (Backup Portal) REST API. Covers
+  the public/private key HMAC-SHA256 signing flow, the /v1 endpoint surface, pagination,
+  appliance/agent hierarchy, screenshot verification retrieval, and known gotchas.
+triggers:
+  - datto bcdr
+  - datto backup
+  - datto siris
+  - datto alto
+  - bcdr api
+  - screenshot verification
+  - recovery point
+  - datto portal
+---
+
+# Datto BCDR API Patterns
+
+## Status note
+
+The MCP server (`datto-bcdr-mcp`) and SDK (`@wyre-technology/node-datto-bcdr`) are in development. This skill is reference documentation; the implementation will follow these patterns.
+
+## Overview
+
+The Datto BCDR API (also known as the Datto Backup Portal API or "RESTful Reporting API") exposes the state of every SIRIS/Alto appliance and protected agent in a partner's fleet. Base URL:
+
+```
+https://api.datto.com/v1
+```
+
+Reference: <https://continuity.datto.com/help/Content/kb/DBMA/KB400000010980.htm>
+
+This is a **separate API from Datto RMM**. Different keys, different signing scheme, different endpoint surface.
+
+## Authentication
+
+Datto BCDR uses **HMAC-SHA256 request signing** with a public + private key pair, not bearer tokens.
+
+### Key issuance
+
+1. Log into the Datto Partner Portal (`partners.datto.com`)
+2. Settings → Integrations → API Keys → Create Key
+3. Capture the **public key** and **private key** — the private key is shown once
+4. (Optional) Restrict the key to specific appliances or read-only
+
+### Request signing
+
+Every request includes three headers:
+
+| Header | Value |
+|--------|-------|
+| `X-Datto-API-Key` | The public key |
+| `X-Datto-API-Timestamp` | Unix epoch seconds (UTC) |
+| `X-Datto-API-Signature` | Hex-encoded HMAC-SHA256 |
+
+The signature input string is:
+
+```
+<METHOD> + "\n" + <URL_PATH> + "\n" + <TIMESTAMP> + "\n" + <REQUEST_BODY>
+```
+
+Body is the empty string for GET requests. Signed with the **private key** as the HMAC secret.
+
+```js
+import { createHmac } from 'node:crypto';
+
+function signRequest({ method, urlPath, body = '', publicKey, privateKey }) {
+  const ts = Math.floor(Date.now() / 1000).toString();
+  const stringToSign = `${method.toUpperCase()}\n${urlPath}\n${ts}\n${body}`;
+  const signature = createHmac('sha256', privateKey).update(stringToSign).digest('hex');
+  return {
+    'X-Datto-API-Key': publicKey,
+    'X-Datto-API-Timestamp': ts,
+    'X-Datto-API-Signature': signature,
+  };
+}
+```
+
+Clock skew tolerance is **5 minutes**. NTP-sync the host or expect 401s.
+
+## Endpoint surface
+
+| Domain | Endpoint | Notes |
+|--------|----------|-------|
+| Devices (appliances) | `GET /bcdr/device` | Full fleet view |
+| Single device | `GET /bcdr/device/{serialNumber}` | Appliance-level health |
+| Agents on device | `GET /bcdr/device/{serialNumber}/asset` | Protected machines |
+| Agent details | `GET /bcdr/device/{sn}/asset/{agentId}` | Per-agent backup state |
+| Recovery points | `GET /bcdr/device/{sn}/asset/{agentId}/backup` | List restore points |
+| Screenshots | `GET /bcdr/device/{sn}/asset/{agentId}/screenshot` | Verification screenshots |
+| Single screenshot | `GET /bcdr/device/{sn}/asset/{agentId}/screenshot/{epoch}` | PNG body |
+| Off-site sync | `GET /bcdr/device/{sn}/offsite` | Cloud sync status |
+| Alerts | `GET /report/v2/alert` | Aggregated portal alerts |
+| Activity log | `GET /report/v2/activity-log` | Per-device activity |
+
+## Pagination
+
+Use `_page` (1-based) and `_perPage` (max 250). Responses include a `pagination` object:
+
+```json
+{
+  "items": [ /* ... */ ],
+  "pagination": {
+    "page": 1,
+    "perPage": 250,
+    "totalPages": 4,
+    "totalItems": 877
+  }
+}
+```
+
+## Screenshot verification
+
+Screenshots are PNG bodies, retrieved by epoch timestamp from the `screenshot` list endpoint. Datto runs hourly screenshot verification against virtualized recovery points; the screenshot is the visual proof that the backup is bootable.
+
+```
+1. GET /bcdr/device/{sn}/asset/{agentId}/screenshot
+   → list of {timestamp, status, errorMessage}
+2. GET /bcdr/device/{sn}/asset/{agentId}/screenshot/{timestamp}
+   → image/png body
+```
+
+For LLM display, base64-encode and embed; or store and link.
+
+## Rate limits
+
+Datto BCDR throttles at **120 req/min per partner**. Above that, expect HTTP 429 with `Retry-After` (seconds). Long-running list operations should batch — avoid blasting per-agent screenshot fetches in parallel.
+
+## Error handling
+
+| HTTP | Meaning | Action |
+|------|---------|--------|
+| 200 | OK | Continue |
+| 400 | Malformed request, e.g. bad timestamp format | Validate inputs |
+| 401 | Bad signature, expired timestamp, or wrong key | Re-sign; check clock skew |
+| 403 | Key lacks permission for this appliance | Surface message |
+| 404 | Serial / agent / restore point unknown | Verify identifiers |
+| 429 | Rate limited | Back off per `Retry-After` |
+| 500-503 | Transient | Exponential backoff, ≤3 retries |
+
+## Gotchas
+
+- **Clock skew**: 5 minutes max. Containerized clients must use NTP.
+- **Path canonicalization**: The `URL_PATH` in the signature must match the request line **exactly** including query string ordering. Sort query params before signing.
+- **Body in signature**: Always include the literal request body — even an empty string for GET.
+- **Distinct from Datto RMM**: A user with Datto RMM API keys cannot call BCDR endpoints; different key types entirely.
+- **Status semantics**: A "successful" backup can still have a failed screenshot verification. Always inspect both `lastBackup` and `lastScreenshotVerification` per agent for full health.
+
+## Related skills
+
+Domain-specific skills for backups, screenshots, virtualization, and alerts will land alongside the MCP server build-out.

--- a/msp-claude-plugins/kaseya/datto-saas-protection/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/kaseya/datto-saas-protection/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "datto-saas-protection",
+  "version": "0.1.0",
+  "description": "Claude plugins for Datto SaaS Protection (Backupify) - M365 / Google Workspace backup status, restore, seat management",
+  "author": {
+    "name": "MSP Claude Plugins Community"
+  },
+  "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
+  "repository": "https://github.com/wyre-technology/msp-claude-plugins",
+  "license": "Apache-2.0"
+}

--- a/msp-claude-plugins/kaseya/datto-saas-protection/README.md
+++ b/msp-claude-plugins/kaseya/datto-saas-protection/README.md
@@ -1,0 +1,28 @@
+# Datto SaaS Protection Plugin
+
+Claude Code skills for working with Datto SaaS Protection (formerly Backupify) — cloud-to-cloud backup for Microsoft 365 and Google Workspace.
+
+## Status
+
+**Scaffolding** — skill content is in place; the matching MCP server (`datto-saas-protection-mcp`) and SDK (`node-datto-saas-protection`) are in development.
+
+## Capabilities (planned)
+
+- Backup status: per-seat, per-tenant
+- Seat management: list, license assignment, archived seats
+- Restore operations: file/email/site restore queueing
+- Tenant inventory: M365 & Google Workspace organizations
+- Activity log: backup runs, errors, restores
+- Domain mapping (M365 tenant → SaaS Protection org)
+
+## Authentication
+
+REST API key issued from the SaaS Protection partner portal. Send as `Authorization: Bearer <key>`. See `skills/api-patterns/SKILL.md`.
+
+## Skills
+
+- `api-patterns` — auth, pagination, error handling
+
+## License
+
+Apache-2.0

--- a/msp-claude-plugins/kaseya/datto-saas-protection/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/kaseya/datto-saas-protection/skills/api-patterns/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: "Datto SaaS Protection API Patterns"
+when_to_use: "When working with the Datto SaaS Protection (Backupify) REST API — auth, seat queries, restore status, M365/Google tenant operations"
+description: >
+  Use this skill when integrating with Datto SaaS Protection (formerly Backupify). Covers
+  the REST API base URL, bearer-token auth, seat & tenant model, backup status queries,
+  restore operations, and known gotchas.
+triggers:
+  - datto saas protection
+  - backupify
+  - saas backup
+  - m365 backup
+  - google workspace backup
+  - saas protection api
+---
+
+# Datto SaaS Protection API Patterns
+
+## Status note
+
+The MCP server (`datto-saas-protection-mcp`) and SDK (`@wyre-technology/node-datto-saas-protection`) are in development.
+
+## Overview
+
+Datto SaaS Protection (rebranded Backupify, now also folded together with Spanning under the same product family) provides cloud-to-cloud backup for Microsoft 365 and Google Workspace tenants.
+
+Reference: <https://saasprotection.datto.com/help/M365/Content/Other_Administrative_Tasks/using-rest-api-saas-protection.htm>
+
+Base URLs (per region):
+
+```
+https://api.dattobackup.com/api/v1            (US)
+https://api.eu.dattobackup.com/api/v1         (EU)
+```
+
+The MCP server takes a `region` credential field (`us` or `eu`); never hard-code.
+
+## Authentication
+
+API key issued from the SaaS Protection partner portal:
+
+1. SaaS Protection portal → Settings → API → Create Key
+2. Optional: scope key to specific clients
+3. Send on every request:
+
+```
+Authorization: Bearer <api_key>
+```
+
+Keys are long-lived; rotate from the same UI.
+
+## Object model
+
+```
+Partner
+ └── Client (a customer organization)
+      └── Domain (M365 tenant / Google domain)
+           └── Seat (mailbox / OneDrive / SharePoint site / Google user)
+                └── Backup runs / restore points
+```
+
+## Common endpoints
+
+| Domain | Endpoint | Notes |
+|--------|----------|-------|
+| Clients | `GET /clients` | All client orgs |
+| Domains | `GET /clients/{clientId}/domains` | M365/Google tenants |
+| Seats | `GET /clients/{clientId}/domains/{domainId}/seats` | Active + archived |
+| Single seat | `GET /seats/{seatId}` | |
+| Backup status | `GET /seats/{seatId}/backups` | Most recent backup runs |
+| Activity log | `GET /clients/{clientId}/activity` | Org-level events |
+| Restore (request) | `POST /seats/{seatId}/restores` | Queue restore |
+| Restore status | `GET /restores/{restoreId}` | |
+| License usage | `GET /clients/{clientId}/usage` | Seat counts |
+
+## Pagination
+
+Cursor-based:
+
+```
+GET /clients?limit=100
+→ { items: [...], nextCursor: "abc123" }
+
+GET /clients?limit=100&cursor=abc123
+```
+
+Default `limit` is 50, max is 250. Stop when `nextCursor` is missing or null.
+
+## Restore operations
+
+Restores are async. The flow:
+
+```
+1. POST /seats/{seatId}/restores   → { restoreId, status: "queued" }
+2. Poll GET /restores/{restoreId}  → status transitions queued → running → completed | failed
+3. On completed, fetch the result location (URL or destination metadata)
+```
+
+Typical restore wall-clock: minutes to hours depending on data volume. Poll at 30-second intervals; do not poll faster.
+
+## Rate limits
+
+**60 req/min per API key** under default policy. HTTP 429 includes `Retry-After`. Aggregate operations (list all seats across all clients) should use `Promise.all` with concurrency capped at 4.
+
+## Error handling
+
+| HTTP | Meaning | Action |
+|------|---------|--------|
+| 200 | OK | |
+| 400 | Bad request | Validate inputs |
+| 401 | Bad / expired key | Rotate key |
+| 403 | Key lacks scope on this client | Verify scope |
+| 404 | Unknown seatId / clientId / domainId | |
+| 409 | Restore already queued for this seat | Surface; offer to cancel-and-retry |
+| 429 | Rate limited | Back off per `Retry-After` |
+| 500-503 | Transient | Exponential backoff |
+
+## Gotchas
+
+- **Region selection is sticky**: A US-region key cannot call EU endpoints. The error is a generic 401, not a 404 — surface a clear message asking the user to check the region credential.
+- **Archived seats**: By default, list endpoints return only active seats. Pass `?includeArchived=true` to see seats whose source mailboxes were deleted but whose backups are retained.
+- **Spanning vs. SaaS Protection**: These are different products that share marketing branding. Spanning has its own API (`spanning-mcp` plugin) — don't conflate keys.
+- **Restore destination quirks**: Restoring an M365 mailbox to an existing user requires Graph API permissions on the target tenant; the SaaS Protection API surfaces the dependency as a 400 once the restore starts running, not at queue time.
+
+## Related skills
+
+When the build-out lands, expect domain skills for: clients, seats, restores, activity-logs, license-usage.

--- a/msp-claude-plugins/kaseya/datto-saas-protection/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/kaseya/datto-saas-protection/skills/api-patterns/SKILL.md
@@ -29,8 +29,8 @@ Reference: <https://saasprotection.datto.com/help/M365/Content/Other_Administrat
 Base URLs (per region):
 
 ```
-https://api.dattobackup.com/api/v1            (US)
-https://api.eu.dattobackup.com/api/v1         (EU)
+https://api.datto.com/api/v1            (US)
+https://api.eu.datto.com/api/v1         (EU)
 ```
 
 The MCP server takes a `region` credential field (`us` or `eu`); never hard-code.

--- a/msp-claude-plugins/kaseya/kaseya-bms/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/kaseya/kaseya-bms/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "kaseya-bms",
+  "version": "0.1.0",
+  "description": "Claude plugins for Kaseya BMS - tickets, accounts, contracts, time entries, billing (PSA)",
+  "author": {
+    "name": "MSP Claude Plugins Community"
+  },
+  "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
+  "repository": "https://github.com/wyre-technology/msp-claude-plugins",
+  "license": "Apache-2.0"
+}

--- a/msp-claude-plugins/kaseya/kaseya-bms/README.md
+++ b/msp-claude-plugins/kaseya/kaseya-bms/README.md
@@ -1,0 +1,30 @@
+# Kaseya BMS Plugin
+
+Claude Code skills for working with the Kaseya BMS PSA platform — tickets, accounts, contracts, time entries, and billing.
+
+## Status
+
+**Scaffolding** — skill content is in place; the matching MCP server (`kaseya-bms-mcp`) and SDK (`node-kaseya-bms`) are in development.
+
+BMS is Kaseya's organic PSA, sharing Kaseya One auth with VSA and (partially) Autotask. Vorex is the legacy product being absorbed into BMS — this plugin targets BMS only.
+
+## Capabilities (planned)
+
+- Tickets: list, create, update, close, assign, time entries
+- Accounts (clients): search, create, update, contacts
+- Contracts: list, billing rules
+- Time entries: log, approve, billable status
+- Service items / catalog
+- Knowledge base articles
+
+## Authentication
+
+BMS REST API v2 uses an API token issued from BMS Admin → Service Desk → API Tokens, plus a tenant subdomain. Kaseya One SSO is supported on unified-login tenants.
+
+## Skills
+
+- `api-patterns` — auth, pagination, error handling
+
+## License
+
+Apache-2.0

--- a/msp-claude-plugins/kaseya/kaseya-bms/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/kaseya/kaseya-bms/skills/api-patterns/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: "Kaseya BMS API Patterns"
+when_to_use: "When working with the Kaseya BMS REST API v2 — auth, tenant subdomain handling, pagination, ticket/account workflows, error handling"
+description: >
+  Use this skill when integrating with the Kaseya BMS PSA REST API v2. Covers tenant
+  subdomain routing, API-token bearer auth, Kaseya One SSO bridging, ticket and account
+  workflows, OData-style pagination, and BMS-specific gotchas.
+triggers:
+  - kaseya bms
+  - bms api
+  - bms tickets
+  - bms accounts
+  - bms psa
+  - vorex
+  - kaseya psa
+---
+
+# Kaseya BMS API Patterns
+
+## Status note
+
+The MCP server (`kaseya-bms-mcp`) and SDK (`@wyre-technology/node-kaseya-bms`) are in development. This skill is reference documentation.
+
+## Overview
+
+Kaseya BMS exposes a REST v2 API at `/api/` on every BMS tenant. Reference: <https://help.bms.kaseya.com/help/Content/BMS%20API/bms-api-v2-bms-rest-apis.html>
+
+Each MSP has a private tenant — there is no shared regional endpoint:
+
+```
+https://<tenant>.bms.kaseya.com/api
+```
+
+The tenant subdomain is a credential field; never hard-code.
+
+## Authentication
+
+Two supported flows.
+
+### API Token (recommended for integrations)
+
+1. BMS Admin → Service Desk → API Tokens → Create
+2. Copy the token (shown once)
+3. Send on every request as:
+
+```
+Authorization: Bearer <api_token>
+X-Tenant: <tenantSubdomain>
+```
+
+Tokens are long-lived; revoke from the same UI.
+
+### Kaseya One SSO
+
+On Kaseya One tenants, mint a token via `https://one.kaseya.com/oauth/token` with `scope=bms.api`, then call BMS endpoints with `Authorization: Bearer <kaseya_one_jwt>`. The JWT carries the tenant claim — no `X-Tenant` header needed.
+
+## Pagination
+
+OData-style:
+
+| Param | Default | Max | Notes |
+|-------|---------|-----|-------|
+| `$top` | 50 | 500 | Page size |
+| `$skip` | 0 | — | Records to skip |
+| `$filter` | none | — | OData filter (e.g. `Status eq 'Open'`) |
+| `$orderby` | none | — | e.g. `CreatedDate desc` |
+
+Responses include `TotalRecords` for total count; loop with `$skip += $top` until `$skip >= TotalRecords`.
+
+## Common endpoints
+
+| Domain | Endpoint | Notes |
+|--------|----------|-------|
+| Tickets | `GET /api/v2/service/tickets` | Filter via `$filter` |
+| Single ticket | `GET /api/v2/service/tickets/{id}` | Includes notes if `?includeNotes=true` |
+| Create ticket | `POST /api/v2/service/tickets` | |
+| Add ticket note | `POST /api/v2/service/tickets/{id}/notes` | |
+| Time entries | `GET /api/v2/service/timeentries` | Per-user/ticket |
+| Accounts | `GET /api/v2/finance/accounts` | Clients |
+| Contacts | `GET /api/v2/crm/contacts` | |
+| Contracts | `GET /api/v2/finance/contracts` | |
+| Service catalog | `GET /api/v2/service/catalog` | |
+| KB articles | `GET /api/v2/service/knowledgebase` | |
+
+## Response shape
+
+```json
+{
+  "Result": [ /* records */ ],
+  "TotalRecords": 1234,
+  "ResponseCode": 0,
+  "Status": "Ok"
+}
+```
+
+`ResponseCode != 0` means application-level error even with HTTP 200; surface `Error` field to the user.
+
+## Rate limits
+
+BMS throttles at **300 req/min per tenant** under default policy. HTTP 429 includes `Retry-After`. Sustained abuse can trigger temporary tenant-level lockouts — back off aggressively.
+
+## Error handling
+
+| HTTP | Meaning | Action |
+|------|---------|--------|
+| 200 | OK (check `ResponseCode`) | |
+| 400 | Bad filter / missing required field | Validate inputs |
+| 401 | Bad token or expired | Re-issue token; check `X-Tenant` |
+| 403 | Token lacks scope on this resource | Surface; verify role |
+| 404 | Endpoint or record missing | Confirm tenant subdomain |
+| 429 | Rate limited | Back off per `Retry-After` |
+| 500-503 | Transient | Exponential backoff |
+
+## Gotchas
+
+- **Tenant header vs JWT claim**: With API token auth, `X-Tenant` is required. With Kaseya One SSO, the JWT carries the tenant claim and `X-Tenant` is *ignored* (or rejected on some versions). Pick one; don't send both.
+- **OData filter strings**: Field names are PascalCase (`CreatedDate`, `Status`). Common 400s come from camelCase (`createdDate`).
+- **Ticket status transitions**: BMS enforces a state machine on `Status`. Setting an invalid transition returns 400 with a generic message; check the workflow definition before bulk updates.
+- **Vorex compatibility shims**: Some legacy Vorex tenants still respond on BMS endpoints with subtly different field names (e.g. `AccountID` vs `AccountId`). Defensive parsing pays off.
+
+## Related skills
+
+When the build-out lands, expect domain skills under this plugin for: tickets, accounts, contracts, time-entries, knowledge-base.

--- a/msp-claude-plugins/kaseya/kaseya-vsa/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/kaseya/kaseya-vsa/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "kaseya-vsa",
+  "version": "0.1.0",
+  "description": "Claude plugins for Kaseya VSA - endpoint monitoring, patch management, agent procedures, remote control",
+  "author": {
+    "name": "MSP Claude Plugins Community"
+  },
+  "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
+  "repository": "https://github.com/wyre-technology/msp-claude-plugins",
+  "license": "Apache-2.0"
+}

--- a/msp-claude-plugins/kaseya/kaseya-vsa/README.md
+++ b/msp-claude-plugins/kaseya/kaseya-vsa/README.md
@@ -1,0 +1,31 @@
+# Kaseya VSA Plugin
+
+Claude Code skills for working with the Kaseya VSA (and VSA 10 / VSA X) RMM platform.
+
+## Status
+
+**Scaffolding** — skill content is in place; the matching MCP server (`kaseya-vsa-mcp`) and SDK (`node-kaseya-vsa`) are in development. Until those ship, these skills act as reference documentation for the API and as a placeholder in the plugin marketplace.
+
+## Capabilities (planned)
+
+- Endpoint inventory: agents, organizations, machine groups
+- Patch management: scan, deploy, schedule, rollback
+- Agent procedures (scripts): list, run, schedule, view status
+- Live Connect / remote control session orchestration
+- Audit data: hardware, software, OS, disk, network adapter inventories
+- Tickets (when VSA Service Desk is enabled)
+- Monitoring: alerts, monitor sets, log monitors
+
+## Authentication
+
+Kaseya VSA uses an API key per user, with optional Kaseya One SSO bearer tokens for unified-login deployments. See `skills/api-patterns/SKILL.md` for the full auth flow.
+
+## Skills
+
+- `api-patterns` — auth, pagination, rate limits, error handling
+
+Domain skills (agents, patches, procedures, etc.) will be added alongside the MCP server build-out.
+
+## License
+
+Apache-2.0

--- a/msp-claude-plugins/kaseya/kaseya-vsa/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/kaseya/kaseya-vsa/skills/api-patterns/SKILL.md
@@ -39,12 +39,23 @@ For Kaseya One SSO tenants, skip the password-hash dance and exchange a Kaseya O
 
 ### Auth header construction (legacy/local users)
 
+The full Authorization string is **six** comma-separated fields. Both the
+"covered" hashes (raw + nonce, re-hashed) and the raw hashes must be sent —
+omitting `rpass2`/`rpass1` silently 401s every login. Source:
+<https://help.vsa9.kaseya.com/help/Content/Modules/rest-api/37334.htm>
+
 ```
-RawSHA256Hash       = SHA-256(password + username)
-DoubleHash          = SHA-256(RawSHA256Hash + RandomString)
-RawSHA1Hash         = SHA-1(password + username)
-DoubleHash1         = SHA-1(RawSHA1Hash + RandomString)
-Authorization: Basic user=<username>,pass2=<DoubleHash>,pass1=<DoubleHash1>,rand2=<RandomString>
+RawSHA256           = SHA-256(password + username)
+RawSHA1             = SHA-1(password + username)
+CoveredSHA256       = SHA-256(RawSHA256 + RandomString)
+CoveredSHA1         = SHA-1(RawSHA1 + RandomString)
+
+Authorization: Basic user=<username>,
+                     pass2=<CoveredSHA256>,
+                     pass1=<CoveredSHA1>,
+                     rpass2=<RawSHA256>,
+                     rpass1=<RawSHA1>,
+                     rand2=<RandomString>
 ```
 
 Capture the returned `Token` field, then send `Authorization: Bearer <Token>` on every subsequent call.

--- a/msp-claude-plugins/kaseya/kaseya-vsa/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/kaseya/kaseya-vsa/skills/api-patterns/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: "Kaseya VSA API Patterns"
+when_to_use: "When working with the Kaseya VSA REST API — authentication, pagination, rate limits, error handling, or planning Kaseya VSA integrations"
+description: >
+  Use this skill when working with the Kaseya VSA REST API. Covers two-step token-based
+  authentication, the /api/v1.0 surface, pagination ($skip/$top), filtering ($filter),
+  request/response envelope, error codes, and Kaseya One SSO bearer-token auth for
+  unified-login tenants.
+triggers:
+  - kaseya vsa
+  - vsa api
+  - kaseya rmm
+  - kaseya patch management
+  - agent procedures
+  - kaseya one
+  - vsa authentication
+---
+
+# Kaseya VSA API Patterns
+
+## Status note
+
+The MCP server (`kaseya-vsa-mcp`) and SDK (`@wyre-technology/node-kaseya-vsa`) are in development. This skill is reference documentation for the API surface and authentication flow; the implementation will follow the patterns described here.
+
+## Overview
+
+Kaseya VSA exposes a REST API at `/api/v1.0/` on every VSA tenant. Modern VSA 10 / VSA X tenants additionally support Kaseya One SSO bearer tokens issued by `https://one.kaseya.com`, sharing identity with Autotask, BMS, IT Glue (partial), and Datto EDR.
+
+Reference: <https://help.vsa10.kaseya.com/>
+
+## Authentication
+
+VSA uses a **two-step token exchange** for API key auth:
+
+1. `GET /api/v1.0/auth` with HTTP basic-auth-style headers built from a SHA-256/SHA-1 hash of the user password + a per-request random nonce.
+2. The response contains a session token that is sent as `Authorization: Bearer <token>` on subsequent calls. Token TTL is short (default 15 minutes); the server returns `Token-Expires-In` in the response.
+
+For Kaseya One SSO tenants, skip the password-hash dance and exchange a Kaseya One JWT for a VSA session token instead.
+
+### Auth header construction (legacy/local users)
+
+```
+RawSHA256Hash       = SHA-256(password + username)
+DoubleHash          = SHA-256(RawSHA256Hash + RandomString)
+RawSHA1Hash         = SHA-1(password + username)
+DoubleHash1         = SHA-1(RawSHA1Hash + RandomString)
+Authorization: Basic user=<username>,pass2=<DoubleHash>,pass1=<DoubleHash1>,rand2=<RandomString>
+```
+
+Capture the returned `Token` field, then send `Authorization: Bearer <Token>` on every subsequent call.
+
+### Kaseya One bearer flow
+
+```
+POST https://one.kaseya.com/oauth/token
+  grant_type=client_credentials
+  client_id=<integration client id>
+  client_secret=<secret>
+  scope=vsa.api
+
+→ access_token (JWT)
+
+GET https://<tenant>/api/v1.0/auth/sso
+  Authorization: Bearer <access_token>
+
+→ VSA session token usable as Bearer on subsequent /api/v1.0 calls
+```
+
+## Base URL
+
+Each MSP has a private VSA tenant URL — there is no shared regional endpoint. Examples:
+
+- `https://vsa.exampleMSP.com/api/v1.0`
+- `https://kaseya.exampleMSP.com/api/v1.0`
+
+The MCP server takes the tenant URL as a credential field; never hard-code.
+
+## Pagination
+
+VSA uses **OData-style** `$skip` + `$top` (not cursor-based). Every list endpoint accepts:
+
+| Parameter | Default | Max  | Description |
+|-----------|---------|------|-------------|
+| `$top`    | 100     | 1000 | Page size |
+| `$skip`   | 0       | —    | Records to skip |
+| `$filter` | none    | —    | OData filter expression |
+| `$orderby`| none    | —    | Sort, e.g. `MachineName asc` |
+
+Pagination loop:
+
+```
+loop:
+  GET /api/v1.0/assetmgmt/agents?$top=1000&$skip=<offset>
+  read response.Result (the array of records)
+  read response.TotalRecords (total count)
+  offset += 1000
+  if offset >= TotalRecords: stop
+```
+
+## Response envelope
+
+All VSA responses use this shape:
+
+```json
+{
+  "Result": [ /* records */ ] or { /* single record */ },
+  "ResponseCode": 0,
+  "TotalRecords": 1234,
+  "Code": "0",
+  "Status": "Ok",
+  "Error": null
+}
+```
+
+A `ResponseCode != 0` or non-null `Error` indicates failure even with HTTP 200. **Always** check both the HTTP status and `Result.ResponseCode` / `Result.Error`.
+
+## Common endpoints
+
+| Domain | Endpoint | Notes |
+|--------|----------|-------|
+| Agents | `GET /assetmgmt/agents` | Returns endpoints with org/group context |
+| Agent details | `GET /assetmgmt/agents/{agentId}` | Hardware, OS, network |
+| Software audit | `GET /assetmgmt/audit/{agentId}/software` | Installed apps |
+| Patch status | `GET /assetmgmt/patch/status/{agentId}` | Pending/installed patches |
+| Patch deploy | `POST /assetmgmt/patch/{agentId}/deploypatchnow` | Force a deploy now |
+| Procedures (scripts) | `GET /automation/agentprocs/{agentId}` | Available procedures |
+| Run procedure | `POST /automation/agentprocs/{agentId}/{procId}/runnow` | Execute |
+| Tickets (SD) | `GET /servicedesk/tickets` | If Service Desk enabled |
+| Alarms | `GET /assetmgmt/alarms` | Active monitor alarms |
+| Organizations | `GET /system/orgs` | Tenant organizations |
+| Machine groups | `GET /system/machinegroups` | Hierarchy under an org |
+
+## Rate limits
+
+Kaseya does not publish hard rate limits but throttles aggressively under load. Defensive defaults:
+
+- Cap concurrent requests per tenant at **4**
+- Token-bucket at **120 req/min sustained**
+- Always handle HTTP 429 with `Retry-After` (seconds)
+- Back off and retry on HTTP 503; treat 504 as transient
+
+## Error handling
+
+| HTTP | VSA `ResponseCode` | Meaning | Action |
+|------|--------------------|---------|--------|
+| 200 | 0 | Success | Continue |
+| 200 | non-zero | Application error in `Error` field | Surface message; do not retry |
+| 401 | — | Token expired | Re-auth, retry once |
+| 403 | — | User lacks scope on this resource | Surface; do not retry |
+| 404 | — | Endpoint or record missing | Surface; check tenant URL |
+| 429 | — | Throttled | Back off per `Retry-After` |
+| 500-503 | — | Transient | Exponential backoff, max 3 retries |
+
+## Known gotchas (from sister Kaseya APIs)
+
+- **Silent IP blocking**: Like Autotask, VSA can drop requests from non-allowlisted IPs as 30s timeouts (no 403). When tools/list works but tools/call hangs, suspect the egress IP. (See gateway memory: ACA egress vs ingress IP — `staticIp` is for inbound; outbound uses a different IP.)
+- **Tenant URL trailing slash**: Some VSA versions redirect `/api/v1.0/agents` → `/api/v1.0/agents/` (301), which strips the `Authorization` header. Normalize all paths to end with `/`.
+- **Token race in concurrent flows**: Re-auth on 401 races between concurrent requests can cause both to refresh and one to clobber the other. Wrap re-auth in a single-flight mutex.
+
+## Related skills
+
+When the build-out lands, expect domain-specific skills under this plugin for: agents, patches, procedures, tickets, alarms, organizations.

--- a/msp-claude-plugins/kaseya/spanning/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/kaseya/spanning/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "spanning",
+  "version": "0.1.0",
+  "description": "Claude plugins for Spanning Cloud Backup - M365 / Google Workspace / Salesforce SaaS backup, restore, audit",
+  "author": {
+    "name": "MSP Claude Plugins Community"
+  },
+  "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
+  "repository": "https://github.com/wyre-technology/msp-claude-plugins",
+  "license": "Apache-2.0"
+}

--- a/msp-claude-plugins/kaseya/spanning/README.md
+++ b/msp-claude-plugins/kaseya/spanning/README.md
@@ -1,0 +1,30 @@
+# Spanning Plugin
+
+Claude Code skills for working with Spanning Cloud Backup — SaaS backup for Microsoft 365, Google Workspace, and Salesforce.
+
+## Status
+
+**Scaffolding** — skill content is in place; the matching MCP server (`spanning-mcp`) and SDK (`node-spanning`) are in development.
+
+Note: Spanning and Datto SaaS Protection share marketing branding under Kaseya but are distinct products with separate APIs and customer bases. This plugin targets Spanning specifically.
+
+## Capabilities (planned)
+
+- User backup status: per-user, per-platform
+- License management: assign, unassign, archive
+- Backup runs: history, success/failure, errors
+- Restore operations: queue, monitor, complete
+- Audit log: admin actions, restore actions
+- Cross-tenant reporting (M365 + GWS + Salesforce in one view)
+
+## Authentication
+
+Spanning uses an admin email + API token issued from the Spanning admin console. See `skills/api-patterns/SKILL.md`.
+
+## Skills
+
+- `api-patterns` — auth, pagination, error handling
+
+## License
+
+Apache-2.0

--- a/msp-claude-plugins/kaseya/spanning/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/kaseya/spanning/skills/api-patterns/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: "Spanning API Patterns"
+when_to_use: "When working with the Spanning Cloud Backup REST API — auth, user/license queries, backup status, restore operations, audit retrieval"
+description: >
+  Use this skill when integrating with Spanning Cloud Backup. Covers admin email + API
+  token auth, the per-platform endpoint surface (M365, Google Workspace, Salesforce),
+  user/license model, backup status queries, restore operations, and audit logs.
+triggers:
+  - spanning
+  - spanning backup
+  - spanning api
+  - saas backup spanning
+  - cloud backup
+---
+
+# Spanning API Patterns
+
+## Status note
+
+The MCP server (`spanning-mcp`) and SDK (`@wyre-technology/node-spanning`) are in development.
+
+## Overview
+
+Spanning Cloud Backup provides daily SaaS backup for Microsoft 365, Google Workspace, and Salesforce. Each platform has its own REST API surface but a shared auth model.
+
+Base URLs:
+
+```
+https://o365-api.spanningbackup.com/external/   (Microsoft 365)
+https://api.spanningbackup.com/external/        (Google Workspace)
+https://salesforce-api.spanningbackup.com/      (Salesforce)
+```
+
+The MCP server takes a `platform` credential field (`m365` | `gws` | `salesforce`) plus the appropriate region if applicable.
+
+## Authentication
+
+Spanning uses admin email + API token, sent as basic-style headers:
+
+```
+X-Spanning-Admin: admin@example.com
+X-Spanning-Authorization: Bearer <api_token>
+```
+
+Token issuance:
+
+1. Spanning admin console → Settings → API Token
+2. Copy token (shown once)
+3. Tokens are tenant-scoped — one per Spanning org
+
+## Object model
+
+```
+Org (a Spanning customer)
+ └── User (a backed-up M365 / GWS / Salesforce user)
+      └── Backup runs (one per day per service per user)
+           └── Restorable items (mail / drive / calendar / records)
+```
+
+## Common endpoints (M365 example)
+
+| Domain | Endpoint | Notes |
+|--------|----------|-------|
+| Users | `GET /external/users` | All users in the org |
+| Single user | `GET /external/users/{userId}` | License + backup state |
+| User services | `GET /external/users/{userId}/services` | Mail, OneDrive, etc. |
+| Backup runs | `GET /external/users/{userId}/services/{service}/backups` | |
+| Restore (queue) | `POST /external/users/{userId}/services/{service}/restores` | |
+| Restore status | `GET /external/restores/{restoreId}` | |
+| Audit log | `GET /external/audit` | Date-ranged |
+| License usage | `GET /external/license` | Seats used vs purchased |
+
+Google Workspace and Salesforce surfaces mirror this with platform-appropriate substitutions.
+
+## Pagination
+
+Cursor-based:
+
+```
+GET /external/users?limit=100
+→ { items: [...], next: "<cursor>" }
+
+GET /external/users?limit=100&cursor=<cursor>
+```
+
+Default `limit` 50, max 200.
+
+## Restore operations
+
+Async, similar pattern to Datto SaaS Protection:
+
+```
+1. POST /external/users/{userId}/services/{service}/restores
+   body: { items: [...], restoreDestination: "..." }
+   → { restoreId, status: "queued" }
+2. Poll GET /external/restores/{restoreId} every 30s
+3. status: queued → running → completed | failed
+```
+
+## Rate limits
+
+**100 req/min per token**. HTTP 429 includes `Retry-After`. Long-running list operations (e.g. iterating audit logs across 90 days) should chunk by date and serialize.
+
+## Error handling
+
+| HTTP | Meaning | Action |
+|------|---------|--------|
+| 200 | OK | |
+| 400 | Bad request | Validate |
+| 401 | Bad / expired token, or admin email mismatch | Re-issue |
+| 403 | Token lacks scope | Verify role |
+| 404 | Unknown user / backup / restore | |
+| 409 | Conflicting restore in flight | Surface to user |
+| 429 | Rate limited | Back off |
+| 500-503 | Transient | Exponential backoff |
+
+## Gotchas
+
+- **Admin email + token must match**: The token is bound to the admin email. If either is wrong, the API returns 401 with a generic message — surface a clear "verify both fields" error.
+- **Platform-specific URL bases**: A token that works for M365 won't work against the GWS endpoint. Cross-platform org reporting requires separate tokens (or one platform-agnostic token at the partner level for partner-tier customers).
+- **Spanning vs Datto SaaS Protection**: Despite shared Kaseya branding, these are different products. Don't mix tokens.
+- **Salesforce API quirks**: The Salesforce surface uses Salesforce object IDs (15- or 18-character) rather than the user-friendly identifiers used by M365/GWS endpoints.
+
+## Related skills
+
+When the build-out lands, expect domain skills for: users, backups, restores, audit, license.

--- a/msp-claude-plugins/kaseya/spanning/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/kaseya/spanning/skills/api-patterns/SKILL.md
@@ -35,12 +35,15 @@ The MCP server takes a `platform` credential field (`m365` | `gws` | `salesforce
 
 ## Authentication
 
-Spanning uses admin email + API token, sent as basic-style headers:
+Spanning uses **HTTP Basic auth** per the public OpenAPI spec
+(<http://o365-docs.spanningbackup.com/swagger/json>):
 
 ```
-X-Spanning-Admin: admin@example.com
-X-Spanning-Authorization: Bearer <api_token>
+Authorization: Basic base64(<admin_email>:<api_token>)
 ```
+
+The admin email and API token are pair-bound — both must match the
+pair on file in the Spanning admin console or the API returns 401.
 
 Token issuance:
 

--- a/msp-claude-plugins/kaseya/unitrends/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/kaseya/unitrends/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "unitrends",
+  "version": "0.1.0",
+  "description": "Claude plugins for Unitrends backup - appliances, jobs, recovery, replication, alerting",
+  "author": {
+    "name": "MSP Claude Plugins Community"
+  },
+  "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
+  "repository": "https://github.com/wyre-technology/msp-claude-plugins",
+  "license": "Apache-2.0"
+}

--- a/msp-claude-plugins/kaseya/unitrends/README.md
+++ b/msp-claude-plugins/kaseya/unitrends/README.md
@@ -1,0 +1,29 @@
+# Unitrends Plugin
+
+Claude Code skills for working with Unitrends Backup appliances and Unitrends MSP — backup jobs, recovery points, replication, and alerts.
+
+## Status
+
+**Scaffolding** — skill content is in place; the matching MCP server (`unitrends-mcp`) and SDK (`node-unitrends`) are in development.
+
+## Capabilities (planned)
+
+- Appliances: list managed Unitrends appliances
+- Backup jobs: list, status, schedules, last run
+- Assets (clients): protected machines, agent state
+- Recovery points: list, mount, restore
+- Replication / hot copy targets: status, queue
+- Alerts: open and historical
+- Reports: success rates, RPO/RTO compliance
+
+## Authentication
+
+Unitrends uses session-based auth: `POST /api/login` with username + password returns a token, sent as `Authorization: Bearer <token>` on subsequent calls. Tokens expire after 60 minutes idle.
+
+## Skills
+
+- `api-patterns` — auth, pagination, error handling
+
+## License
+
+Apache-2.0

--- a/msp-claude-plugins/kaseya/unitrends/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/kaseya/unitrends/skills/api-patterns/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: "Unitrends API Patterns"
+when_to_use: "When working with the Unitrends Backup REST API — login flow, appliance & asset hierarchy, job status, recovery points"
+description: >
+  Use this skill when integrating with the Unitrends Backup REST API. Covers login token
+  exchange, appliance vs asset hierarchy, backup job status queries, recovery point
+  listing, replication state, and Unitrends-specific gotchas.
+triggers:
+  - unitrends
+  - unitrends api
+  - unitrends backup
+  - unitrends job
+  - unitrends recovery
+---
+
+# Unitrends API Patterns
+
+## Status note
+
+The MCP server (`unitrends-mcp`) and SDK (`@wyre-technology/node-unitrends`) are in development.
+
+## Overview
+
+Unitrends Backup appliances expose a REST API on each appliance. Reference: <https://github.com/unitrends/unitrends-api-doc/wiki>
+
+Base URL is per-appliance:
+
+```
+https://<appliance>/api
+```
+
+For multi-appliance MSPs, an MSP Console aggregates across appliances at:
+
+```
+https://<msp-console>/api
+```
+
+The MCP server takes the base URL as a credential field.
+
+## Authentication
+
+Session-token flow:
+
+1. `POST /api/login` with body `{ "username": "...", "password": "..." }`
+2. Response: `{ "token": "...", "expires": <epochSeconds> }`
+3. Send on every call: `Authorization: Bearer <token>`
+4. Token TTL: 60 minutes idle, sliding window
+
+Re-auth on 401; wrap in single-flight mutex to avoid concurrent re-auth races.
+
+## Hierarchy
+
+```
+Appliance (the Unitrends host)
+ └── Asset (a protected machine — VM, physical, NAS, M365 tenant)
+      └── Asset Source (specific data type — VMware VM, file system, SQL DB)
+           └── Backup Job
+                └── Recovery Point (restore point)
+```
+
+When designing queries, always think appliance-first; assets are scoped to one appliance unless on the MSP Console.
+
+## Common endpoints
+
+| Domain | Endpoint | Notes |
+|--------|----------|-------|
+| Appliances (MSP Console) | `GET /api/appliances` | |
+| Assets | `GET /api/assets` | Filter by `applianceId` |
+| Backup jobs | `GET /api/jobs/backups` | Currently running + queued |
+| Job history | `GET /api/jobs/history` | Date-ranged |
+| Recovery points | `GET /api/recovery_points` | Per asset |
+| Restore | `POST /api/restores` | Queue a restore |
+| Replication | `GET /api/replication/queue` | Hot copy targets |
+| Alerts | `GET /api/alerts` | Open alarms |
+| Reports | `GET /api/reports/successrate` | RPO compliance |
+
+## Pagination
+
+Page-based:
+
+| Param | Default | Max |
+|-------|---------|-----|
+| `limit` | 50 | 500 |
+| `offset` | 0 | — |
+
+Responses include `total` for the full result count.
+
+## Rate limits
+
+Per-appliance limits depend on hardware tier; Unitrends doesn't publish them. Defensive defaults: cap concurrency at 2 per appliance, sustained 60 req/min. HTTP 503 typically signals an appliance under load — back off for 30 seconds.
+
+## Error handling
+
+| HTTP | Meaning | Action |
+|------|---------|--------|
+| 200 | OK | |
+| 400 | Bad parameter | Validate |
+| 401 | Token expired | Re-auth, retry once |
+| 403 | User lacks role on this appliance | Surface |
+| 404 | Asset / job / recovery point unknown | |
+| 503 | Appliance overloaded or in maintenance | Back off 30s |
+
+## Gotchas
+
+- **Self-signed certs**: On-prem Unitrends appliances often ship with self-signed certs. The MCP server should accept a `verifyTls` credential field; default `true`, allow `false` for trusted internal networks.
+- **MSP Console vs appliance API drift**: The MSP Console aggregates a subset of endpoints. Asset-level operations (mount, restore) typically must target the appliance directly, not the console.
+- **Asset IDs are appliance-scoped**: An asset ID `123` on appliance A is *not* the same asset on appliance B. Always carry `applianceId` alongside.
+- **Job status semantics**: `success` ≠ "data is recoverable". A job can complete successfully with a degraded recovery point. Inspect both `status` and `verifyState` for full health.
+
+## Related skills
+
+When the build-out lands, expect domain skills for: appliances, assets, jobs, recovery-points, replication.


### PR DESCRIPTION
## Summary
- Adds plugin folders for **Kaseya VSA**, **Datto BCDR**, **Kaseya BMS**, **Datto SaaS Protection**, **Unitrends**, and **Spanning** — closing the gap in WYRE's Kaseya catalog beyond the four already-shipped products (Autotask, Datto RMM, IT Glue, RocketCyber).
- Each plugin ships a README + `skills/api-patterns/SKILL.md` covering auth, pagination, rate limits, and known gotchas — content acts as reference documentation for the matching MCP servers and SDKs (in development).
- Introduces a new \`bcdr\` category in the marketplace for backup/continuity/disaster-recovery products (Datto BCDR, Datto SaaS Protection, Unitrends, Spanning).

## Why now
Aaron is in Vegas Tue 2026-04-28 meeting the Datto RMM head and likely the Kaseya CCO for WYRE MCP Gateway conversations. Shipping these scaffolds means WYRE's plugin marketplace visibly covers the Kaseya portfolio end-to-end — even where the underlying MCP servers haven't been built yet — and gives the meetings a credible \"we're already building this\" story.

## What's deliberately NOT in this PR
Per the scaffolding skill, each new vendor needs:
1. SDK repo (\`node-{vendor}\`) published to GitHub Packages
2. MCP server repo (\`{vendor}-mcp\`) building a Docker image to GHCR
3. \`mcp-gateway\` vendor-config + docker-compose + Bicep entries
4. Container deployment on Azure Container Apps

Items 1–4 land in follow-up PRs once the SDKs are in place — wiring those up before the containers exist would just create dead-routing entries in the gateway. Each plugin's version is \`0.1.0\` and tagged \`scaffolding\` to make this status explicit in the marketplace listing.

## Plugins added

| Plugin | Category | Auth model |
|---|---|---|
| kaseya-vsa | rmm | Two-step token (legacy users) or Kaseya One JWT |
| datto-bcdr | bcdr | HMAC-SHA256 public/private key signing |
| kaseya-bms | psa | API token + tenant subdomain, or Kaseya One JWT |
| datto-saas-protection | bcdr | Bearer API key (region-scoped) |
| unitrends | bcdr | Session-token login (per-appliance) |
| spanning | bcdr | Admin email + API token (per-platform) |

## Test plan
- [ ] CI passes (json schema validation on \`marketplace.json\`, plugin.json files)
- [ ] \`marketplace.json\` parses (validated locally with \`python3 -c 'import json; json.load(open(...))'\`)
- [ ] Plugin install in Claude Code surfaces all 6 new plugins under their categories
- [ ] \`api-patterns\` SKILL.md activates on the trigger keywords listed in each skill's frontmatter
- [ ] Follow-up issues filed for: SDK repos × 6, MCP server repos × 6, gateway vendor-config wiring × 6