### PR TITLE
feat(threatlocker): add 6 skills + 3 agents

### DIFF
--- a/msp-claude-plugins/threatlocker/threatlocker/agents/approval-triage-analyst.md
+++ b/msp-claude-plugins/threatlocker/threatlocker/agents/approval-triage-analyst.md
@@ -1,0 +1,44 @@
+---
+name: approval-triage-analyst
+description: Use this agent when reviewing the ThreatLocker pending approval queue, classifying application requests as high-confidence vs needs-review, recommending approve/deny decisions with documented reasoning, and escalating suspicious patterns. Trigger for: review approvals, pending approvals, ThreatLocker triage, approve application, deny application, ThreatLocker queue, application request review, allowlist request, permit application. Examples: "Review the ThreatLocker approval queue and tell me what's safe to approve", "How many pending approvals do we have across all clients?", "Triage today's ThreatLocker requests and flag anything suspicious", "What's blocking on hash 8a3f...? — should we approve it?"
+tools: ["Bash", "Read", "Write", "Glob", "Grep"]
+model: inherit
+---
+
+You are an expert approval-triage analyst for MSP environments using the ThreatLocker application allowlisting platform. The pending approval queue is where the rubber meets the road in a ThreatLocker deployment: every entry represents a user being blocked from doing something they want to do, and every decision you make is either a defended boundary or unblocked productivity. Your job is to triage that queue with the speed of an SOC analyst and the discipline of a forensic reviewer — neither rubber-stamping nor letting the queue grow stale.
+
+You start every shift with `threatlocker_approvals_pending_count` to set expectations. A small queue gets reviewed item-by-item. A large queue gets grouped by `fileHash` first — duplicate requests from many endpoints for the same binary are usually a single decision applied broadly, and clearing them quickly takes pressure off the rest of the queue. You then call `threatlocker_approvals_list` with `status: "Pending"`, oldest-first, and walk forward.
+
+For each unique hash, you classify. **High-confidence approve** looks like: `signerVerified: true`, a known publisher (Microsoft, Adobe, JetBrains, Mozilla, Google), a vendor-installed path (`C:\Program Files\...`), the same hash already permitted elsewhere in the fleet, and a justification that names a specific business need. **Needs-review** is anything in `%TEMP%`, `%APPDATA%`, `Downloads`, or `C:\Users\Public`, anything unsigned that should be signed, anything with a generic or empty justification, and anything where the file name mimics a system binary from an unusual path. Before approving anything that crosses an org boundary or could affect many endpoints, you call `threatlocker_approvals_get_permit_application` to confirm the resulting permit's scope — surprising blast radius is the most common quiet mistake in approval work.
+
+You escalate hard, immediately, when you see indicators of LOLBin abuse (`certutil`, `mshta`, `bitsadmin` from a user-writable path), RAT/remote-tool installers requested by end users rather than IT (`AnyDesk`, `ScreenConnect`, `ConnectWise Control`), or phishing dropper signatures (Office macro children, ISO-mounted shortcuts, HTA files). These don't get a "needs-review" tag — they get surfaced to a senior analyst and, where the signal is strong enough, denied with a security-specific reason while you investigate.
+
+For ambiguous binaries, you don't guess in isolation — you pivot to the audit log via the `audit-log` skill and look at what the binary actually did on the endpoint where it was blocked. A binary that tried to reach out to a strange domain or spawn `powershell` with encoded arguments is a different decision than one that simply tried to start its own UI.
+
+Every decision — approve or deny — gets a one-line documented reason. The audit trail is your defense if a policy change is ever questioned, and a pattern of clear reasons makes the next analyst's job easier.
+
+## Capabilities
+
+- Pull pending approval count and full queue, grouped by hash, application, and organization
+- Classify requests as high-confidence approve, needs-review, or escalate based on signer/path/context
+- Confirm resulting permit scope via the permit-application detail endpoint before approving
+- Approve at hash + signer level rather than path level for durability
+- Deny with specific, actionable reasons that the requesting user can act on
+- Surface escalation triggers (LOLBins, RAT installers, phishing droppers) to senior analysts
+- Re-validate the queue after bulk approvals to confirm duplicate requests cleared
+- Cross-reference suspicious requests with the audit log for behavior context
+- Produce shift-summary reports of decisions made, with reasoning, for handoff and audit
+
+## Approach
+
+Always check pending count first, then list with `status: "Pending"`, `orderBy: "dateRequested"`, `isAscending: true`. Group by `fileHash` before deciding anything — one decision per hash is more efficient and more consistent than per-row. For the high-confidence bucket, decide and document. For needs-review, fetch full detail with `threatlocker_approvals_get` and pivot to audit history if behavior context would change the call. For the escalate bucket, do not approve unilaterally — flag and route. Re-pull the queue after a session of approvals to confirm duplicates cleared and no new high-priority requests came in during your work.
+
+When the queue is large enough that an item-by-item review is not feasible in your window, prioritize: requests over 7 days old (user is blocked and waiting), requests from named senior staff (their pain disproportionately affects the business), requests for the same hash already approved elsewhere in the fleet (cheap, high-confidence wins).
+
+## Output Format
+
+For queue summaries: pending total, grouped table by hash with columns for application name, signer, signer verified, path, requester count (how many requests for this hash), and recommended action. Below the table: a short list of items that need senior escalation, each with the specific indicator that triggered escalation.
+
+For individual decisions: hash, app name, signer + verified status, path, requester user(s), computer(s), justification, decision (Approve / Deny / Escalate), and a one-line reason. For approves with broader scope, also include the permit's group target so the reader can confirm blast radius.
+
+For shift summaries: counts by decision (approved / denied / escalated / deferred), notable patterns (e.g. "5 separate hashes from `%TEMP%` requested by domain user `j.smith` — recommend a follow-up with the user"), and a final pending count for handoff.

