### PR TITLE
feat(threatlocker): add ThreatLocker plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -450,6 +450,20 @@
         "tickets",
         "msp"
       ]
+    },
+    {
+      "name": "threatlocker",
+      "source": "./msp-claude-plugins/threatlocker/threatlocker",
+      "description": "ThreatLocker - zero-trust application allowlisting, approval triage, audit log investigation, computer inventory",
+      "version": "1.0.0",
+      "category": "security",
+      "tags": [
+        "threatlocker",
+        "security",
+        "msp",
+        "zero-trust",
+        "application-control"
+      ]
     }
   ]
 }

--- a/msp-claude-plugins/threatlocker/threatlocker/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/threatlocker/threatlocker/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "threatlocker",
+  "version": "0.1.0",
+  "description": "Claude plugins for ThreatLocker - zero-trust application allowlisting, approval request triage, audit log investigation, and computer/group inventory for MSPs",
+  "author": {
+    "name": "MSP Claude Plugins Community"
+  },
+  "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
+  "repository": "https://github.com/wyre-technology/msp-claude-plugins",
+  "license": "Apache-2.0"
+}

--- a/msp-claude-plugins/threatlocker/threatlocker/.env.example
+++ b/msp-claude-plugins/threatlocker/threatlocker/.env.example
@@ -1,0 +1,8 @@
+# ThreatLocker MCP Server
+# Generate API credentials in the ThreatLocker portal under your user profile / API keys.
+THREATLOCKER_API_KEY=your-api-key
+
+# Optional. The organization (tenant) UUID to scope requests to.
+# Leave blank to operate against your primary organization.
+# For MSPs working across child orgs, set this per-session or use threatlocker_organizations_list_children to pivot.
+THREATLOCKER_ORGANIZATION_ID=

--- a/msp-claude-plugins/threatlocker/threatlocker/.mcp.json
+++ b/msp-claude-plugins/threatlocker/threatlocker/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "threatlocker": {
+      "type": "http",
+      "url": "https://mcp.wyretechnology.com/v1/threatlocker/mcp",
+      "headers": {
+        "X-Threatlocker-Api-Key": "${THREATLOCKER_API_KEY}",
+        "X-Threatlocker-Organization-Id": "${THREATLOCKER_ORGANIZATION_ID}"
+      }
+    }
+  }
+}

