### PR TITLE
fix(docs): UX-audit copy fixes — sales typo, FAQ vs pricing, page-title casing

### DIFF
--- a/msp-claude-plugins/docs/src/pages/index.astro
+++ b/msp-claude-plugins/docs/src/pages/index.astro
@@ -45,7 +45,7 @@ const faqs = [
   },
   {
     question: "Are MSP Claude Plugins free?",
-    answer: "Yes, all MSP Claude Plugins are free and open source under the Apache 2.0 license. Community contributions are welcome."
+    answer: "The open-source MSP Claude Plugins (the skills, commands, and self-hostable MCP servers in this collection) are free under the Apache 2.0 license. The hosted WYRE Gateway is a separate paid managed service — see the Pro, Business, and Enterprise plans on the Pricing page. Community contributions to the OSS plugins are welcome."
   },
   {
     question: "What is the Model Context Protocol (MCP)?",
@@ -332,7 +332,7 @@ const features = [
       </div>
 
       <p class="text-center text-sm text-[var(--muted)] mt-8">
-        Need a custom plan? <a href="mailto:sales@wyre.technology" class="text-accent hover:underline">Get in touch.</a>
+        Need a custom plan? <a href="mailto:sales@wyre.ai" class="text-accent hover:underline">Get in touch.</a>
       </p>
     </div>
   </section>

--- a/msp-claude-plugins/docs/src/pages/privacy.astro
+++ b/msp-claude-plugins/docs/src/pages/privacy.astro
@@ -5,8 +5,8 @@ import Footer from '@/components/Footer.astro';
 ---
 
 <BaseLayout
-  title="Privacy Policy - Wyre Technology"
-  description="Privacy Policy for the Wyre Technology MCP Gateway and MSP Claude Plugins."
+  title="Privacy Policy - WYRE Technology"
+  description="Privacy Policy for the WYRE Technology MCP Gateway and MSP Claude Plugins."
 >
   <Header />
 

--- a/msp-claude-plugins/docs/src/pages/terms.astro
+++ b/msp-claude-plugins/docs/src/pages/terms.astro
@@ -5,8 +5,8 @@ import Footer from '@/components/Footer.astro';
 ---
 
 <BaseLayout
-  title="Terms of Service - Wyre Technology"
-  description="Terms of Service for the Wyre Technology MCP Gateway and MSP Claude Plugins."
+  title="Terms of Service - WYRE Technology"
+  description="Terms of Service for the WYRE Technology MCP Gateway and MSP Claude Plugins."
 >
   <Header />
 


### PR DESCRIPTION
## Summary

Three remaining quick-win fixes from the 2026-05 UX audit ([review branch + report on wyre-mcp-gateway-platform](https://github.com/wyre-technology/wyre-mcp-gateway-platform/pull/37)).

Several other audit findings were already addressed since the snapshot:
- **C-4** (mcp.wyretechnology.com → mcp.wyre.ai sweep) — handled by #61, #62, #67
- **D-1 / sidebar IA work** — handled by #65
- **Pricing free-tier removal** — handled by #66

So this PR covers only the remaining items in scope:

- **C-5** — Custom-plan "Get in touch" link pointed at `sales@wyre.technology` (not a real WYRE domain) instead of `sales@wyre.ai`. Fixed in `docs/src/pages/index.astro:335`. The pricing page already uses `sales@wyre.ai`.
- **C-6** — FAQ Q4 ("Are MSP Claude Plugins free?") answered *"Yes, all MSP Claude Plugins are free…"* which sat next to the paid Pro/Business pricing tiers and read as a contradiction. Rewritten to distinguish the OSS plugins (Apache 2.0) from the paid hosted gateway.
- **C-2** — Page-title + meta-description prose used "Wyre Technology" (mixed case) on `/privacy` and `/terms`, violating the WYRE brand rule (all-caps in prose). Fixed the title/description attributes only — the legal body prose is left unchanged so whoever owns those documents can do that sweep separately.

## Test plan

- [ ] `npm run dev` and verify FAQ Q4 reads cleanly next to the pricing tiers
- [ ] Hover the "Get in touch" link in the pricing CTA and confirm `mailto:sales@wyre.ai`
- [ ] View source on /privacy and /terms and confirm `<title>` reads "WYRE Technology"

## Out of scope (deferred)

- Sweeping body prose in `terms.astro` and `privacy.astro` to apply the WYRE brand rule (legal review required first)
- D-6 CTA standardization — post-rebase the surface is now coherent enough to skip
- D-3 (pricing terminology glossary) — needs design pass
- D-4 (FAQ regurgitation) — needs editorial decision
- D-5 (a11y PR for mcp.wyre.ai) — separate focused PR