--- a/msp-claude-plugins/threatlocker/threatlocker/agents/fleet-health-auditor.md
+++ b/msp-claude-plugins/threatlocker/threatlocker/agents/fleet-health-auditor.md
@@ -1,0 +1,50 @@
+---
+name: fleet-health-auditor
+description: Use this agent when producing ThreatLocker fleet inventory and hygiene reports — computer inventory by OS or group, offline-agent identification with check-in age tiering, computer-group hygiene analysis (orphans, oversized groups, OS-mismatched assignments), and multi-tenant pivots across child organizations. Trigger for: fleet report, offline agents, computer inventory, ThreatLocker hygiene, ThreatLocker coverage, agent count by org, stale endpoints, group audit, ThreatLocker fleet health. Examples: "Generate a ThreatLocker fleet health report", "Which agents haven't checked in for over 7 days?", "Show me the computer inventory broken down by OS and organization", "Audit our computer groups for orphans and oversized groups"
+tools: ["Bash", "Read", "Write", "Glob", "Grep"]
+model: inherit
+---
+
+You are an expert fleet health auditor for MSP environments using the ThreatLocker platform. Where the threat-investigator looks at single events and the approval-triage-analyst looks at the queue, you look at the whole fleet — every endpoint, every group, every tenant — and answer the operations questions: who's protected, who's not checking in, where are the gaps, and which groups have drifted from their original intent. ThreatLocker only protects what's reporting; an agent that hasn't checked in for two weeks is functionally an unprotected endpoint, and your job is to surface those gaps before they become incidents.
+
+Your default starting point is `threatlocker_organizations_list_children` so you know the tenant landscape. For partner-wide reports you fan out using `childOrganizations: true` on `threatlocker_computers_list`; for client-specific reports you scope per-org via the `organizationId` header. You always include both `organizationId` and `organizationName` in your output — a number without a tenant attached is useless to an MSP analyst with 30 clients.
+
+For inventory and offline-agent analysis, you order by `lastCheckin` ascending so the oldest check-ins surface first, then bucket into recency tiers: **Fresh** (< 24h), **Stale** (24h–7d), **Cold** (7d–30d), **Dead** (> 30d). Stale endpoints get an investigation suggestion (reboot the agent, check network connectivity, verify the endpoint is still in service). Cold endpoints get a ticket (operations should know whether the device is decommissioned or genuinely offline). Dead endpoints get a removal recommendation — they are inflating your fleet count and possibly your billing without providing any protection.
+
+For flapping agents — endpoints that come and go — you call `threatlocker_computers_get_checkins` against the suspicious computer to see whether check-ins are intermittent (network problem) or genuinely stopped at a point (agent died). The two diagnoses lead to different remediations.
+
+For computer-group hygiene, you pull `threatlocker_computer_groups_list` and look for three patterns: **orphan groups** (zero computers — likely deprecated and safe to remove), **oversized groups** (where a single policy change has wide blast radius — these need extra review when policies change), and **OS-mismatched assignments** (computers whose OS doesn't match their group's `osType` enum, usually misclassified at provisioning time). Each pattern produces a different recommendation.
+
+For multi-tenant pivots, you produce per-org rollups. Per-tenant agent counts compared against the MSP's RMM device inventory expose the most operationally important gap: endpoints that the RMM can see but ThreatLocker cannot. Those endpoints are outside the MDR-equivalent protection boundary and represent the highest-priority follow-up. You report the delta and surface the missing hostnames if the RMM data is available.
+
+## Capabilities
+
+- Fleet-wide computer inventory with breakdowns by OS, by group, and by organization
+- Offline-agent identification with 24h / 7d / 30d / >30d tiering and per-tier remediation suggestions
+- Flapping-agent detection via check-in history rather than just `lastCheckin`
+- Computer-group hygiene: orphan groups, oversized groups, OS-mismatched assignments
+- Multi-tenant fan-out using `childOrganizations: true` or per-org `organizationId` header
+- Per-tenant agent-count audit with RMM-delta gap analysis when reference data is available
+- Agent-version currency report — flagging endpoints running stale agent versions
+- Policy-mode distribution per group (Learning / Secured / Lockdown) for posture review
+- Quarterly fleet trend reports — agent count, group count, offline rate over time
+
+## Approach
+
+Always start with `threatlocker_organizations_list_children` and cache the result for the session. Then decide whether the report is partner-wide (use `childOrganizations: true`) or client-specific (scope via `organizationId`). For inventory, paginate fully — never trust the first page to represent the fleet. For offline analysis, sort by `lastCheckin` ascending and stop reading once you cross into the Fresh bucket.
+
+For group hygiene, pull the full group list (not the dropdown) so you have computer counts and parent-org context. Cross-reference against the computer list to spot OS mismatches — a group with `osType: 1` (Windows) housing a Mac is misclassified at provisioning. Spot-check the OS strings carefully; edge cases (Windows IoT, ARM64 Macs, Linux distros) sometimes land in unexpected buckets.
+
+For RMM-delta gap analysis, you need a reference list of expected endpoints per organization. Where one is provided, the diff is the report. Where one isn't, recommend that the operations team produce one; the gap analysis is the most operationally valuable output you produce, and it depends on having that reference.
+
+Always produce per-org rollups even when the question is fleet-wide. An MSP operator needs to know which client has the offline-agent problem, not just that the fleet has one.
+
+## Output Format
+
+For fleet inventory: a per-org table with columns for organization name, total agents, fresh / stale / cold / dead counts, count by primary OS (Windows / macOS / Linux), and a short status indicator (HEALTHY / WARNINGS / ATTENTION). Below the table: a list of the top three orgs by attention level and what specifically is flagged.
+
+For offline-agent reports: a per-tier breakdown — for each of Stale / Cold / Dead, list affected hosts with hostname, OS, organization, last check-in age, and a recommended action. Top of the report shows total counts per tier and the trend if comparing to a prior period.
+
+For group hygiene reports: three sections — Orphan Groups (table of empty groups with org and OS type), Oversized Groups (table of groups exceeding a threshold like 100 computers, with org), and OS-Mismatched Assignments (table of computer + assigned group + OS-type mismatch detail). Each section ends with specific recommended actions per finding.
+
+For multi-tenant rollups: per-tenant numbers always shown side-by-side, never collapsed into a fleet-wide single number unless the question explicitly asks for it. Include the percentage of agents in each recency bucket per tenant — relative health is more meaningful than absolute counts when comparing clients.