--- a/msp-claude-plugins/threatlocker/threatlocker/README.md
+++ b/msp-claude-plugins/threatlocker/threatlocker/README.md
@@ -1,0 +1,77 @@
+# ThreatLocker Plugin
+
+Claude Code plugin for the ThreatLocker zero-trust endpoint protection platform.
+
+## Overview
+
+This plugin provides Claude with deep knowledge of ThreatLocker, enabling MSP analysts to triage approval requests, investigate audit logs, and report on managed computer fleets without leaving the chat.
+
+## What It Does
+
+- **Approval Request Triage** - Surface pending application approval requests, group by app/computer, and recommend approve/deny with reasoning based on signer, file hash, and request justification
+- **Audit Log Investigation** - Search the ThreatLocker audit trail for blocked actions, policy bypasses, and repeated denials around a security event, and assemble timelines
+- **Computer Inventory** - Generate fleet reports across organizations - by OS, by group, by check-in recency
+- **Computer Groups** - Browse and pivot through ThreatLocker computer groups to scope policies and reports
+- **Multi-Tenant Pivot** - Enumerate child organizations and surface their pending approvals and audit volume in a single view for MSP analysts
+
+## Installation
+
+Install via the [MSP Claude Plugins marketplace](https://github.com/wyre-technology/msp-claude-plugins):
+
+```
+/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin install threatlocker
+```
+
+The plugin connects through the [WYRE MCP Gateway](https://mcp.wyretechnology.com) at `https://mcp.wyretechnology.com/v1/threatlocker/mcp`.
+
+## Configuration
+
+Set the following environment variables (or paste your credentials into the gateway UI):
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `THREATLOCKER_API_KEY` | Yes | API key generated from your ThreatLocker portal under user profile / API keys |
+| `THREATLOCKER_ORGANIZATION_ID` | No | Organization UUID to scope requests. Leave blank to use your primary organization. MSPs can pivot to child orgs via `threatlocker_organizations_list_children` |
+
+See [ThreatLocker documentation](https://docs.threatlocker.com/) for instructions on issuing an API key and locating your organization UUID.
+
+## Available Commands
+
+| Command | Description |
+|---------|-------------|
+| `/approval-triage` | Prioritize pending approval requests with approve/deny recommendations |
+| `/audit-investigation` | Build a timeline of audit events around a security incident |
+| `/computer-inventory` | Generate a managed computer report grouped by OS, group, and check-in age |
+| `/offline-agents` | Find agents that have not checked in within tiered windows (24h / 7d / 30d) |
+| `/tenant-overview` | Multi-tenant pivot - approval counts and audit volume across child orgs |
+
+## Available Tools
+
+Provided by the ThreatLocker MCP server through the WYRE MCP Gateway:
+
+### Computers
+- `threatlocker_computers_list` - List managed computers
+- `threatlocker_computers_get` - Get details for a single computer
+- `threatlocker_computers_get_checkins` - Inspect agent check-in history
+
+### Computer Groups
+- `threatlocker_computer_groups_list` - List computer groups
+- `threatlocker_computer_groups_get` - Get group details and members
+
+### Approval Requests
+- `threatlocker_approvals_list` - List approval requests (filterable by status)
+- `threatlocker_approvals_get` - Get a single approval request
+- `threatlocker_approvals_pending_count` - Quick count of pending approvals
+
+### Audit Log
+- `threatlocker_audit_search` - Search audit events by computer, user, file, or time window
+- `threatlocker_audit_file_history` - Trace the history of a file path across the audit log
+
+### Organizations
+- `threatlocker_organizations_list_children` - Enumerate child organizations (MSP)
+- `threatlocker_organizations_get` - Get organization details
+
+## License
+
+Apache-2.0

--- a/msp-claude-plugins/threatlocker/threatlocker/commands/approval-triage.md
+++ b/msp-claude-plugins/threatlocker/threatlocker/commands/approval-triage.md
@@ -1,0 +1,76 @@
+---
+name: approval-triage
+description: Triage pending ThreatLocker approval requests with approve/deny recommendations
+arguments:
+  - name: organization_id
+    description: Optional organization (tenant) UUID to scope to a single child org
+    required: false
+  - name: limit
+    description: Maximum number of approval requests to surface
+    required: false
+    default: "100"
+---
+
+# ThreatLocker Approval Triage
+
+Triage pending ThreatLocker application approval requests across the managed fleet. This is the killer daily workflow for MSP SOC analysts working ThreatLocker tenants - surface what's waiting, group it logically, and recommend approve/deny based on signer reputation and request context.
+
+## Prerequisites
+
+- ThreatLocker MCP server connected with a valid `THREATLOCKER_API_KEY`
+- Tools available: `threatlocker_approvals_pending_count`, `threatlocker_approvals_list`, `threatlocker_approvals_get`
+
+## Steps
+
+1. **Get the pending count first**
+
+   Call `threatlocker_approvals_pending_count` (optionally scoped via `organization_id`). Use this as a sanity check on volume before pulling the full list - if there are hundreds, recommend the analyst narrow scope before continuing.
+
+2. **List pending approvals**
+
+   Call `threatlocker_approvals_list` with `status=Pending`, paginating up to `limit`. Include `organization_id` if provided.
+
+3. **Group by application / computer**
+
+   Aggregate by application name + file hash. Multiple requests for the same hash from many endpoints almost always resolve as a single approve-once decision. Note the affected computer count per group.
+
+4. **Classify each group**
+
+   Split into two buckets:
+
+   - **High confidence (auto-approve candidates):** signed by well-known publisher (Microsoft, Adobe, Google, Citrix, etc.), known good hash, common business app
+   - **Needs review:** unsigned, novel/uncommon hash, unusual install path (`%TEMP%`, `%APPDATA%`), unfamiliar publisher, request justification missing or suspicious
+
+5. **Surface the key fields per request**
+
+   For each approval (or representative request per group): requester user, computer name, application name, file path, file hash, signer, and the requester's justification text.
+
+6. **Recommend a disposition**
+
+   For each group provide approve / deny / investigate with one-line reasoning. Call out anything that looks like a phishing dropper, LOLBin abuse, or remote-access tool installed outside policy.
+
+## Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| organization_id | string | No | primary org | Scope to a child organization (MSP usage) |
+| limit | integer | No | 100 | Max pending requests to fetch |
+
+## Examples
+
+### Triage all pending approvals
+
+```
+/approval-triage
+```
+
+### Triage approvals for a specific child org
+
+```
+/approval-triage --organization_id "org-abc-123"
+```
+
+## Related Commands
+
+- `/audit-investigation` - Investigate the actions around a suspicious approval request
+- `/tenant-overview` - See pending counts across all child orgs first

--- a/msp-claude-plugins/threatlocker/threatlocker/commands/audit-investigation.md
+++ b/msp-claude-plugins/threatlocker/threatlocker/commands/audit-investigation.md
@@ -1,0 +1,89 @@
+---
+name: audit-investigation
+description: Build a timeline of ThreatLocker audit events around a security incident
+arguments:
+  - name: target
+    description: Computer name, file path, or user to focus the investigation on
+    required: false
+  - name: start_time
+    description: ISO 8601 start of the time window (e.g. 2026-04-29T00:00:00Z)
+    required: false
+  - name: end_time
+    description: ISO 8601 end of the time window
+    required: false
+  - name: organization_id
+    description: Optional organization (tenant) UUID
+    required: false
+---
+
+# ThreatLocker Audit Investigation
+
+Investigate ThreatLocker audit logs around a security event. Builds a chronological timeline highlighting blocked actions, policy bypasses, and repeated denials so an analyst can quickly understand attacker / user behavior on a host.
+
+## Prerequisites
+
+- ThreatLocker MCP server connected with a valid `THREATLOCKER_API_KEY`
+- Tools available: `threatlocker_audit_search`, `threatlocker_audit_file_history`
+
+## Steps
+
+1. **Determine the search shape**
+
+   - If `target` looks like a file path (contains `\` or `/` or ends with an extension), plan to call BOTH `threatlocker_audit_search` and `threatlocker_audit_file_history` - the file history endpoint surfaces denies/allows over time for that exact path
+   - If `target` looks like a hostname, filter `threatlocker_audit_search` by computer
+   - If `target` looks like a username (contains `\` or `@`), filter by user
+   - If no target, search the full org over the time window and let volume guide the pivot
+
+2. **Run the searches**
+
+   Call `threatlocker_audit_search` with the inferred filters and the supplied time window. If a file path was given, also call `threatlocker_audit_file_history` for that path. Paginate as needed.
+
+3. **Build a chronological timeline**
+
+   Sort events by timestamp. For each event surface: timestamp, computer, user, action (Allow/Deny/Elevate), application/file, policy that matched, hash.
+
+4. **Call out high-signal patterns**
+
+   Highlight specifically:
+   - **Blocked actions** - Denies, especially for known tooling (PsExec, mimikatz, BloodHound, AnyDesk, etc.)
+   - **Policy bypasses** - Elevations, ringfence violations, or one-off allows
+   - **Repeated denials from the same source** - Five+ blocks for the same hash on one host suggests the user is fighting the policy (or malware is retrying)
+   - **Off-hours activity** - Anything outside the user's normal working hours
+
+5. **Summarize and recommend next steps**
+
+   Two-paragraph summary: what happened, and what to do (approve, tighten policy, isolate host via RMM, escalate to IR).
+
+## Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| target | string | No | none | Computer name, file path, or username |
+| start_time | string | No | last 24h | ISO 8601 start of window |
+| end_time | string | No | now | ISO 8601 end of window |
+| organization_id | string | No | primary org | Scope to a child organization |
+
+## Examples
+
+### Investigate a specific computer last 24h
+
+```
+/audit-investigation --target "WIN-DC01"
+```
+
+### Trace a suspicious file path
+
+```
+/audit-investigation --target "C:\\Users\\jsmith\\AppData\\Local\\Temp\\update.exe"
+```
+
+### Investigate a user across a time window
+
+```
+/audit-investigation --target "CONTOSO\\jsmith" --start_time "2026-04-28T00:00:00Z" --end_time "2026-04-29T00:00:00Z"
+```
+
+## Related Commands
+
+- `/approval-triage` - Pivot from a denied audit event to its approval request
+- `/offline-agents` - Check whether the host went silent during the window

--- a/msp-claude-plugins/threatlocker/threatlocker/commands/computer-inventory.md
+++ b/msp-claude-plugins/threatlocker/threatlocker/commands/computer-inventory.md
@@ -1,0 +1,73 @@
+---
+name: computer-inventory
+description: Generate a ThreatLocker computer inventory report
+arguments:
+  - name: organization_id
+    description: Optional organization (tenant) UUID
+    required: false
+  - name: group
+    description: Optional computer group name or ID to drill into
+    required: false
+---
+
+# ThreatLocker Computer Inventory
+
+Produce a managed computer inventory report from ThreatLocker. Useful for QBRs, license reconciliation, and detecting drift between the RMM source-of-truth and the actual ThreatLocker fleet.
+
+## Prerequisites
+
+- ThreatLocker MCP server connected with a valid `THREATLOCKER_API_KEY`
+- Tools available: `threatlocker_computers_list`, `threatlocker_computer_groups_list`
+
+## Steps
+
+1. **List all computers**
+
+   Call `threatlocker_computers_list`, paginating until exhausted. Include `organization_id` if provided.
+
+2. **List computer groups**
+
+   Call `threatlocker_computer_groups_list` so you can label every computer with its group(s).
+
+3. **Build summary metrics**
+
+   - Total managed computer count
+   - Breakdown by OS (Windows / macOS / Linux, with version where available)
+   - Breakdown by computer group
+   - Count of agents that have NOT checked in within the last 7 days (use the most recent check-in timestamp on the computer record)
+
+4. **Optional group drill-in**
+
+   If `group` was supplied, filter to members of that group and produce a per-host detail table: hostname, OS, last check-in, agent version, group(s).
+
+5. **Call out anomalies**
+
+   - Hosts with no group assignment
+   - Wildly out-of-date agent versions
+   - Servers (where identifiable by hostname or OS) that haven't checked in recently
+
+## Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| organization_id | string | No | primary org | Scope to a child organization |
+| group | string | No | all groups | Drill into a single computer group |
+
+## Examples
+
+### Inventory the whole org
+
+```
+/computer-inventory
+```
+
+### Drill into a single group
+
+```
+/computer-inventory --group "Finance Servers"
+```
+
+## Related Commands
+
+- `/offline-agents` - Same data, focused on stale check-ins
+- `/tenant-overview` - Multi-tenant view across all child orgs

--- a/msp-claude-plugins/threatlocker/threatlocker/commands/offline-agents.md
+++ b/msp-claude-plugins/threatlocker/threatlocker/commands/offline-agents.md
@@ -1,0 +1,75 @@
+---
+name: offline-agents
+description: Find ThreatLocker agents that have not checked in recently
+arguments:
+  - name: organization_id
+    description: Optional organization (tenant) UUID
+    required: false
+  - name: limit
+    description: Maximum number of computers to inspect
+    required: false
+    default: "500"
+---
+
+# ThreatLocker Offline Agents
+
+Find ThreatLocker agents that have stopped checking in. Bucketed by severity so an MSP analyst can route remediation: a 26-hour outage probably needs a reboot, a 35-day outage likely needs reinstall or offboarding.
+
+## Prerequisites
+
+- ThreatLocker MCP server connected with a valid `THREATLOCKER_API_KEY`
+- Tools available: `threatlocker_computers_list`, `threatlocker_computers_get_checkins`
+
+## Steps
+
+1. **List all computers**
+
+   Call `threatlocker_computers_list` (paginating up to `limit`), scoped by `organization_id` if provided.
+
+2. **Inspect check-in history per host**
+
+   For each computer, call `threatlocker_computers_get_checkins` to retrieve the latest check-in timestamp. Skip the call if the list response already exposes a `last_checkin` field accurately - prefer the explicit endpoint when in doubt.
+
+3. **Bucket the results**
+
+   Compute time since last check-in and bucket:
+
+   - **Warn (>24h, ≤7d)** - probably temporarily off / sleeping / VPN; nudge user
+   - **Stale (>7d, ≤30d)** - investigate; likely needs RMM remote-in to restart agent service
+   - **Dead (>30d)** - reinstall agent, decommission asset in RMM, or remove from ThreatLocker
+
+4. **Render the report**
+
+   Three tables (one per bucket) with: hostname, OS, group, last check-in, days offline. Sort each table descending by days offline.
+
+5. **Provide remediation suggestions per tier**
+
+   - Warn: leave alone unless pattern persists
+   - Stale: open a ticket to remote-in and check the `ThreatLockerService` Windows service or `threatlocker` macOS daemon
+   - Dead: reinstall or remove
+
+## Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| organization_id | string | No | primary org | Scope to a child organization |
+| limit | integer | No | 500 | Max computers to inspect |
+
+## Examples
+
+### Find offline agents across the org
+
+```
+/offline-agents
+```
+
+### Scoped to a child org
+
+```
+/offline-agents --organization_id "org-abc-123"
+```
+
+## Related Commands
+
+- `/computer-inventory` - Full fleet report
+- `/audit-investigation` - Was the host doing anything suspicious right before it went silent?

--- a/msp-claude-plugins/threatlocker/threatlocker/commands/tenant-overview.md
+++ b/msp-claude-plugins/threatlocker/threatlocker/commands/tenant-overview.md
@@ -1,0 +1,62 @@
+---
+name: tenant-overview
+description: Multi-tenant ThreatLocker overview across child organizations
+arguments:
+  - name: limit
+    description: Maximum number of child orgs to enumerate
+    required: false
+    default: "200"
+---
+
+# ThreatLocker Tenant Overview
+
+Multi-tenant pivot for MSP analysts working many ThreatLocker customers. Enumerates child organizations and shows pending approval volume + recent audit activity for each, so the analyst can prioritize which tenants to look at first.
+
+## Prerequisites
+
+- ThreatLocker MCP server connected with a valid `THREATLOCKER_API_KEY` issued at the parent / MSP level
+- Tools available: `threatlocker_organizations_list_children`, `threatlocker_approvals_pending_count`, `threatlocker_audit_search`
+
+## Steps
+
+1. **Enumerate child organizations**
+
+   Call `threatlocker_organizations_list_children`, paginating up to `limit`.
+
+2. **Pull pending approval counts per child**
+
+   For each child org, call `threatlocker_approvals_pending_count` scoped to that organization. Cache the result alongside the org name.
+
+3. **Pull recent audit volume per child (last 24h)**
+
+   For each child org, call `threatlocker_audit_search` for the last 24h with a small page size and read total / count. If volume is large enough to be expensive, sample the first page and note "≥N" instead of an exact figure.
+
+4. **Render the overview table**
+
+   Columns: organization name, organization ID, pending approvals, audit events (24h), notes. Sort descending by pending approvals, then by audit volume.
+
+5. **Surface the analyst recommendation**
+
+   - Tenants with >10 pending approvals: run `/approval-triage --organization_id <id>` next
+   - Tenants with abnormally high 24h audit volume vs. their baseline: run `/audit-investigation --organization_id <id>`
+   - Tenants with zero approvals AND zero events: probably fine, but worth confirming agent health via `/offline-agents --organization_id <id>`
+
+## Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| limit | integer | No | 200 | Max child orgs to enumerate |
+
+## Examples
+
+### Run the morning multi-tenant sweep
+
+```
+/tenant-overview
+```
+
+## Related Commands
+
+- `/approval-triage` - Drill into a tenant's pending approvals
+- `/audit-investigation` - Drill into a tenant's audit log
+- `/offline-agents` - Drill into a tenant's agent health


### PR DESCRIPTION
## Summary

Adds a new security-category plugin for **ThreatLocker** zero-trust application allowlisting. The plugin routes through the WYRE MCP Gateway at `mcp.wyretechnology.com/v1/threatlocker/mcp` and exposes ThreatLocker tooling for MSP analyst workflows: approval triage, audit investigation, fleet inventory, and multi-tenant pivots.

## Commands

- `/approval-triage` - prioritize pending approval requests with approve/deny recommendations
- `/audit-investigation` - timeline a security event from the audit log
- `/computer-inventory` - report on managed computers grouped by OS / group / check-in age
- `/offline-agents` - find stale check-ins bucketed by age (24h / 7d / 30d)
- `/tenant-overview` - multi-tenant analyst pivot across child orgs

## Dependencies

- Depends on the gateway PR for vendor registration (`wyre-technology/wyre-mcp-gateway`)
- Underlying MCP server: `wyre-technology/threatlocker-mcp`
- ThreatLocker SDK: `wyre-technology/node-threatlocker`

## Test plan

- [ ] `jq empty` validates `plugin.json`, `.mcp.json`, and `marketplace.json`
- [ ] After gateway PR merges, `/plugin install threatlocker` succeeds via the marketplace
- [ ] `THREATLOCKER_API_KEY` flows through to the MCP server header
- [ ] `THREATLOCKER_ORGANIZATION_ID` is honored when set, falls back to primary org when blank
- [ ] Each slash command invokes its expected `threatlocker_*` tools