--- a/msp-claude-plugins/threatlocker/threatlocker/agents/threat-investigator.md
+++ b/msp-claude-plugins/threatlocker/threatlocker/agents/threat-investigator.md
@@ -1,0 +1,50 @@
+---
+name: threat-investigator
+description: Use this agent when investigating a ThreatLocker security event — reconstructing a timeline around a host/user/file, tracing a file's history across the fleet, identifying repeated denials, and surfacing policy bypasses or audit-only matches that warrant new policy rules. Trigger for: investigate, what happened on, audit logs around, ThreatLocker timeline, ThreatLocker forensics, ThreatLocker incident, suspicious activity, repeated denials, file history, policy bypass, IOC search ThreatLocker. Examples: "Investigate what happened on WS-042 around 2pm yesterday", "Trace the history of this file hash across the fleet", "We're seeing repeated blocks from user j.doe — what's going on?", "Show me everywhere this binary appeared in the action log"
+tools: ["Bash", "Read", "Write", "Glob", "Grep"]
+model: inherit
+---
+
+You are an expert security incident investigator for MSP environments using the ThreatLocker platform. The ThreatLocker Action Log is your primary forensic surface — every execution attempt, every block, every permit, every audit-only match is recorded with the user, host, file path, hash, signer, and parent process context. Your job is to take a thin signal — a hostname, a time window, a suspicious file, a noisy user — and reconstruct what actually happened, who or what is responsible, and whether the existing policy posture is sufficient.
+
+You begin every investigation by tightening the question. "Something weird on host X" gets paired with a time window before you make the first API call. You search the Action Log via `threatlocker_audit_search` with the tightest plausible window — usually `±30m` around an alert time, or the last hour if the question is vague — and `orderBy: "actionTime"`, `isAscending: true` so you read forward through the timeline. You scan for the inflection: the first unusual binary, the first child process of a known LOLBin parent, the first network-active process, the first deviation from baseline.
+
+For any anomaly you spot, you call `threatlocker_audit_get` for the full record — the truncated row in the search response is rarely enough. You note the `fileHash`, the `processChain`, and the `policyName` that fired (or didn't, in the case of an audit-only match). Then you pivot. The single most useful pivot in ThreatLocker investigations is `threatlocker_audit_file_history` against the suspicious hash — it tells you everywhere in the fleet that binary appeared, when, and what happened each time. Patient zero often reveals itself just from the earliest `actionTime` across affected endpoints.
+
+You think hard about the `kindOfAction` distribution. **Block** events are your control working — count them, but don't over-celebrate. **Permit** events for an unfamiliar binary against a sensitive endpoint are where you slow down: that thing ran. **Audit** events on a Secured-Mode endpoint are particularly interesting — a watch rule fired without enforcement, which is policy debt that often warrants tightening. You cross-reference the affected endpoint's policy mode via `threatlocker_computers_get` to know whether you are looking at a Learning-Mode environment (where audit hits are baseline noise) or a Secured-Mode environment (where they are signal).
+
+When the investigation surfaces a pattern — a user generating 50+ Block events in an hour, the same hash repeatedly trying to execute from `%TEMP%` across multiple hosts, a suspicious binary that was Permit'd somewhere it shouldn't have been — you coordinate with the approval-triage-analyst. Sometimes the right outcome is a new deny rule, sometimes an approval that should be rolled back, sometimes a conversation with the user. You produce a clear recommendation with the evidence trail attached.
+
+You always capture `actionId` references in your write-ups so a reviewer can re-pull the exact source rows you used. Investigations that can't be reproduced are folklore, not forensics.
+
+## Capabilities
+
+- Reconstruct timelines from the Action Log around a host, user, file, or time window
+- Trace a file path or hash across the fleet using file-history queries to identify spread and patient zero
+- Distinguish baseline audit noise (Learning Mode) from real audit-only signal (Secured Mode)
+- Identify repeated denials clustering on a single user or computer and classify cause
+- Surface Permit events that look retrospectively suspicious (post-hoc IOC review)
+- Cross-reference affected endpoints with their current policy mode and group assignment
+- Build process-tree narratives from `processChain` data when parent context is available
+- Recommend policy actions: new deny rules, rollback of approvals, tighter group assignments
+- Produce reproducible incident write-ups with `actionId` references back to source data
+
+## Approach
+
+Tighten the question first. Always ask: what host, what user, what file, what window? If any of those is missing, decide whether to constrain by the others or to scope a broader hunt with a clear statement of scope.
+
+Search forward through the timeline rather than starting from the alleged event and working backward — this surfaces precursors you'd miss otherwise. For any candidate IOC, pivot to file history immediately and bucket results by `computerName`. For any suspicious user pattern, group Block events by `userName` over a 24h window and look at the distribution.
+
+Read parent process chains carefully. A `winword.exe -> cmd.exe -> powershell.exe -encodedcommand` chain is a phishing pattern; flag it and pivot to the original attachment if Outlook context is in the same Action Log window. A `cmd.exe -> certutil.exe -urlcache` chain is a download-and-execute pattern. These deserve immediate escalation.
+
+When a finding is strong enough to warrant a policy change, draft the proposed change — group, action, scope — and hand off to the approval-triage-analyst rather than implementing unilaterally. Investigations and policy changes are different decisions with different review processes.
+
+## Output Format
+
+For timeline investigations: a chronologically ordered table with columns for `actionTime` (UTC), `kindOfAction`, `fileName`, `filePath`, `userName`, parent process, `policyName`, and `actionId`. Below the table, a narrative paragraph identifying the inflection event, the root cause hypothesis, and what the evidence supports vs. what is still uncertain.
+
+For file-history pivots: a per-host table — host, first seen, last seen, count of Block / Permit / Audit, and current policy mode for that host. Below: the conclusion (limited spread / wide spread / patient-zero candidate) and recommended next step.
+
+For repeated-denial reports: top users and top computers by Block count in the window, with a paragraph on each top entry classifying the likely cause (user fighting tooling, compromised account, malware retry loop) and the recommended response (open approval request, investigate further, isolate endpoint).
+
+For incident write-ups: a structured summary — Background, Timeline, Evidence (with `actionId` references), Conclusion, Recommended Actions. Recommended Actions should be specific and assigned: "Open new deny rule for hash 8a3f... in group `Workstations - Standard` (assign to approval-triage-analyst)" rather than "consider tightening policy".

--- a/msp-claude-plugins/threatlocker/threatlocker/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/threatlocker/threatlocker/skills/api-patterns/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: "ThreatLocker API Patterns"
+description: >
+  Use this skill when working with the ThreatLocker MCP tools —
+  raw-key authentication (NO Bearer prefix), multi-tenant routing via
+  organizationId header, POST-heavy "GetByParameters" endpoints,
+  pagination shape, and child-organization fan-out patterns.
+when_to_use: "When working with ThreatLocker auth headers, multi-tenant requests, POST-based list endpoints, pagination, or fanning queries across child organizations"
+triggers:
+  - threatlocker api
+  - threatlocker authentication
+  - threatlocker pagination
+  - threatlocker organizationid
+  - threatlocker mcp
+  - threatlocker tools
+  - threatlocker child organizations
+  - threatlocker getbyparameters
+  - threatlocker portalapi
+---
+
+# ThreatLocker MCP Tools & API Patterns
+
+## Overview
+
+The ThreatLocker MCP server wraps the ThreatLocker Portal API
+(`https://portalapi.g.threatlocker.com/portalapi`) and exposes tools
+across computers, computer groups, approval requests, audit log
+("Action Log" in the UI), and organizations. The API has two quirks
+that surprise people: the auth header does NOT use `Bearer`, and most
+"list" endpoints are POSTs against `/Entity/EntityGetByParameters` with
+a structured body — not GETs with query strings.
+
+## Connection & Authentication
+
+### Raw API Key Header
+
+ThreatLocker authenticates with a raw API key — no `Bearer` prefix:
+
+| Header | Value |
+|--------|-------|
+| `Authorization` | `<apiKey>` (raw, no prefix) |
+| `ManagedClientId` | (optional) for legacy partner setups |
+| `organizationId` | (optional) tenant to scope this call to |
+
+> **Common mistake:** Sending `Authorization: Bearer <key>` returns
+> 401. Send the key bare.
+
+### Environment Variables
+
+```bash
+export THREATLOCKER_API_KEY="your-raw-api-key"
+export THREATLOCKER_BASE_URL="https://portalapi.g.threatlocker.com/portalapi"
+```
+
+## Multi-Tenant Routing
+
+ThreatLocker is built for MSPs and uses organizations as the tenant
+boundary. Three patterns:
+
+1. **Default org** — Omit the `organizationId` header. The API uses
+   the API key's primary organization.
+2. **Specific child org** — Set `organizationId` to a child org ID to
+   scope a single call to that tenant.
+3. **Fleet-wide fan-out** — Set the body flag `childOrganizations: true`
+   on `*GetByParameters` endpoints to roll up data across all child
+   organizations the API key can see.
+
+For tenant pivots, see the `organizations` skill.
+
+## Available MCP Tools
+
+### Computers
+
+| Tool | Description |
+|------|-------------|
+| `threatlocker_computers_list` | List computers with pagination/filters |
+| `threatlocker_computers_get` | Get full details for one computer |
+| `threatlocker_computers_get_checkins` | Recent check-in history |
+
+### Computer Groups
+
+| Tool | Description |
+|------|-------------|
+| `threatlocker_computer_groups_list` | Full group list with metadata |
+| `threatlocker_computer_groups_dropdown` | Slim list for selection UIs |
+
+### Approval Requests
+
+| Tool | Description |
+|------|-------------|
+| `threatlocker_approvals_list` | List approval requests |
+| `threatlocker_approvals_get` | Single approval with full context |
+| `threatlocker_approvals_pending_count` | Quick pending-queue size |
+| `threatlocker_approvals_get_permit_application` | Application that would be permitted |
+
+### Audit Log (Action Log)
+
+| Tool | Description |
+|------|-------------|
+| `threatlocker_audit_search` | Search Action Log by time/host/file |
+| `threatlocker_audit_get` | Full record for one action |
+| `threatlocker_audit_file_history` | All actions for a given file path/hash |
+
+### Organizations
+
+| Tool | Description |
+|------|-------------|
+| `threatlocker_organizations_list_children` | All child orgs visible to the key |
+| `threatlocker_organizations_get_auth_key` | Auth key for a specific org |
+| `threatlocker_organizations_for_move_computers` | Orgs eligible as move targets |
+
+## POST-Based "GetByParameters" Pattern
+
+Most list endpoints are `POST /Entity/EntityGetByParameters` with a
+JSON body. Request shape:
+
+```json
+{
+  "pageNumber": 1,
+  "pageSize": 50,
+  "isAscending": false,
+  "orderBy": "lastCheckin",
+  "searchText": "",
+  "childOrganizations": false
+}
+```
+
+Response shape:
+
+```json
+{
+  "totalItems": 1284,
+  "items": [ /* array of entities */ ]
+}
+```
+
+### Pagination
+
+ThreatLocker uses page numbers, not cursors:
+
+1. Call with `pageNumber: 1`, `pageSize: 50` (or 100/200).
+2. Compute `totalPages = ceil(totalItems / pageSize)`.
+3. Continue until you have collected `totalItems` rows or reached
+   the last page.
+
+Avoid huge `pageSize` values — large pages can time out. 50–200 is the
+sweet spot.
+
+### Sort and Search
+
+- `orderBy` is an entity-specific column name (e.g. `lastCheckin`,
+  `computerName`).
+- `isAscending` toggles direction.
+- `searchText` is a substring match across the entity's searchable
+  columns (computer name, hostname, OS, etc.).
+
+## Error Handling
+
+| Code | Meaning | Fix |
+|------|---------|-----|
+| 401 | Bad API key OR `Bearer` prefix included | Send raw key |
+| 403 | Key valid, but no access to requested org | Check `organizationId` |
+| 404 | Wrong endpoint or unknown entity ID | Recheck path |
+| 429 | Rate limited | Backoff and retry |
+| 500 | Portal API hiccup | Retry, then escalate |
+
+## Best Practices
+
+- Default to `pageSize: 100` and paginate; always check `totalItems`
+  before assuming you have the full set.
+- For multi-tenant reports, fan out with `childOrganizations: true`
+  rather than looping per-org when the entity supports it.
+- Cache the result of `threatlocker_organizations_list_children` —
+  child org lists rarely change within a session.
+- Always pass `organizationId` explicitly when generating client-facing
+  reports so the source tenant is unambiguous.
+
+## Related Skills
+
+- [computers](../computers/SKILL.md) — Endpoint inventory
+- [computer-groups](../computer-groups/SKILL.md) — Policy scoping
+- [approval-requests](../approval-requests/SKILL.md) — Application approvals
+- [audit-log](../audit-log/SKILL.md) — Action Log investigation
+- [organizations](../organizations/SKILL.md) — Multi-tenant pivots

--- a/msp-claude-plugins/threatlocker/threatlocker/skills/approval-requests/SKILL.md
+++ b/msp-claude-plugins/threatlocker/threatlocker/skills/approval-requests/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: "ThreatLocker Approval Requests"
+description: >
+  Use this skill when triaging ThreatLocker application approval
+  requests — the heart of day-to-day ThreatLocker operations. Covers
+  pulling the pending queue, grouping requests by application/hash,
+  applying signed-publisher heuristics, and recommending approve/deny
+  decisions with audit-friendly reasoning.
+when_to_use: "When triaging pending application approvals, evaluating signer/path heuristics, classifying high-confidence vs needs-review requests, or producing an approval queue summary"
+triggers:
+  - threatlocker approval
+  - threatlocker pending approval
+  - threatlocker approve application
+  - threatlocker deny application
+  - threatlocker request triage
+  - threatlocker application request
+  - approve threatlocker
+  - permit application threatlocker
+  - threatlocker queue
+---
+
+# ThreatLocker Approval Requests
+
+Approval requests are how ThreatLocker users ask for an application
+that's currently being blocked to be permitted. Each request carries
+rich context — file path, hash, signer, the user who asked, the
+computer it ran on, and a free-text justification. Triaging this queue
+well is the difference between a productive ThreatLocker deployment
+and a frustrated client.
+
+## API Tools
+
+### List Approval Requests
+
+```
+threatlocker_approvals_list
+```
+
+POST-based `GetByParameters` — see `api-patterns`. Useful filters via
+`searchText`: file name, application name, requester user, computer
+name. Each request typically includes:
+
+- `requestId`, `applicationName`, `fileName`, `filePath`, `fileHash`
+- `signer` (Authenticode publisher), `signerVerified` boolean
+- `requesterUser`, `computerName`, `computerId`, `organizationName`
+- `justification` (free-text from the user), `dateRequested`
+- `status` — `Pending`, `Approved`, or `Denied`
+
+### Get Approval Request
+
+```
+threatlocker_approvals_get
+```
+
+Full detail for one request — includes additional context like the
+specific policy that blocked it and any prior history of the same hash.
+
+### Pending Count
+
+```
+threatlocker_approvals_pending_count
+```
+
+Cheap call — returns the size of the pending queue. Use this as the
+opening move every shift to know whether you have 3 requests or 300.
+
+### Get Permit Application Detail
+
+```
+threatlocker_approvals_get_permit_application
+```
+
+Returns the application that *would be permitted* if the request is
+approved — including which group(s) the approval would scope to and
+what other endpoints would be affected. Always check this before
+approving anything that looks like it could have a wider blast radius
+than expected.
+
+## Common Workflows
+
+### Daily Queue Triage
+
+1. `threatlocker_approvals_pending_count` — sets expectations.
+2. `threatlocker_approvals_list` with `status: "Pending"`,
+   `orderBy: "dateRequested"`, `isAscending: true` (oldest first).
+3. Group results by `fileHash` — many requests are duplicates of the
+   same binary asked for from multiple endpoints. Decide once, apply
+   broadly.
+4. Within each hash, classify (see heuristics below).
+5. For approves, call `threatlocker_approvals_get_permit_application`
+   to confirm scope. Then approve.
+6. For denies, capture a reason that the requesting user can act on.
+
+### Signed-Publisher Heuristics
+
+Signals that increase confidence to **approve**:
+
+- `signerVerified: true` AND `signer` is a known vendor (Microsoft,
+  Adobe, JetBrains, Mozilla, Google, etc.).
+- `filePath` is in a vendor-installed location (`C:\Program Files\...`).
+- The same hash has been previously approved for other endpoints.
+- The requester user matches the computer's primary user.
+- Justification includes a specific business reason ("Need Wireshark
+  for ticket INC-5123").
+
+Signals that warrant **needs-review** or **deny**:
+
+- Unsigned or signer-unverified binary.
+- Path is in `%TEMP%`, `%APPDATA%`, `Downloads`, or `C:\Users\Public`.
+- File name mimics a system binary (`svchost`, `lsass`, `runtime`)
+  but path is unusual.
+- Justification is empty, generic ("need this"), or copy-pasted across
+  many requests.
+- Hash has been denied previously, especially with a security reason.
+
+Hard escalation triggers — surface to a senior analyst:
+
+- Known LOLBin (`certutil`, `mshta`, `bitsadmin`) requested from a
+  user-writable path.
+- RAT/remote-tool installer (`AnyDesk`, `ConnectWise Control`,
+  `ScreenConnect`) requested by an end user rather than IT.
+- Phishing dropper indicators — Office macros, ISO-mounted shortcuts,
+  HTA files.
+
+### Bulk Approve Pattern
+
+When a single hash appears across many requests:
+
+1. Pick one representative request and review fully.
+2. Approve via the application — the resulting policy will cover all
+   endpoints in the chosen group.
+3. The other pending requests for the same hash typically resolve
+   automatically once the application is permitted at group scope.
+4. Re-pull pending after a minute and confirm the duplicates cleared.
+
+## Edge Cases
+
+- **Vendor binaries with broken signatures** — Newer versions of some
+  legitimate apps occasionally ship with signature timing issues.
+  Verify the hash with VirusTotal or the vendor before approving an
+  unsigned binary that *should* be signed.
+- **Self-signed installers** — Common in line-of-business apps.
+  Approve on hash, not signer.
+- **Stale requests** — A request older than 30 days where the user has
+  since left the org should usually be denied with a "stale request"
+  reason.
+- **Status transitions** — A request in `Approved`/`Denied` is
+  terminal; do not attempt to re-process it. Filter to `Pending` only.
+
+## Best Practices
+
+- Always document a one-line reason on every decision — the audit log
+  is your defense if a policy change ever needs review.
+- Approve at the application level (hash + signer), not file path —
+  paths drift, hashes don't.
+- Re-check the queue immediately after a bulk approve to confirm
+  duplicate requests resolved.
+- For unfamiliar binaries, check the audit log (`audit-log` skill) to
+  see what the binary actually did before deciding.
+
+## Related Skills
+
+- [api-patterns](../api-patterns/SKILL.md) — Auth and pagination
+- [audit-log](../audit-log/SKILL.md) — Behavior of binaries before
+  approval decisions
+- [computers](../computers/SKILL.md) — Endpoint context for requests
+- [computer-groups](../computer-groups/SKILL.md) — Policy scope of
+  the resulting permit

--- a/msp-claude-plugins/threatlocker/threatlocker/skills/audit-log/SKILL.md
+++ b/msp-claude-plugins/threatlocker/threatlocker/skills/audit-log/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: "ThreatLocker Audit Log"
+description: >
+  Use this skill when investigating events in the ThreatLocker Action Log
+  (the API name is "audit") — building incident timelines, tracing a file's
+  history across endpoints, identifying repeated denials, and correlating
+  policy bypasses or audit-only matches with user/computer context.
+when_to_use: "When investigating a security event timeline, tracing a file path or hash across endpoints, looking up repeated denials, or correlating policy bypasses to specific actions"
+triggers:
+  - threatlocker audit log
+  - threatlocker action log
+  - threatlocker investigate
+  - threatlocker file history
+  - threatlocker timeline
+  - threatlocker denied execution
+  - what happened on
+  - threatlocker policy bypass
+  - threatlocker forensics
+---
+
+# ThreatLocker Audit Log
+
+What the API calls the "audit" endpoints, the ThreatLocker UI calls the
+**Action Log** — the same data either way. Every execution attempt,
+every block, every permit, every audit-only match generates an entry.
+This is your forensics surface: when something happened on an endpoint,
+this is where you find out what.
+
+## API Tools
+
+### Search Action Log
+
+```
+threatlocker_audit_search
+```
+
+POST-based `GetByParameters`. Common filters via the body:
+
+- `searchText` — substring across file name, path, computer name, user
+- Date-range fields (typically `fromDate` / `toDate` in ISO 8601 UTC)
+- `pageNumber`, `pageSize`, `orderBy: "actionTime"`,
+  `isAscending: false` (newest first is the usual default)
+- `organizationId` header for tenant scoping
+
+Each row typically includes `actionId`, `actionTime`, `kindOfAction`
+(Block, Permit, Audit), `fileName`, `filePath`, `fileHash`, `signer`,
+`computerName`, `userName`, `policyName`, and `processChain` (parent
+process info).
+
+### Get Action Detail
+
+```
+threatlocker_audit_get
+```
+
+Returns a single action with full context — full process tree, command
+line, network endpoints contacted (when available), and any related
+actions clustered around the same event.
+
+### File History
+
+```
+threatlocker_audit_file_history
+```
+
+Aggregates all Action Log entries for a given file path or hash. Use
+this when you have a candidate IOC and want to know everywhere it
+appeared in the fleet, when, and what happened each time.
+
+## `kindOfAction` Categorization
+
+| Action | Meaning |
+|--------|---------|
+| **Block** | Policy denied execution — the binary did not run |
+| **Permit** | Policy allowed execution — the binary ran |
+| **Audit** | Audit-only — observed but not acted on (often Learning Mode) |
+
+Block + Audit together is the high-signal pair for hunting:
+
+- A **Block** event is your control working as designed.
+- An **Audit** event in Secured Mode means something matched a watch
+  rule but was not stopped — investigate.
+- An **Audit** event in Learning Mode is just baseline data, less
+  actionable.
+
+## Common Workflows
+
+### Timeline Around a Security Event
+
+When given "something happened on host X around time T":
+
+1. `threatlocker_audit_search` with `searchText: "<host>"`,
+   `fromDate: T - 1h`, `toDate: T + 1h`,
+   `orderBy: "actionTime"`, `isAscending: true`.
+2. Read forward through the timeline and look for the inflection —
+   the first unusual binary, the first child process from a known LOLBin
+   parent, the first network-active process.
+3. For any anomaly, call `threatlocker_audit_get` for the full detail
+   and add the parent process to your investigation list.
+4. Pivot on `fileHash` of the suspicious binary using
+   `threatlocker_audit_file_history` to see where else in the fleet it
+   appeared.
+
+### File-Path-Across-Endpoints Investigation
+
+When given an IOC (path or hash):
+
+1. `threatlocker_audit_file_history` with the IOC.
+2. Bucket results by `computerName` — which endpoints saw it?
+3. For each affected endpoint, note the earliest `actionTime` —
+   the spread pattern often points to patient zero.
+4. For every Permit action against the IOC, that endpoint may have
+   been impacted. For every Block, you have evidence the control
+   stopped it.
+
+### Repeated Denials From the Same Source
+
+A pattern worth surfacing: same user or same computer generating many
+Block events in a short window.
+
+1. Search a recent window with `kindOfAction: "Block"`.
+2. Group results client-side by `userName` and `computerName`.
+3. Anyone with > N blocks in a short window is either:
+   - A user fighting their tooling (open an approval — see
+     `approval-requests` skill).
+   - A compromised account or malware retrying execution.
+
+### Policy Bypass / Audit-Only Match Correlation
+
+1. Search with `kindOfAction: "Audit"`.
+2. Filter to Secured-Mode endpoints (cross-reference computers via
+   `threatlocker_computers_get` — `policyMode`).
+3. Each Audit hit on a Secured endpoint indicates a watch rule fired
+   without enforcement — review the rule and decide if it should
+   become a Block.
+
+## Date-Range Filter Patterns
+
+- **Last hour** — `now - 1h` to `now`. Tight, high-signal.
+- **Last 24h** — Daily triage and report scope.
+- **Last 7d** — Threat-hunting baseline.
+- **Around an alert** — `alertTime ± 30m` is usually enough; expand
+  if the parent process is unclear.
+
+Always send dates in ISO 8601 UTC. The Action Log itself stores UTC.
+
+## Edge Cases
+
+- **High-volume endpoints** — Build servers, dev workstations and
+  jump boxes can generate thousands of audit rows per day. Use tight
+  date windows or `signer` filters to keep result sets manageable.
+- **Duplicate-looking events** — A single execution can produce
+  multiple log rows (file open, hash check, network connect). Always
+  read the `actionId` to confirm uniqueness.
+- **Truncated process chains** — `processChain` is best-effort. If
+  the parent is empty or `unknown`, treat the row as a starting point
+  for further investigation, not a final answer.
+
+## Best Practices
+
+- Start with the tightest possible time window; expand only if needed.
+- Always pivot on `fileHash` rather than `filePath` for IOC work —
+  attackers rename binaries, hashes don't change.
+- Capture `actionId` references in any incident write-up so a
+  reviewer can re-pull the exact source rows.
+- Cross-reference findings with `approval-requests` — a recent
+  approval may explain an otherwise suspicious Permit.
+
+## Related Skills
+
+- [api-patterns](../api-patterns/SKILL.md) — Auth and pagination
+- [computers](../computers/SKILL.md) — Endpoint policy mode context
+- [approval-requests](../approval-requests/SKILL.md) — Decisions that
+  produce Permit actions
+- [organizations](../organizations/SKILL.md) — Multi-tenant pivot

--- a/msp-claude-plugins/threatlocker/threatlocker/skills/computer-groups/SKILL.md
+++ b/msp-claude-plugins/threatlocker/threatlocker/skills/computer-groups/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: "ThreatLocker Computer Groups"
+description: >
+  Use this skill when working with ThreatLocker computer groups —
+  the policy-scoping boundary that determines which allow/deny rules
+  apply to which endpoints. Covers listing groups, mapping computer to
+  group, and the difference between the dropdown and full list endpoints.
+when_to_use: "When scoping policies, mapping computers to groups, choosing a target group for new endpoints, or auditing global vs org-specific group usage"
+triggers:
+  - threatlocker computer group
+  - threatlocker policy scope
+  - threatlocker group dropdown
+  - threatlocker groups list
+  - threatlocker ostype
+  - assign computer group
+  - threatlocker policy targeting
+---
+
+# ThreatLocker Computer Groups
+
+Computer groups are the policy-scoping unit in ThreatLocker. Policies
+are applied at the group level, never at the individual computer level.
+A computer must belong to exactly one group, and moving a computer
+between groups changes which policy set applies to it. Groups can be
+**global** (visible across all child organizations) or **org-specific**.
+
+## API Tools
+
+### List Computer Groups (Full)
+
+```
+threatlocker_computer_groups_list
+```
+
+Full list with metadata — group name, ID, OS type, parent org,
+computer count, and policy associations. Use this for audits and
+reports.
+
+### List Computer Groups (Dropdown)
+
+```
+threatlocker_computer_groups_dropdown
+```
+
+Slim list intended for selection UIs — typically just `id`, `name`, and
+`osType`. Use this when you only need to map an ID to a name or pick a
+target group for a move.
+
+### Why two endpoints?
+
+The full list is heavier and includes counts and metadata that requires
+more lookups server-side. The dropdown returns immediately and is the
+right choice when you are about to issue another call (move, assign)
+and just need the IDs.
+
+## Key Concepts
+
+### `osType` Enum
+
+| Value | Meaning |
+|-------|---------|
+| 0 | All / Any |
+| 1 | Windows |
+| 2 | macOS |
+| 3 | Linux |
+
+A group's `osType` constrains which computers can be assigned to it —
+you cannot put a Mac into a Windows-only group.
+
+### Global vs Org-Specific Groups
+
+- **Global groups** are defined at the partner level and inherited by
+  all child organizations. Useful for fleet-wide baselines (e.g.
+  "All Windows Servers").
+- **Org-specific groups** live inside a single child org. Most
+  client-specific policy customization lives here.
+
+The full list endpoint exposes the parent organization on each row, so
+you can filter or group by it.
+
+## Common Workflows
+
+### Mapping Computer → Group
+
+The `threatlocker_computers_list` response includes
+`computerGroupId` and `computerGroupName` directly, so a separate
+call is usually unnecessary. When you have a stale ID and need the
+current name, use `threatlocker_computer_groups_dropdown` to resolve.
+
+### Auditing Group Hygiene
+
+1. List all groups with `threatlocker_computer_groups_list`.
+2. Flag groups with zero computers (likely dead or deprecated).
+3. Flag groups with extreme computer counts (oversized — policy
+   changes there will have wide blast radius).
+4. Flag groups whose `osType` does not match the OS distribution of
+   the computers actually assigned to it (misclassified group).
+
+### Choosing a Target Group for a New Endpoint
+
+1. Pull dropdown groups with `threatlocker_computer_groups_dropdown`.
+2. Filter to the matching `osType` for the new computer.
+3. Filter to the appropriate organization scope.
+4. Pick the group whose policy posture matches the endpoint's role
+   (workstation, server, kiosk, etc.).
+
+### Identifying Global vs Org-Specific
+
+1. Use the full list endpoint and inspect the parent organization on
+   each row.
+2. Groups with the partner organization as parent are global.
+3. Groups whose parent matches a child org ID are org-specific to that
+   child.
+
+## Edge Cases
+
+- **Empty groups** — Some groups exist for future use. Don't auto-flag
+  every empty group as a problem; cross-reference recent policy edits
+  before recommending deletion.
+- **OS-mismatch surprises** — A computer's reported `operatingSystem`
+  string is normalized into the `osType` enum at assignment time.
+  Edge OS strings (Windows IoT, macOS preview builds) sometimes land
+  in the wrong bucket.
+- **Dropdown vs full** — Don't try to compute counts from the dropdown
+  — it does not return computer counts. Use the full list for that.
+
+## Best Practices
+
+- Use the dropdown for any "pick a group" workflow; only call the full
+  list when you genuinely need metadata or counts.
+- When scoping a policy change, list the group's computers first and
+  estimate impact before recommending the change.
+- Keep group naming consistent across organizations — analysts triage
+  faster when "Workstations - Standard" means the same thing
+  everywhere.
+
+## Related Skills
+
+- [api-patterns](../api-patterns/SKILL.md) — Auth and pagination
+- [computers](../computers/SKILL.md) — Computers within groups
+- [organizations](../organizations/SKILL.md) — Org scope for groups

--- a/msp-claude-plugins/threatlocker/threatlocker/skills/computers/SKILL.md
+++ b/msp-claude-plugins/threatlocker/threatlocker/skills/computers/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: "ThreatLocker Computers"
+description: >
+  Use this skill when working with ThreatLocker-protected endpoints —
+  fleet inventory, identifying offline agents, drilling into a single
+  computer's check-in history, and correlating computers across
+  organizations and groups.
+when_to_use: "When listing, inspecting, or auditing ThreatLocker computers across one or many organizations, including offline-agent triage and check-in history"
+triggers:
+  - threatlocker computer
+  - threatlocker endpoint
+  - threatlocker agent inventory
+  - threatlocker offline
+  - threatlocker last seen
+  - threatlocker checkin
+  - threatlocker fleet
+  - endpoint inventory threatlocker
+---
+
+# ThreatLocker Computers
+
+Computers (endpoints) are the unit of protection in ThreatLocker.
+Every protected machine has an agent that checks in periodically and
+is bound to a computer group, which in turn carries the policies that
+govern allow/deny behavior. This skill covers fleet inventory, offline
+agent identification, and drilling into a single endpoint's history.
+
+## API Tools
+
+### List Computers
+
+```
+threatlocker_computers_list
+```
+
+POST-based `GetByParameters` endpoint — see `api-patterns` for the
+request body shape. Common parameters:
+
+- `pageNumber`, `pageSize`, `isAscending`, `orderBy`
+- `searchText` — substring match on computer name, hostname, OS, etc.
+- `childOrganizations` — set `true` to roll up across all child orgs
+- `organizationId` header — scope to a single tenant
+
+Each returned computer typically includes `computerId`, `computerName`,
+`hostname`, `operatingSystem`, `lastCheckin`, `computerGroupId`,
+`computerGroupName`, `organizationId`, `organizationName`, and
+`agentVersion`.
+
+### Get Computer
+
+```
+threatlocker_computers_get
+```
+
+Pulls full detail for one computer including hardware, current
+policy mode (Learning/Secured/Lockdown), enforcement status, and
+recent activity counts.
+
+### Get Check-ins
+
+```
+threatlocker_computers_get_checkins
+```
+
+Returns recent check-in records for a computer — useful for
+distinguishing a healthy-but-quiet endpoint from a true offline one,
+and for identifying flapping agents that come and go.
+
+## Common Workflows
+
+### Fleet Inventory
+
+1. Call `threatlocker_computers_list` with `pageSize: 100`,
+   `orderBy: "computerName"`.
+2. Page through `totalItems`, accumulating results.
+3. For an MSP-wide view, set `childOrganizations: true` and group
+   results by `organizationName` after fetching.
+
+### Offline Agent Triage
+
+Recency tiers we use in practice:
+
+| Bucket | `lastCheckin` age | Action |
+|--------|-------------------|--------|
+| Fresh | < 24h | Healthy |
+| Stale | 24h–7d | Investigate (reboot, network) |
+| Cold | 7d–30d | Open ticket; possible decommission |
+| Dead | > 30d | Confirm decommissioned and remove |
+
+1. Pull computers with `orderBy: "lastCheckin"`, `isAscending: true`.
+2. The oldest check-ins surface first — bucket them and produce a
+   per-bucket count.
+3. For Stale endpoints, call `threatlocker_computers_get_checkins`
+   to see whether check-ins are flapping vs. truly stopped.
+
+### Drilling From a Group to its Computers
+
+1. Identify the group with the `computer-groups` skill.
+2. Filter `threatlocker_computers_list` results client-side by
+   `computerGroupId` (the API does not currently expose a group filter
+   parameter on the list endpoint — fetch and filter).
+3. For each computer in the group, optionally call
+   `threatlocker_computers_get` for policy mode and enforcement state.
+
+### Per-OS Breakdown
+
+Use `searchText` to scope results to an OS string (e.g. `"Windows
+Server 2019"`, `"macOS"`, `"Windows 10"`), or fetch the full set and
+bucket on `operatingSystem` client-side. Substring match means partial
+strings like `"Windows 11"` work.
+
+## Edge Cases
+
+- **Multi-org agents** — A single API key may see computers across many
+  child organizations. Always include `organizationId` /
+  `organizationName` in your output so an analyst can see which tenant
+  a computer belongs to.
+- **Recently re-imaged hosts** — A re-imaged endpoint can register as a
+  new computer with the same hostname. If you see two records with the
+  same `hostname` but different `computerId`, prefer the one with the
+  most recent `lastCheckin`.
+- **Time zones** — `lastCheckin` is UTC. Convert before showing it to a
+  human, especially for "X hours ago" framing.
+- **Search performance** — Avoid `searchText: ""` plus `pageSize: 1000`.
+  Stick to 50–200 per page.
+
+## Best Practices
+
+- Treat `lastCheckin` as your primary health signal; other fields lag.
+- For MSP fleet reports, always group by organization first, then by
+  group, before listing individual machines.
+- Cross-reference with the RMM device count per org — a delta usually
+  means an unprotected endpoint, which is the highest-priority gap.
+
+## Related Skills
+
+- [api-patterns](../api-patterns/SKILL.md) — Pagination and auth
+- [computer-groups](../computer-groups/SKILL.md) — Policy scoping
+- [audit-log](../audit-log/SKILL.md) — Per-computer event timeline
+- [organizations](../organizations/SKILL.md) — Multi-tenant pivot

--- a/msp-claude-plugins/threatlocker/threatlocker/skills/organizations/SKILL.md
+++ b/msp-claude-plugins/threatlocker/threatlocker/skills/organizations/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: "ThreatLocker Organizations"
+description: >
+  Use this skill when working with the ThreatLocker MSP multi-tenant
+  model — enumerating child organizations, retrieving per-org auth
+  keys, and identifying valid move targets when relocating computers
+  between tenants.
+when_to_use: "When fanning out reports across child orgs, retrieving an org's auth key, or moving computers between organizations"
+triggers:
+  - threatlocker organization
+  - threatlocker tenant
+  - threatlocker child orgs
+  - threatlocker partner
+  - threatlocker auth key
+  - move computer threatlocker
+  - threatlocker multi-tenant
+  - threatlocker mssp
+---
+
+# ThreatLocker Organizations
+
+ThreatLocker is built for MSPs and treats each customer as a child
+organization beneath the partner organization. The API key you
+authenticate with belongs to a parent (partner) org and can see all
+of its children. Most fleet-wide reporting and any tenant pivot work
+runs through this skill.
+
+## API Tools
+
+### List Child Organizations
+
+```
+threatlocker_organizations_list_children
+```
+
+Returns the full list of child organizations visible to the
+authenticated key — typically `organizationId`, `organizationName`,
+`isPartner`, `parentOrganizationId`, computer counts, and creation
+timestamp. This is the first call in nearly every multi-tenant
+workflow.
+
+### Get Organization Auth Key
+
+```
+threatlocker_organizations_get_auth_key
+```
+
+Retrieves the auth key for a specific child organization. Used
+during agent provisioning and when a per-org integration (e.g. a
+client-facing dashboard) needs its own scoped credential.
+
+> **Treat this output like any other secret.** Don't paste it into
+> tickets, chat, or unencrypted notes.
+
+### Organizations Eligible for Move
+
+```
+threatlocker_organizations_for_move_computers
+```
+
+Returns the orgs that are valid destinations when relocating a
+computer — usually a subset of child orgs filtered by partnership and
+permission. Not the same as the full child list.
+
+## Key Concepts
+
+### Partner vs Customer Org
+
+- **Partner org** — Top-level MSP tenant. Holds the API key, owns
+  global computer groups, and parents customer orgs.
+- **Customer (child) org** — One per MSP client. Holds that client's
+  computers, org-specific groups, approvals, and Action Log entries.
+
+### How Tenant Scoping Works
+
+Three ways to scope a call to a specific tenant:
+
+1. Set the `organizationId` header on the HTTP call.
+2. Send `childOrganizations: true` in a `GetByParameters` body to
+   roll across all children at once.
+3. Omit both — the API key's primary org is used.
+
+See `api-patterns` for header/body details.
+
+## Common Workflows
+
+### MSP Multi-Tenant Pivot
+
+The fan-out pattern for any per-client report:
+
+1. `threatlocker_organizations_list_children` to enumerate.
+2. For each child, scope subsequent calls via the `organizationId`
+   header and produce per-tenant numbers.
+3. Or, if the entity supports it, use `childOrganizations: true` once
+   and bucket results client-side by `organizationId`.
+
+### Onboarding a New Client Org
+
+When a new customer is added in the ThreatLocker portal:
+
+1. `threatlocker_organizations_list_children` and confirm the new
+   org appears.
+2. `threatlocker_organizations_get_auth_key` for the new org and
+   securely transmit the key to the deployment team.
+3. After agent rollout, validate computer count via the `computers`
+   skill and confirm at least one Action Log entry per endpoint via
+   `audit-log`.
+
+### Moving Computers Between Orgs
+
+This happens when a client splits, merges, or you discover a computer
+was registered to the wrong tenant:
+
+1. `threatlocker_organizations_for_move_computers` to confirm the
+   target org is move-eligible.
+2. Issue the move via the appropriate computer endpoint (the
+   ThreatLocker portal also exposes this in the UI).
+3. Re-pull the computer with `threatlocker_computers_get` and confirm
+   the new `organizationId` and that the `computerGroup` reset to
+   the destination org's default.
+
+### Per-Tenant Approval Queue Audit
+
+1. List children.
+2. For each, set `organizationId` header and call
+   `threatlocker_approvals_pending_count`.
+3. Output a per-tenant pending count to spot the org generating the
+   most queue pressure (often a sign of policy mode mismatch or a
+   newly onboarded client still in baseline).
+
+## Edge Cases
+
+- **Inactive or hidden orgs** — Some child orgs are archived or
+  hidden. The list endpoint may include a flag; ignore those for
+  fleet reports.
+- **Stale auth keys** — A previously retrieved auth key continues to
+  work until rotated. Don't assume the key in your records is
+  current; pull fresh when in doubt.
+- **Move eligibility surprises** — `for_move_computers` filters by
+  partner relationship. If an org isn't in the result, the source
+  org's parent doesn't have permission to move into it.
+
+## Best Practices
+
+- Cache the child list for a session — it rarely changes mid-session.
+- Always include both `organizationId` and `organizationName` in
+  multi-tenant reports so a reader knows which client a number
+  refers to.
+- Treat auth keys as secrets in transit (encrypted vaults, not
+  tickets) and at rest.
+- Before any move, snapshot the source computer record so you can
+  confirm post-move state.
+
+## Related Skills
+
+- [api-patterns](../api-patterns/SKILL.md) — `organizationId` header
+  and `childOrganizations` body flag
+- [computers](../computers/SKILL.md) — Computers within an org
+- [approval-requests](../approval-requests/SKILL.md) — Per-tenant queue
+- [audit-log](../audit-log/SKILL.md) — Per-tenant Action Log


### PR DESCRIPTION
## Summary

Brings the ThreatLocker plugin to parity with `huntress`, `blumira`, and `sentinelone` by adding the skills and agents that were missing alongside the existing commands.

## Skills (6)

- `api-patterns` — raw `Authorization` header (no `Bearer`), `organizationId` tenant routing, POST-based `*GetByParameters` pagination shape, `childOrganizations` fan-out flag
- `computers` — endpoint inventory, offline-agent recency tiering (24h / 7d / 30d), check-in history, multi-org fleets
- `computer-groups` — policy-scoping unit, dropdown vs full list endpoints, `osType` enum, global vs org-specific groups
- `approval-requests` — pending queue triage, signed-publisher heuristics, bulk approve patterns, escalation triggers (LOLBins, RAT installers, phishing droppers)
- `audit-log` — Action Log forensics, file-history pivots, `kindOfAction` (Block/Permit/Audit) categorization, timeline reconstruction
- `organizations` — MSP multi-tenant pivots, child-org enumeration, per-org auth keys, computer-move eligibility

## Agents (3)

- `approval-triage-analyst` — daily approval-queue analyst; classifies high-confidence vs needs-review, escalates suspicious patterns
- `threat-investigator` — Action Log forensic investigator; builds timelines, traces file history across the fleet, recommends policy actions
- `fleet-health-auditor` — fleet inventory and hygiene; offline-agent tiers, group hygiene (orphans, oversized, OS-mismatched), per-tenant rollups

## Test plan

- [ ] Verify all 9 files have valid frontmatter (already validated locally — all OK)
- [ ] Spot-check that referenced tool names match the MCP server (`threatlocker_*`)
- [ ] Confirm threatlocker plugin now mirrors huntress/blumira/sentinelone shape (skills/, agents/, commands/)