### PR TITLE
feat: add Wave 1 vendor plugins (blackpoint, crewhu, immybot, timezest)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "msp-claude-plugins",
   "description": "Community-driven Claude Code plugins for Managed Service Providers. Integrates with PSA, RMM, and documentation tools.",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "owner": {
     "name": "Aaron Sachs"
   },
@@ -448,6 +448,60 @@
         "psa",
         "rmm",
         "tickets",
+        "msp"
+      ]
+    },
+    {
+      "name": "blackpoint",
+      "source": "./msp-claude-plugins/blackpoint/blackpoint",
+      "description": "Blackpoint Cyber / CompassOne MDR - tenants, assets, detections, vulnerabilities (dark web, external, scans)",
+      "version": "1.0.0",
+      "category": "security",
+      "tags": [
+        "blackpoint",
+        "compassone",
+        "security",
+        "mdr",
+        "msp"
+      ]
+    },
+    {
+      "name": "crewhu",
+      "source": "./msp-claude-plugins/crewhu/crewhu",
+      "description": "Crewhu - CSAT/NPS surveys, employee recognition, badges, prize redemptions for MSPs",
+      "version": "1.0.0",
+      "category": "productivity",
+      "tags": [
+        "crewhu",
+        "csat",
+        "engagement",
+        "msp"
+      ]
+    },
+    {
+      "name": "immybot",
+      "source": "./msp-claude-plugins/immybot/immybot",
+      "description": "ImmyBot - desired-state Windows software deployment, maintenance sessions, scripts (Entra ID OAuth)",
+      "version": "1.0.0",
+      "category": "rmm",
+      "tags": [
+        "immybot",
+        "rmm",
+        "deployment",
+        "windows",
+        "msp"
+      ]
+    },
+    {
+      "name": "timezest",
+      "source": "./msp-claude-plugins/timezest/timezest",
+      "description": "TimeZest - tech scheduling against ConnectWise / Autotask / Halo PSA tickets",
+      "version": "1.0.0",
+      "category": "productivity",
+      "tags": [
+        "timezest",
+        "scheduling",
+        "psa",
         "msp"
       ]
     },

--- a/msp-claude-plugins/blackpoint/blackpoint/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/blackpoint/blackpoint/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "blackpoint",
+  "version": "1.0.0",
+  "description": "Blackpoint Cyber / CompassOne MDR - tenant, asset, detection, and vulnerability data for MSP incident response",
+  "author": {
+    "name": "WYRE Technology"
+  },
+  "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
+  "repository": "https://github.com/wyre-technology/msp-claude-plugins",
+  "license": "Apache-2.0"
+}

--- a/msp-claude-plugins/blackpoint/blackpoint/.mcp.json
+++ b/msp-claude-plugins/blackpoint/blackpoint/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "blackpoint": {
+      "type": "http",
+      "url": "https://mcp.wyretechnology.com/v1/blackpoint/mcp",
+      "headers": {
+        "Authorization": "Bearer ${BLACKPOINT_API_TOKEN}"
+      }
+    }
+  }
+}

--- a/msp-claude-plugins/blackpoint/blackpoint/.mcp.json
+++ b/msp-claude-plugins/blackpoint/blackpoint/.mcp.json
@@ -4,7 +4,7 @@
       "type": "http",
       "url": "https://mcp.wyretechnology.com/v1/blackpoint/mcp",
       "headers": {
-        "Authorization": "Bearer ${BLACKPOINT_API_TOKEN}"
+        "X-Blackpoint-Api-Token": "${BLACKPOINT_API_TOKEN}"
       }
     }
   }

--- a/msp-claude-plugins/blackpoint/blackpoint/README.md
+++ b/msp-claude-plugins/blackpoint/blackpoint/README.md
@@ -1,0 +1,66 @@
+# Blackpoint Cyber Plugin
+
+Claude Code plugin for [Blackpoint Cyber](https://blackpointcyber.com) (the CompassOne portal) - managed detection and response for MSPs.
+
+## What It Does
+
+- **Detections** - List and drill into MDR detections
+- **Assets** - Tenant-scoped asset inventory with relationship traversal
+- **Vulnerabilities** - Scan results, dark-web exposure, external (internet-facing) vulns
+- **Tenants** - Partner-tenant-asset hierarchy navigation
+
+> Today's tool surface is read-only and covers four domains: tenants,
+> assets, detections, and vulnerabilities. Stubs exist for alerts,
+> cloud security, notifications, partners, threat intel, and tickets;
+> those will be implemented in a later wave.
+
+## Installation
+
+```
+/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin install blackpoint
+```
+
+The plugin connects through the [WYRE MCP Gateway](https://mcp.wyretechnology.com) at `https://mcp.wyretechnology.com/v1/blackpoint/mcp`.
+
+## Configuration
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `BLACKPOINT_API_TOKEN` | Yes | CompassOne portal Bearer token |
+
+## Skills
+
+- `api-patterns` - Auth, partner-tenant-asset hierarchy, navigation, pagination
+- `incident-response` - Primary investigation skill (detections + assets + vulnerabilities)
+
+## Commands
+
+- `/search-detections` - List recent detections, optionally scoped to a tenant
+
+## Tools
+
+Provided by the Blackpoint MCP server through the WYRE MCP Gateway:
+
+### Navigation
+- `blackpoint_navigate`, `blackpoint_back`, `blackpoint_status`
+
+### Tenants
+- `blackpoint_tenants_list`, `blackpoint_tenants_get`
+
+### Assets
+- `blackpoint_assets_list`, `blackpoint_assets_get`
+- `blackpoint_assets_search`, `blackpoint_assets_relationships`
+
+### Detections
+- `blackpoint_detections_list`, `blackpoint_detections_get`
+
+### Vulnerabilities
+- `blackpoint_vulnerabilities_list`
+- `blackpoint_vulnerabilities_scans_list`
+- `blackpoint_vulnerabilities_darkweb_list`
+- `blackpoint_vulnerabilities_external_list`
+
+## License
+
+Apache-2.0

--- a/msp-claude-plugins/blackpoint/blackpoint/commands/search-detections.md
+++ b/msp-claude-plugins/blackpoint/blackpoint/commands/search-detections.md
@@ -1,0 +1,53 @@
+---
+name: search-detections
+description: List recent Blackpoint Cyber detections for a tenant
+arguments:
+  - name: tenant
+    description: Tenant name or ID to scope the search
+    required: false
+---
+
+# Blackpoint Detection Search
+
+List recent CompassOne detections, then enrich each with its affected asset for an investigation-ready view.
+
+## Prerequisites
+
+- Blackpoint MCP server connected with a valid `BLACKPOINT_API_TOKEN`
+- Tools available: `blackpoint_tenants_list`, `blackpoint_detections_list`, `blackpoint_detections_get`, `blackpoint_assets_get`
+
+## Steps
+
+1. **Resolve tenant scope**
+
+   If `tenant` was supplied, call `blackpoint_tenants_list` and match. Otherwise, list across all tenants the partner can see.
+
+2. **List detections**
+
+   Call `blackpoint_detections_list` for the chosen tenant scope.
+
+3. **Enrich the top results**
+
+   For the top N (e.g. 10) detections, call `blackpoint_detections_get` and `blackpoint_assets_get` for the affected asset.
+
+4. **Output**
+
+   - Detection count, severity distribution, time range
+   - Top 10 detection table: timestamp, severity, detection type, asset hostname, tenant
+   - Suggested follow-up assets to investigate further (`blackpoint_assets_relationships`)
+
+## Examples
+
+### All recent detections, partner-wide
+```
+/search-detections
+```
+
+### Drill into one tenant
+```
+/search-detections "Acme Corp"
+```
+
+## Related Commands
+
+- (none yet)

--- a/msp-claude-plugins/blackpoint/blackpoint/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/blackpoint/blackpoint/skills/api-patterns/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: "Blackpoint Cyber API Patterns"
+when_to_use: "When working with Blackpoint Cyber / CompassOne authentication, partner-tenant-asset hierarchy, or pagination through detections and vulnerabilities"
+description: >
+  Use this skill when working with the Blackpoint Cyber (CompassOne)
+  MCP tools — Bearer token authentication, the partner-tenant-asset
+  hierarchy, navigation tools, and the read-only tool surface across
+  tenants, assets, detections, and vulnerabilities.
+triggers:
+  - blackpoint api
+  - blackpoint authentication
+  - blackpoint mcp
+  - compassone api
+  - compassone authentication
+  - blackpoint tenant
+  - blackpoint asset
+---
+
+# Blackpoint Cyber (CompassOne) MCP Tools & API Patterns
+
+## Overview
+
+Blackpoint Cyber is a managed detection and response (MDR) provider.
+The CompassOne portal exposes a partner-tenant-asset hierarchy: a
+partner (the MSP) sees many tenants (their customers), each tenant has
+many assets (endpoints, identities, cloud accounts), and detections /
+vulnerabilities are produced against those assets.
+
+## Connection & Authentication
+
+CompassOne uses a Bearer token issued from the partner portal:
+
+| Header | Value |
+|--------|-------|
+| `Authorization` | `Bearer <token>` |
+
+```bash
+export BLACKPOINT_API_TOKEN="your-compassone-bearer-token"
+```
+
+## Hierarchy
+
+```
+Partner (MSP)
+  └── Tenant (customer)
+        └── Asset (endpoint / identity / cloud account)
+              └── Detections / Vulnerabilities
+```
+
+Always pivot top-down: identify the tenant first, then drill into
+assets, then look at detections/vulnerabilities for that asset.
+
+## Navigation Tools
+
+| Tool | Purpose |
+|------|---------|
+| `blackpoint_navigate` | Discover available domains |
+| `blackpoint_back` | Pop back to the prior context |
+| `blackpoint_status` | Health/status check |
+
+## Functional Tool Surface (today)
+
+Tools follow `blackpoint_<domain>_<action>`. Currently functional
+domains:
+
+- `tenants`
+- `assets`
+- `detections`
+- `vulnerabilities`
+
+Additional domains (alerts, cloud security, notifications, partners,
+threat intel, tickets) are stubbed in the MCP server but not yet
+implemented — do not call those.
+
+## Pagination
+
+Blackpoint list endpoints use page/limit-style pagination. Always
+check whether more pages exist before claiming a result is complete,
+especially for `detections` and `vulnerabilities` — those can run
+into the thousands.
+
+## Error Handling
+
+| Status | Meaning | Action |
+|--------|---------|--------|
+| 401 | Bad/missing Bearer token | Re-check `BLACKPOINT_API_TOKEN` |
+| 403 | Token valid but no access to the requested tenant | Check partner-tenant scoping |
+| 404 | Unknown tenant / asset / detection | Re-list to confirm |
+| 429 | Rate limit | Back off and retry |
+
+## Best Practices
+
+- For incident-response work, always list the affected tenant's
+  assets and detections together — a detection without its asset
+  context is hard to action.
+- For multi-tenant rollups (partner view), iterate
+  `blackpoint_tenants_list` first and then drill in per-tenant.
+- The current tool surface is read-only — there are no write tools
+  yet. Any "respond to detection" workflow must happen in the
+  CompassOne portal itself.
+
+## Related Skills
+
+- [incident-response](../incident-response/SKILL.md) - Primary investigation skill

--- a/msp-claude-plugins/blackpoint/blackpoint/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/blackpoint/blackpoint/skills/api-patterns/SKILL.md
@@ -28,15 +28,24 @@ vulnerabilities are produced against those assets.
 
 ## Connection & Authentication
 
-CompassOne uses a Bearer token issued from the partner portal:
+Blackpoint uses an API token passed via header. CompassOne issues the
+token in the partner portal.
 
 | Header | Value |
 |--------|-------|
-| `Authorization` | `Bearer <token>` |
+| `X-Blackpoint-Api-Token` | The raw CompassOne token |
+
+The gateway maps the environment variable `BLACKPOINT_API_TOKEN` onto
+the `X-Blackpoint-Api-Token` header automatically. Internally, the
+Blackpoint MCP server forwards this to CompassOne as a `Bearer` token —
+you do not need to add the `Bearer ` prefix yourself.
 
 ```bash
-export BLACKPOINT_API_TOKEN="your-compassone-bearer-token"
+export BLACKPOINT_API_TOKEN="your-compassone-token"
 ```
+
+Optional: `BLACKPOINT_BASE_URL` overrides the CompassOne base URL for
+regional or partner-specific deployments.
 
 ## Hierarchy
 

--- a/msp-claude-plugins/blackpoint/blackpoint/skills/incident-response/SKILL.md
+++ b/msp-claude-plugins/blackpoint/blackpoint/skills/incident-response/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: "Blackpoint Incident Response"
+when_to_use: "When investigating a Blackpoint Cyber / CompassOne detection, building an incident timeline across assets, or correlating detections with known vulnerabilities"
+description: >
+  Use this skill when investigating a Blackpoint Cyber detection —
+  drilling from a tenant to its assets, walking the detection list,
+  pulling vulnerability and dark-web context, and assembling an
+  incident timeline.
+triggers:
+  - blackpoint detection
+  - blackpoint investigation
+  - blackpoint incident
+  - compassone detection
+  - blackpoint vulnerability
+  - blackpoint asset relationships
+  - blackpoint dark web
+---
+
+# Blackpoint Incident Response
+
+The functional Blackpoint tool surface today is read-only and centers
+on detections and the assets they fire against. This skill walks the
+investigation flow: tenant → asset → detections → vulnerabilities,
+plus dark-web and external-vulnerability cross-references.
+
+## API Tools
+
+### Tenants
+
+| Tool | Purpose |
+|------|---------|
+| `blackpoint_tenants_list` | Partner's customer tenants |
+| `blackpoint_tenants_get` | Detail for one tenant |
+
+### Assets
+
+| Tool | Purpose |
+|------|---------|
+| `blackpoint_assets_list` | Assets for a tenant |
+| `blackpoint_assets_get` | Detail for one asset |
+| `blackpoint_assets_search` | Search assets by name / identifier |
+| `blackpoint_assets_relationships` | Asset relationships (parent / child / related) |
+
+### Detections
+
+| Tool | Purpose |
+|------|---------|
+| `blackpoint_detections_list` | Detections for the tenant / asset scope |
+| `blackpoint_detections_get` | Full detail for one detection |
+
+### Vulnerabilities
+
+| Tool | Purpose |
+|------|---------|
+| `blackpoint_vulnerabilities_list` | Known vulnerabilities for the scope |
+| `blackpoint_vulnerabilities_scans_list` | Recent scan results |
+| `blackpoint_vulnerabilities_darkweb_list` | Dark-web exposure findings |
+| `blackpoint_vulnerabilities_external_list` | External (internet-facing) vulnerabilities |
+
+## Common Workflows
+
+### Walk a detection end-to-end
+
+1. Identify the tenant: `blackpoint_tenants_list` →
+   `blackpoint_tenants_get`.
+2. List recent detections: `blackpoint_detections_list`.
+3. Pick the detection of interest: `blackpoint_detections_get`.
+4. Pivot to the affected asset:
+   `blackpoint_assets_get` and `blackpoint_assets_relationships`.
+5. Cross-reference vulnerabilities on that asset:
+   `blackpoint_vulnerabilities_list`.
+
+### Per-tenant exposure rollup
+
+1. `blackpoint_tenants_get` to confirm scope.
+2. `blackpoint_vulnerabilities_external_list` for internet-facing
+   exposure.
+3. `blackpoint_vulnerabilities_darkweb_list` for credential / data
+   leakage.
+4. `blackpoint_vulnerabilities_scans_list` for recent scan history.
+5. Roll up: count by severity, age, and asset. Surface anything
+   high-severity with no recent scan.
+
+### Asset relationship map
+
+1. `blackpoint_assets_search` to find the entry asset.
+2. `blackpoint_assets_relationships` to enumerate connected assets.
+3. For each related asset, summarize detections and vulnerabilities
+   to build a blast-radius view.
+
+### Multi-tenant detection sweep (partner view)
+
+1. `blackpoint_tenants_list` to enumerate customers.
+2. For each tenant, call `blackpoint_detections_list` for a recent
+   window.
+3. Roll up: detections per tenant, severity distribution, top
+   detection types.
+4. Surface tenants with abnormal volume or new detection types as
+   priority follow-ups.
+
+## Edge Cases
+
+- **Stub domains** — `blackpoint_alerts_*`,
+  `blackpoint_cloud_security_*`, `blackpoint_notifications_*`,
+  `blackpoint_partners_*`, `blackpoint_threat_intel_*`, and
+  `blackpoint_tickets_*` are placeholders today and should not be
+  invoked. Prefer the four functional domains.
+- **Read-only** — Any "respond" or "acknowledge" action must happen
+  in the CompassOne portal; the MCP surface cannot mutate state yet.
+- **Asset identity drift** — Re-imaged endpoints can produce two
+  asset records. Use `blackpoint_assets_search` and dedupe on
+  hostname / serial before reporting.
+
+## Best Practices
+
+- Always include tenant name in every output — partner-level work
+  spans many customers and ambiguity bites.
+- Pair detections with the associated asset and any related
+  vulnerabilities in a single view; analysts should not have to chase
+  the link themselves.
+- For QBRs, pull the external-vulnerability list and dark-web list
+  together — they tell complementary stories.
+
+## Related Skills
+
+- [api-patterns](../api-patterns/SKILL.md) - Auth, hierarchy, pagination

--- a/msp-claude-plugins/crewhu/crewhu/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/crewhu/crewhu/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "crewhu",
+  "version": "1.0.0",
+  "description": "Crewhu - CSAT/NPS surveys, employee recognition, badges, and prize/redemption gamification for MSPs",
+  "author": {
+    "name": "WYRE Technology"
+  },
+  "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
+  "repository": "https://github.com/wyre-technology/msp-claude-plugins",
+  "license": "Apache-2.0"
+}

--- a/msp-claude-plugins/crewhu/crewhu/.mcp.json
+++ b/msp-claude-plugins/crewhu/crewhu/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "crewhu": {
+      "type": "http",
+      "url": "https://mcp.wyretechnology.com/v1/crewhu/mcp",
+      "headers": {
+        "X-Crewhu-Api-Token": "${X_CREWHU_APITOKEN}"
+      }
+    }
+  }
+}

--- a/msp-claude-plugins/crewhu/crewhu/README.md
+++ b/msp-claude-plugins/crewhu/crewhu/README.md
@@ -1,0 +1,60 @@
+# Crewhu Plugin
+
+Claude Code plugin for [Crewhu](https://crewhu.com) - CSAT/NPS surveys, recognition, and gamification for MSP teams.
+
+## What It Does
+
+- **Survey analysis** - Recent CSAT/NPS responses, trend lines, detractor/promoter breakouts
+- **Recognition** - Badge history, per-user recognition, contest management
+- **Prizes** - Prize catalog, redemption history, pending redemption queue
+- **Users** - List, search, and inspect Crewhu users (techs)
+
+## Installation
+
+```
+/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin install crewhu
+```
+
+The plugin connects through the [WYRE MCP Gateway](https://mcp.wyretechnology.com) at `https://mcp.wyretechnology.com/v1/crewhu/mcp`.
+
+## Configuration
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `X_CREWHU_APITOKEN` | Yes | Crewhu API token (sent as `X-Crewhu-Api-Token` header) |
+
+## Skills
+
+- `api-patterns` - Auth, navigation, pagination, error handling
+- `surveys` - Primary CSAT/NPS analysis skill (detractors, promoters, trends)
+
+## Commands
+
+- `/search-surveys` - Search recent surveys with detractor/promoter breakout
+
+## Tools
+
+Provided by the Crewhu MCP server through the WYRE MCP Gateway:
+
+### Navigation
+- `crewhu_navigate`, `crewhu_back`, `crewhu_status`
+
+### Surveys
+- `crewhu_surveys_list`, `crewhu_surveys_get`, `crewhu_surveys_search`
+- `crewhu_surveys_detractors`, `crewhu_surveys_promoters`
+
+### Users
+- `crewhu_users_list`, `crewhu_users_get`, `crewhu_users_search`
+
+### Badges
+- `crewhu_badges_list`, `crewhu_badges_get`, `crewhu_badges_history_list`
+- `crewhu_badges_user_recognition`, `crewhu_badges_update_contest` (write)
+
+### Prizes
+- `crewhu_prizes_list`, `crewhu_prizes_get`, `crewhu_prizes_history_list`
+- `crewhu_prizes_user_redemptions`, `crewhu_prizes_pending_redemptions`
+
+## License
+
+Apache-2.0

--- a/msp-claude-plugins/crewhu/crewhu/commands/search-surveys.md
+++ b/msp-claude-plugins/crewhu/crewhu/commands/search-surveys.md
@@ -1,0 +1,54 @@
+---
+name: search-surveys
+description: Search recent Crewhu surveys, surfacing detractors and promoters
+arguments:
+  - name: query
+    description: Optional keyword to filter survey responses
+    required: false
+---
+
+# Crewhu Survey Search
+
+Search Crewhu CSAT/NPS responses, then break the result into detractors and promoters so a manager has actionable follow-ups.
+
+## Prerequisites
+
+- Crewhu MCP server connected with a valid `X_CREWHU_APITOKEN`
+- Tools available: `crewhu_surveys_search`, `crewhu_surveys_detractors`, `crewhu_surveys_promoters`
+
+## Steps
+
+1. **Search responses**
+
+   Call `crewhu_surveys_search` with `query` if provided. Otherwise call `crewhu_surveys_list` for a recent window.
+
+2. **Pull detractors**
+
+   Call `crewhu_surveys_detractors` to get the negative end of the curve.
+
+3. **Pull promoters**
+
+   Call `crewhu_surveys_promoters` to get the positive end.
+
+4. **Summarize**
+
+   Output a short report:
+   - Total responses in window, average score, response count
+   - Top 5 detractors (score, customer, tech, comment) with suggested follow-up action
+   - Top 5 promoters (score, customer, tech, comment) for recognition
+
+## Examples
+
+### Recent surveys, all topics
+```
+/search-surveys
+```
+
+### Filter by keyword
+```
+/search-surveys "outage"
+```
+
+## Related Commands
+
+- (none yet)

--- a/msp-claude-plugins/crewhu/crewhu/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/crewhu/crewhu/skills/api-patterns/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: "Crewhu API Patterns"
+when_to_use: "When working with Crewhu authentication headers, pagination, navigation tools, or error handling for the Crewhu MCP server"
+description: >
+  Use this skill when working with the Crewhu MCP tools — token-based
+  authentication via the `X-Crewhu-Api-Token` header, the
+  navigation pattern (`crewhu_navigate`, `crewhu_back`, `crewhu_status`),
+  read-heavy tool surface, and error handling.
+triggers:
+  - crewhu api
+  - crewhu authentication
+  - crewhu pagination
+  - crewhu mcp
+  - crewhu navigate
+  - crewhu token
+---
+
+# Crewhu MCP Tools & API Patterns
+
+## Overview
+
+The Crewhu MCP server exposes CSAT/NPS surveys, employee recognition
+(badges), and prize/redemption data for MSP teams. The tool surface is
+read-heavy — only `crewhu_badges_update_contest` performs writes.
+
+## Connection & Authentication
+
+Crewhu uses an API token passed via header:
+
+| Header | Value |
+|--------|-------|
+| `X-Crewhu-Api-Token` | The raw API token |
+
+The gateway maps the environment variable `X_CREWHU_APITOKEN` onto the
+`X-Crewhu-Api-Token` header automatically.
+
+```bash
+export X_CREWHU_APITOKEN="your-crewhu-api-token"
+```
+
+## Navigation Tools
+
+Crewhu provides three navigation/meta tools that complement the
+functional surface:
+
+| Tool | Purpose |
+|------|---------|
+| `crewhu_navigate` | Discover available tool domains (surveys, users, badges, prizes) |
+| `crewhu_back` | Pop back to the prior navigation context |
+| `crewhu_status` | Health/status check for the Crewhu connection |
+
+When you do not yet know which tool to call, start with
+`crewhu_navigate` to enumerate the available domains.
+
+## Functional Tool Surface
+
+Tools follow the `crewhu_<domain>_<action>` pattern. The four
+functional domains are surveys, users, badges, and prizes — see the
+domain skills for detail.
+
+## Pagination
+
+Crewhu list endpoints typically accept page/limit-style parameters.
+Always check whether more pages exist before claiming a result set is
+complete; for survey trend analysis, pull enough history to have a
+stable denominator.
+
+## Error Handling
+
+| Status | Meaning | Action |
+|--------|---------|--------|
+| 401 | Missing or invalid token | Re-check `X_CREWHU_APITOKEN` |
+| 403 | Token valid but not authorized for this resource | Check token scope |
+| 404 | Unknown survey / user / badge / prize ID | Re-list to confirm |
+| 429 | Rate limit | Back off and retry |
+
+## Best Practices
+
+- Treat almost every Crewhu tool as read-only — only
+  `crewhu_badges_update_contest` mutates data; flag it explicitly
+  before invoking.
+- For CSAT trend analysis, pull a wide enough window
+  (last 90 days minimum) to avoid sampling noise.
+- For multi-team MSPs, group survey results by user/team after fetching.
+
+## Related Skills
+
+- [surveys](../surveys/SKILL.md) - CSAT/NPS analysis (the primary skill)

--- a/msp-claude-plugins/crewhu/crewhu/skills/surveys/SKILL.md
+++ b/msp-claude-plugins/crewhu/crewhu/skills/surveys/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: "Crewhu Surveys"
+when_to_use: "When analyzing CSAT/NPS surveys, drilling into detractors and promoters, or pulling per-user / per-team satisfaction trends from Crewhu"
+description: >
+  Use this skill when working with Crewhu CSAT/NPS surveys — listing
+  recent responses, drilling into a specific survey, isolating
+  detractors and promoters for follow-up, and rolling responses up by
+  user.
+triggers:
+  - crewhu csat
+  - crewhu nps
+  - crewhu survey
+  - crewhu detractor
+  - crewhu promoter
+  - csat trend
+  - customer satisfaction crewhu
+  - nps score
+---
+
+# Crewhu Surveys (CSAT / NPS)
+
+Surveys are Crewhu's primary product — short CSAT/NPS responses tied
+to a ticket close, a specific tech, or a project milestone. This skill
+covers listing surveys, finding a specific one, and isolating the two
+ends of the curve (detractors and promoters) so MSP managers can react.
+
+## API Tools
+
+### List & Search
+
+| Tool | Purpose |
+|------|---------|
+| `crewhu_surveys_list` | Paginated list of recent survey responses |
+| `crewhu_surveys_search` | Search surveys by keyword / metadata |
+| `crewhu_surveys_get` | Pull full detail for one survey response |
+
+### Sentiment Slices
+
+| Tool | Purpose |
+|------|---------|
+| `crewhu_surveys_detractors` | Detractor responses (low scores / negative comments) |
+| `crewhu_surveys_promoters` | Promoter responses (high scores / positive comments) |
+
+## Common Workflows
+
+### Pull recent survey trend
+
+1. Call `crewhu_surveys_list` with a wide enough window (90 days
+   minimum).
+2. Bucket results by week and compute average score and response count.
+3. Surface the trend line, not just the latest week — single weeks are
+   noisy.
+
+### Detractor follow-up queue
+
+1. Call `crewhu_surveys_detractors` to get the negative responses.
+2. For each, call `crewhu_surveys_get` to retrieve the full comment
+   and the responsible technician (the responses include user
+   attribution — cross-reference with `crewhu_users_get`).
+3. Produce a follow-up list: customer, ticket, tech, score, comment,
+   suggested action (call-back, account-manager hand-off, escalation).
+
+### Promoter recognition loop
+
+1. Call `crewhu_surveys_promoters` to find positive responses.
+2. Use the responsible tech to drive a recognition workflow:
+   - `crewhu_badges_user_recognition` to see whether the tech is
+     already trending in recognition.
+   - Consider awarding a badge via the `badges` domain (see
+     `crewhu_badges_history_list`).
+
+### Per-user roll-up
+
+1. Use `crewhu_users_list` to enumerate techs.
+2. For each tech, use `crewhu_surveys_search` (keyed on the user) to
+   pull their responses.
+3. Compute average score, response count, and detractor rate per tech
+   for a manager scorecard.
+
+## Edge Cases
+
+- **Sparse responses** — Some techs have few surveys; flag any
+  per-user metrics with N < 10 as low-confidence rather than ranking.
+- **Comment-only feedback** — Some responses have a comment without a
+  score. Surface those separately; do not coerce them into the score
+  average.
+- **Time zones** — Survey timestamps are in the tenant's configured
+  zone; normalize before comparing across tenants.
+
+## Best Practices
+
+- Always show denominators (response count) alongside averages.
+- Pair detractor lists with promoter lists in a manager dashboard so
+  the picture is balanced.
+- Capture the tech for every response in your output so action items
+  are unambiguous.
+
+## Related Skills
+
+- [api-patterns](../api-patterns/SKILL.md) - Auth and pagination

--- a/msp-claude-plugins/docs/src/pages/index.astro
+++ b/msp-claude-plugins/docs/src/pages/index.astro
@@ -45,7 +45,7 @@ const faqs = [
   },
   {
     question: "Are MSP Claude Plugins free?",
-    answer: "Yes, all MSP Claude Plugins are free and open source under the Apache 2.0 license. Community contributions are welcome."
+    answer: "The open-source MSP Claude Plugins (the skills, commands, and self-hostable MCP servers in this collection) are free under the Apache 2.0 license. The hosted WYRE Gateway is a separate paid managed service — see the Pro, Business, and Enterprise plans on the Pricing page. Community contributions to the OSS plugins are welcome."
   },
   {
     question: "What is the Model Context Protocol (MCP)?",
@@ -332,7 +332,7 @@ const features = [
       </div>
 
       <p class="text-center text-sm text-[var(--muted)] mt-8">
-        Need a custom plan? <a href="mailto:sales@wyre.technology" class="text-accent hover:underline">Get in touch.</a>
+        Need a custom plan? <a href="mailto:sales@wyre.ai" class="text-accent hover:underline">Get in touch.</a>
       </p>
     </div>
   </section>

--- a/msp-claude-plugins/docs/src/pages/privacy.astro
+++ b/msp-claude-plugins/docs/src/pages/privacy.astro
@@ -5,8 +5,8 @@ import Footer from '@/components/Footer.astro';
 ---
 
 <BaseLayout
-  title="Privacy Policy - Wyre Technology"
-  description="Privacy Policy for the Wyre Technology MCP Gateway and MSP Claude Plugins."
+  title="Privacy Policy - WYRE Technology"
+  description="Privacy Policy for the WYRE Technology MCP Gateway and MSP Claude Plugins."
 >
   <Header />
 

--- a/msp-claude-plugins/docs/src/pages/terms.astro
+++ b/msp-claude-plugins/docs/src/pages/terms.astro
@@ -5,8 +5,8 @@ import Footer from '@/components/Footer.astro';
 ---
 
 <BaseLayout
-  title="Terms of Service - Wyre Technology"
-  description="Terms of Service for the Wyre Technology MCP Gateway and MSP Claude Plugins."
+  title="Terms of Service - WYRE Technology"
+  description="Terms of Service for the WYRE Technology MCP Gateway and MSP Claude Plugins."
 >
   <Header />
 

--- a/msp-claude-plugins/immybot/immybot/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/immybot/immybot/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "immybot",
+  "version": "1.0.0",
+  "description": "ImmyBot - desired-state Windows software deployment, maintenance sessions, and script execution for MSPs (Entra ID OAuth)",
+  "author": {
+    "name": "WYRE Technology"
+  },
+  "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
+  "repository": "https://github.com/wyre-technology/msp-claude-plugins",
+  "license": "Apache-2.0"
+}

--- a/msp-claude-plugins/immybot/immybot/.mcp.json
+++ b/msp-claude-plugins/immybot/immybot/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "immybot": {
+      "type": "http",
+      "url": "https://mcp.wyretechnology.com/v1/immybot/mcp",
+      "headers": {
+        "X-Immybot-Instance-Subdomain": "${IMMYBOT_INSTANCE_SUBDOMAIN}",
+        "X-Immybot-Tenant-Id": "${IMMYBOT_TENANT_ID}",
+        "X-Immybot-Client-Id": "${IMMYBOT_CLIENT_ID}",
+        "X-Immybot-Client-Secret": "${IMMYBOT_CLIENT_SECRET}"
+      }
+    }
+  }
+}

--- a/msp-claude-plugins/immybot/immybot/README.md
+++ b/msp-claude-plugins/immybot/immybot/README.md
@@ -1,0 +1,100 @@
+# ImmyBot Plugin
+
+Claude Code plugin for [ImmyBot](https://immy.bot) - desired-state Windows software deployment for MSPs.
+
+## What It Does
+
+- **Software deployment** - Configure desired state for tenants or computers, then reconcile via maintenance sessions
+- **Maintenance sessions** - Start, pause, resume, cancel, and inspect reconciliation runs
+- **Scripts** - List, search, and (with care) execute PowerShell scripts; review execution history
+- **Computers** - Enrolled-endpoint inventory, per-computer deployment view, force check-in
+- **Tenants** - MSP-level scoping for software inventory and compliance
+- **Tasks** - Lower-level work units feeding into maintenance sessions
+
+## Installation
+
+```
+/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin install immybot
+```
+
+The plugin connects through the [WYRE MCP Gateway](https://mcp.wyretechnology.com) at `https://mcp.wyretechnology.com/v1/immybot/mcp`.
+
+## Configuration
+
+ImmyBot uses Microsoft Entra ID (Azure AD) OAuth 2.0 client credentials. All four fields are required.
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `IMMYBOT_INSTANCE_SUBDOMAIN` | Yes | Your ImmyBot instance subdomain |
+| `IMMYBOT_TENANT_ID` | Yes | Microsoft Entra tenant UUID |
+| `IMMYBOT_CLIENT_ID` | Yes | Entra app registration client ID |
+| `IMMYBOT_CLIENT_SECRET` | Yes | Entra app registration client secret |
+
+## Skills
+
+- `api-patterns` - Auth, navigation, the desired-state model, polling
+- `software-deployment` - Primary skill: deploy software end-to-end
+
+## Commands
+
+- `/search-software` - Search the ImmyBot software catalog
+
+## Destructive Tools
+
+These tools mutate live customer infrastructure. Get human approval before invoking:
+
+- `immybot_scripts_run`
+- `immybot_deployments_trigger`
+- `immybot_software_install`
+- `immybot_maintenance_sessions_start`
+
+## Tools
+
+Provided by the ImmyBot MCP server through the WYRE MCP Gateway:
+
+### Navigation
+- `immybot_navigate`, `immybot_back`, `immybot_status`
+
+### Computers
+- `immybot_computers_list`, `immybot_computers_get`, `immybot_computers_search`, `immybot_computers_create`
+- `immybot_computers_inventory`, `immybot_computers_deployments`, `immybot_computers_trigger_checkin`
+
+### Software
+- `immybot_software_list`, `immybot_software_list_global`, `immybot_software_get`, `immybot_software_search`
+- `immybot_software_versions`, `immybot_software_latest_version`
+- `immybot_software_categories`, `immybot_software_publishers`
+- `immybot_software_install` (write), `immybot_software_stats`
+
+### Deployments
+- `immybot_deployments_list`, `immybot_deployments_get`, `immybot_deployments_create`
+- `immybot_deployments_trigger` (write), `immybot_deployments_compliance`
+- `immybot_deployments_for_computer`, `immybot_deployments_for_software`
+
+### Scripts
+- `immybot_scripts_list`, `immybot_scripts_get`, `immybot_scripts_search`
+- `immybot_scripts_run` (write), `immybot_scripts_categories`
+- `immybot_scripts_execution_history`, `immybot_scripts_execution_result`, `immybot_scripts_validate`
+
+### Tenants
+- `immybot_tenants_list`, `immybot_tenants_get`, `immybot_tenants_search`
+- `immybot_tenants_stats`, `immybot_tenants_computers`, `immybot_tenants_deployments`
+- `immybot_tenants_compliance`, `immybot_tenants_software_inventory`
+
+### Maintenance Sessions
+- `immybot_maintenance_sessions_list`, `immybot_maintenance_sessions_get`
+- `immybot_maintenance_sessions_start` (write), `immybot_maintenance_sessions_cancel`
+- `immybot_maintenance_sessions_pause`, `immybot_maintenance_sessions_resume`
+- `immybot_maintenance_sessions_logs`, `immybot_maintenance_sessions_results`
+- `immybot_maintenance_sessions_active`, `immybot_maintenance_sessions_summary`
+
+### Tasks
+- `immybot_tasks_list`, `immybot_tasks_get`, `immybot_tasks_history`, `immybot_tasks_logs`
+- `immybot_tasks_queued`, `immybot_tasks_running`, `immybot_tasks_failed`
+- `immybot_tasks_for_computer`, `immybot_tasks_for_tenant`, `immybot_tasks_by_type`
+- `immybot_tasks_child_tasks`, `immybot_tasks_dependencies`
+- `immybot_tasks_estimated_completion`, `immybot_tasks_queue_stats`, `immybot_tasks_metrics`
+
+## License
+
+Apache-2.0

--- a/msp-claude-plugins/immybot/immybot/commands/search-software.md
+++ b/msp-claude-plugins/immybot/immybot/commands/search-software.md
@@ -1,0 +1,48 @@
+---
+name: search-software
+description: Search the ImmyBot software catalog (per-tenant + global)
+arguments:
+  - name: query
+    description: Software name or keyword
+    required: true
+---
+
+# ImmyBot Software Search
+
+Search the ImmyBot software catalog before configuring a deployment, to confirm a publisher / version exists and is the canonical entry to target.
+
+## Prerequisites
+
+- ImmyBot MCP server connected with valid `IMMYBOT_INSTANCE_SUBDOMAIN`, `IMMYBOT_TENANT_ID`, `IMMYBOT_CLIENT_ID`, `IMMYBOT_CLIENT_SECRET`
+- Tools available: `immybot_software_search`, `immybot_software_get`, `immybot_software_versions`, `immybot_software_latest_version`
+
+## Steps
+
+1. **Search the catalog**
+
+   Call `immybot_software_search` with `query`.
+
+2. **Drill into the candidate**
+
+   For each result, optionally call `immybot_software_get` for full detail.
+
+3. **List versions**
+
+   For the chosen software, call `immybot_software_versions` and `immybot_software_latest_version` so the operator can pick a pinned version or track latest.
+
+4. **Output**
+
+   - Top matches (name, publisher, software ID)
+   - For each: latest version, total versions available
+   - Suggested next step: pass the software ID to a deployment workflow
+
+## Examples
+
+### Find Adobe Reader entries
+```
+/search-software "Adobe Reader"
+```
+
+## Related Commands
+
+- (none yet)

--- a/msp-claude-plugins/immybot/immybot/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/immybot/immybot/skills/api-patterns/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: "ImmyBot API Patterns"
+when_to_use: "When working with ImmyBot authentication (Entra ID OAuth client credentials), the desired-state model, destructive write operations, or task / maintenance-session polling"
+description: >
+  Use this skill when working with the ImmyBot MCP tools — Entra ID
+  OAuth 2.0 client-credentials authentication (4 fields), the
+  two-step desired-state deployment model, destructive operations
+  that need explicit confirmation, and the task/session polling
+  cadence.
+triggers:
+  - immybot api
+  - immybot authentication
+  - immybot oauth
+  - immybot entra
+  - immybot mcp
+  - immybot desired state
+  - immybot maintenance session
+---
+
+# ImmyBot MCP Tools & API Patterns
+
+## Overview
+
+ImmyBot is a desired-state software deployment platform for Windows
+endpoints. You configure what should be installed at the tenant or
+computer level, then a maintenance session reconciles the live state
+to the desired state. The MCP surface mirrors that model — listing
+and configuring desired state is one set of tools; running and
+inspecting maintenance sessions is another.
+
+## Connection & Authentication
+
+ImmyBot uses Microsoft Entra ID (Azure AD) OAuth 2.0 client
+credentials. Four fields are required:
+
+| Variable | Description |
+|----------|-------------|
+| `IMMYBOT_INSTANCE_SUBDOMAIN` | Your ImmyBot instance subdomain (e.g. `acme` for `acme.immy.bot`) |
+| `IMMYBOT_TENANT_ID` | Microsoft Entra tenant UUID |
+| `IMMYBOT_CLIENT_ID` | App registration client ID |
+| `IMMYBOT_CLIENT_SECRET` | App registration client secret |
+
+The gateway exchanges these for a token automatically. Token cache is
+managed gateway-side; you should not need to think about token
+refresh.
+
+## Navigation Tools
+
+| Tool | Purpose |
+|------|---------|
+| `immybot_navigate` | Discover available domains |
+| `immybot_back` | Pop back to the prior context |
+| `immybot_status` | Health/status check |
+
+## Functional Tool Surface
+
+Tools follow `immybot_<domain>_<action>`. Domains:
+
+- `computers` - Enrolled Windows endpoints
+- `software` - Software catalog (per-tenant + global)
+- `deployments` - Desired-state assignments (the "what should be installed")
+- `scripts` - PowerShell scripts and execution history
+- `tenants` - MSP-level tenant scoping
+- `maintenance_sessions` - The reconciliation runs (active, paused, etc.)
+- `tasks` - Lower-level work units inside sessions
+
+## The Two-Step Desired-State Model
+
+This is the most important concept in ImmyBot. Software does not get
+installed by a single API call. Instead:
+
+1. **Configure desired state** — Use `immybot_deployments_create`
+   (or update an existing deployment) to assert: "Software X should
+   be installed at version Y on this scope."
+2. **Reconcile** — A maintenance session runs (either on schedule, or
+   triggered via `immybot_maintenance_sessions_start`) and brings
+   the endpoints in scope into compliance with the desired state.
+
+If you skip step 2, nothing happens on the endpoint. If you skip
+step 1 and try to "install software directly," there is no API for
+that — the platform is desired-state by design.
+
+## Destructive Operations
+
+The following tools mutate live customer infrastructure. Always
+confirm with a human before invoking:
+
+- `immybot_scripts_run` - Executes a PowerShell script on endpoints
+- `immybot_deployments_trigger` - Forces deployment evaluation
+- `immybot_software_install` - Triggers software install via desired state
+- `immybot_maintenance_sessions_start` - Starts a reconciliation run
+
+For all four, log who approved, the scope (computer / tenant), and
+the expected outcome before calling.
+
+## Polling Tasks and Sessions
+
+`immybot_maintenance_sessions_start` and similar tools return
+quickly with a session/task ID. Actual progress is observed by
+polling:
+
+- `immybot_maintenance_sessions_get` - Snapshot of one session
+- `immybot_maintenance_sessions_logs` - Log lines so far
+- `immybot_maintenance_sessions_results` - Final outcome
+- `immybot_tasks_get`, `immybot_tasks_logs` - Lower-level task detail
+
+Reasonable cadence: 10-15s while a session is `running`, stop once it
+reaches a terminal state.
+
+## Error Handling
+
+| Status | Meaning | Action |
+|--------|---------|--------|
+| 401 | Bad client credentials or expired token | Recheck the four creds; gateway refreshes tokens |
+| 403 | App registration lacks the right ImmyBot permissions | Check ImmyBot RBAC for the app |
+| 404 | Unknown computer / software / deployment | Re-list to confirm |
+| 409 | Conflicting maintenance session already running | Wait or cancel the existing one |
+| 429 | Rate limit | Back off and retry |
+
+## Best Practices
+
+- Treat ImmyBot deployments as code: configure desired state, then
+  let maintenance reconcile.
+- For MSP work, scope by tenant first (`immybot_tenants_get`) and
+  pivot down — never modify deployments without confirming the
+  tenant.
+- Always pull `immybot_maintenance_sessions_results` after a session
+  to see which endpoints succeeded vs failed.
+
+## Related Skills
+
+- [software-deployment](../software-deployment/SKILL.md) - Primary skill, the desired-state workflow

--- a/msp-claude-plugins/immybot/immybot/skills/software-deployment/SKILL.md
+++ b/msp-claude-plugins/immybot/immybot/skills/software-deployment/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: "ImmyBot Software Deployment"
+when_to_use: "When deploying software to Windows endpoints via ImmyBot, configuring desired state, running maintenance sessions, or auditing per-computer compliance"
+description: >
+  Use this skill when configuring desired-state software deployments
+  in ImmyBot — picking the software, scoping the deployment to a
+  tenant or computer, kicking off a maintenance session to reconcile,
+  and checking compliance afterwards.
+triggers:
+  - immybot deploy
+  - immybot install
+  - immybot software
+  - immybot maintenance
+  - deploy software immybot
+  - immybot compliance
+  - desired state windows software
+---
+
+# ImmyBot Software Deployment
+
+This is ImmyBot's headline capability. The model is desired-state:
+you assert what should be installed, then a maintenance session
+brings the endpoint into compliance. This skill walks the canonical
+deployment workflow end-to-end.
+
+## API Tools
+
+### Discover the catalog
+
+| Tool | Purpose |
+|------|---------|
+| `immybot_software_list` | Per-tenant software catalog |
+| `immybot_software_list_global` | Global ImmyBot software catalog |
+| `immybot_software_search` | Search by name |
+| `immybot_software_get` | Full detail for one software |
+| `immybot_software_versions` | Available versions for a software |
+| `immybot_software_latest_version` | The current "latest" version |
+| `immybot_software_categories` | Browse by category |
+| `immybot_software_publishers` | Browse by publisher |
+| `immybot_software_stats` | Usage stats across the fleet |
+
+### Configure desired state
+
+| Tool | Purpose |
+|------|---------|
+| `immybot_deployments_list` | Current deployments |
+| `immybot_deployments_get` | Detail for a deployment |
+| `immybot_deployments_create` | Assert new desired state |
+| `immybot_deployments_for_computer` | Deployments scoped to a computer |
+| `immybot_deployments_for_software` | Deployments scoped to a software |
+| `immybot_deployments_compliance` | Compliance report for a deployment |
+| `immybot_deployments_trigger` | Force immediate reconciliation (destructive) |
+| `immybot_software_install` | Install a software via desired state (destructive) |
+
+### Reconcile
+
+| Tool | Purpose |
+|------|---------|
+| `immybot_maintenance_sessions_list` | Recent sessions |
+| `immybot_maintenance_sessions_get` | One session snapshot |
+| `immybot_maintenance_sessions_start` | Start a session (destructive) |
+| `immybot_maintenance_sessions_pause` | Pause a running session |
+| `immybot_maintenance_sessions_resume` | Resume a paused session |
+| `immybot_maintenance_sessions_cancel` | Cancel a session |
+| `immybot_maintenance_sessions_logs` | Log stream |
+| `immybot_maintenance_sessions_results` | Final outcome |
+| `immybot_maintenance_sessions_active` | Currently active sessions |
+| `immybot_maintenance_sessions_summary` | Summary metrics |
+
+### Computers in scope
+
+| Tool | Purpose |
+|------|---------|
+| `immybot_computers_list` | Enrolled computers |
+| `immybot_computers_get` | One computer detail |
+| `immybot_computers_search` | Search by name |
+| `immybot_computers_inventory` | Installed software on a computer |
+| `immybot_computers_deployments` | Deployments hitting a computer |
+| `immybot_computers_trigger_checkin` | Force a check-in |
+
+## The Canonical Deployment Workflow
+
+### 1. Identify the software
+
+```
+immybot_software_search → immybot_software_get → immybot_software_latest_version
+```
+
+Confirm the software exists in the catalog and what version you intend
+to deploy.
+
+### 2. Identify the scope
+
+For tenant-wide rollouts:
+```
+immybot_tenants_get → immybot_tenants_computers
+```
+
+For a single computer:
+```
+immybot_computers_search → immybot_computers_get
+```
+
+### 3. Configure desired state
+
+Call `immybot_deployments_create` with the chosen software, version,
+and scope. The deployment now exists, but nothing has happened on
+the endpoint yet.
+
+### 4. Reconcile
+
+Either wait for the next scheduled maintenance window, or trigger
+immediately:
+
+```
+immybot_maintenance_sessions_start
+```
+
+This is destructive — get human approval first.
+
+### 5. Watch the session
+
+Poll `immybot_maintenance_sessions_get` and tail
+`immybot_maintenance_sessions_logs`. Stop polling once the session is
+in a terminal state.
+
+### 6. Confirm compliance
+
+Call `immybot_deployments_compliance` to see which computers in
+scope reached the desired state and which failed.
+
+## Other Common Workflows
+
+### Per-computer audit
+
+1. `immybot_computers_get` for the computer
+2. `immybot_computers_inventory` for installed software
+3. `immybot_computers_deployments` for what desired-state expects
+4. Reconcile differences
+
+### Per-tenant compliance scorecard
+
+1. `immybot_tenants_get`
+2. `immybot_tenants_compliance` for the rollup
+3. Drill into failing deployments via `immybot_deployments_compliance`
+
+### Investigate a failed install
+
+1. Identify the maintenance session: `immybot_maintenance_sessions_list`
+2. `immybot_maintenance_sessions_results` for outcome
+3. `immybot_maintenance_sessions_logs` for the failing log lines
+4. Cross-reference with `immybot_tasks_logs` for lower-level detail
+
+## Edge Cases
+
+- **Pinned versions vs latest** - A deployment can pin a specific
+  version or track latest. Always confirm which mode you are in
+  before changing the desired version.
+- **Conflicting deployments** - Two deployments hitting the same
+  software on the same scope can fight. Use
+  `immybot_deployments_for_computer` to spot conflicts before adding
+  a new one.
+- **Reboot requirements** - Some installs require a reboot. Maintenance
+  sessions handle this, but expect the session to span longer than the
+  install itself.
+
+## Best Practices
+
+- Prefer tenant-scoped deployments over per-computer deployments for
+  fleet-wide software; reserve per-computer for exceptions.
+- Always run a small pilot (one or two computers) before triggering a
+  fleet-wide maintenance session.
+- For destructive operations, log the approver, the scope, and the
+  expected outcome.
+
+## Related Skills
+
+- [api-patterns](../api-patterns/SKILL.md) - Auth and the desired-state model

--- a/msp-claude-plugins/timezest/timezest/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/timezest/timezest/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "timezest",
+  "version": "1.0.0",
+  "description": "TimeZest - tech scheduling and appointment booking against ConnectWise / Autotask / Halo PSA tickets for MSPs",
+  "author": {
+    "name": "WYRE Technology"
+  },
+  "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
+  "repository": "https://github.com/wyre-technology/msp-claude-plugins",
+  "license": "Apache-2.0"
+}

--- a/msp-claude-plugins/timezest/timezest/.mcp.json
+++ b/msp-claude-plugins/timezest/timezest/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "timezest": {
+      "type": "http",
+      "url": "https://mcp.wyretechnology.com/v1/timezest/mcp",
+      "headers": {
+        "Authorization": "Bearer ${TIMEZEST_API_TOKEN}"
+      }
+    }
+  }
+}

--- a/msp-claude-plugins/timezest/timezest/.mcp.json
+++ b/msp-claude-plugins/timezest/timezest/.mcp.json
@@ -4,7 +4,7 @@
       "type": "http",
       "url": "https://mcp.wyretechnology.com/v1/timezest/mcp",
       "headers": {
-        "Authorization": "Bearer ${TIMEZEST_API_TOKEN}"
+        "X-Timezest-Api-Token": "${TIMEZEST_API_TOKEN}"
       }
     }
   }

--- a/msp-claude-plugins/timezest/timezest/README.md
+++ b/msp-claude-plugins/timezest/timezest/README.md
@@ -1,0 +1,61 @@
+# TimeZest Plugin
+
+Claude Code plugin for [TimeZest](https://timezest.com) - PSA-coupled customer scheduling for MSP technicians.
+
+## What It Does
+
+- **Book a tech against a PSA ticket** - Create a TimeZest scheduling request that links to a ConnectWise / Autotask / Halo ticket so the customer can self-serve their slot
+- **Track scheduling requests** - Sent / clicked / booked / canceled lifecycle visibility
+- **Manage agents, teams, appointment types** - Resolve the right tech and the right kind of appointment for a given ticket
+- **Cancel pending bookings** - Revoke an outstanding customer link
+
+## Installation
+
+```
+/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin install timezest
+```
+
+The plugin connects through the [WYRE MCP Gateway](https://mcp.wyretechnology.com) at `https://mcp.wyretechnology.com/v1/timezest/mcp`.
+
+## Configuration
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `TIMEZEST_API_TOKEN` | Yes | TimeZest API token (sent as `Authorization: Bearer ...`) |
+
+## Skills
+
+- `api-patterns` - Auth, navigation, polling, PSA association payload
+- `scheduling` - Primary booking workflow against ConnectWise / Autotask / Halo
+
+## Commands
+
+- `/search-scheduling` - List recent scheduling requests grouped by state
+
+## Tools
+
+Provided by the TimeZest MCP server through the WYRE MCP Gateway:
+
+### Navigation
+- `timezest_navigate`, `timezest_back`, `timezest_status`
+
+### Agents
+- `timezest_agents_list`, `timezest_agents_get`
+
+### Teams
+- `timezest_teams_list`, `timezest_teams_get`
+
+### Appointment Types
+- `timezest_appointment_types_list`, `timezest_appointment_types_get`
+
+### Resources
+- `timezest_resources_list`
+
+### Scheduling
+- `timezest_scheduling_list`, `timezest_scheduling_get`
+- `timezest_scheduling_create_request`, `timezest_scheduling_cancel`
+
+## License
+
+Apache-2.0

--- a/msp-claude-plugins/timezest/timezest/commands/search-scheduling.md
+++ b/msp-claude-plugins/timezest/timezest/commands/search-scheduling.md
@@ -1,0 +1,53 @@
+---
+name: search-scheduling
+description: List recent TimeZest scheduling requests, grouped by state
+arguments:
+  - name: state
+    description: Optional state filter (sent / booked / canceled / expired)
+    required: false
+---
+
+# TimeZest Scheduling Search
+
+Pull recent TimeZest scheduling requests and produce a dispatch-friendly summary grouped by lifecycle state.
+
+## Prerequisites
+
+- TimeZest MCP server connected with a valid `TIMEZEST_API_TOKEN`
+- Tools available: `timezest_scheduling_list`, `timezest_scheduling_get`
+
+## Steps
+
+1. **List recent requests**
+
+   Call `timezest_scheduling_list`.
+
+2. **Group by state**
+
+   Bucket results: sent (waiting on customer), booked (confirmed), canceled, expired.
+
+3. **Drill into stuck requests**
+
+   For any request that has been "sent" for more than a working day, call `timezest_scheduling_get` to confirm and call out the PSA ticket from `associated_entities` so dispatch can chase the customer.
+
+4. **Output**
+
+   - Counts per state
+   - Stuck-request list (PSA ticket, agent, age)
+   - Today's bookings (agent, customer, appointment type, start time)
+
+## Examples
+
+### All recent scheduling activity
+```
+/search-scheduling
+```
+
+### Only the stuck "sent" queue
+```
+/search-scheduling sent
+```
+
+## Related Commands
+
+- (none yet)

--- a/msp-claude-plugins/timezest/timezest/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/timezest/timezest/skills/api-patterns/SKILL.md
@@ -28,11 +28,16 @@ when the customer picks a slot.
 
 ## Connection & Authentication
 
-TimeZest uses Bearer token authentication:
+TimeZest uses an API token passed via header.
 
 | Header | Value |
 |--------|-------|
-| `Authorization` | `Bearer <token>` |
+| `X-Timezest-Api-Token` | The raw TimeZest API token |
+
+The gateway maps the environment variable `TIMEZEST_API_TOKEN` onto
+the `X-Timezest-Api-Token` header automatically. Internally, the
+TimeZest MCP server forwards this to TimeZest as a `Bearer` token — you
+do not need to add the `Bearer ` prefix yourself.
 
 ```bash
 export TIMEZEST_API_TOKEN="your-timezest-token"

--- a/msp-claude-plugins/timezest/timezest/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/timezest/timezest/skills/api-patterns/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: "TimeZest API Patterns"
+when_to_use: "When working with TimeZest authentication, scheduling request payloads, PSA entity associations, or polling cadence for status changes"
+description: >
+  Use this skill when working with the TimeZest MCP tools — Bearer
+  token authentication, the navigation pattern, scheduling-request
+  payloads that carry PSA associated_entities (ConnectWise / Autotask
+  / Halo ticket IDs), and the polling-only update model (no webhooks).
+triggers:
+  - timezest api
+  - timezest authentication
+  - timezest bearer
+  - timezest scheduling
+  - timezest mcp
+  - timezest associated entities
+  - timezest poll
+---
+
+# TimeZest MCP Tools & API Patterns
+
+## Overview
+
+TimeZest provides scheduling-request flows tightly coupled to MSP PSA
+systems. A scheduling request is created against a PSA ticket
+(ConnectWise / Autotask / Halo), TimeZest sends the customer a
+self-service booking link, and the technician's calendar is updated
+when the customer picks a slot.
+
+## Connection & Authentication
+
+TimeZest uses Bearer token authentication:
+
+| Header | Value |
+|--------|-------|
+| `Authorization` | `Bearer <token>` |
+
+```bash
+export TIMEZEST_API_TOKEN="your-timezest-token"
+```
+
+## Navigation Tools
+
+| Tool | Purpose |
+|------|---------|
+| `timezest_navigate` | Discover the available domains |
+| `timezest_back` | Pop back to the prior context |
+| `timezest_status` | Health/status check |
+
+## Functional Tool Surface
+
+Tools follow `timezest_<domain>_<action>`. Domains:
+
+- `agents` (technicians)
+- `teams`
+- `appointment_types`
+- `resources`
+- `scheduling` (the primary domain)
+
+## Scheduling Request Payload — `associated_entities`
+
+This is the most important pattern. When you call
+`timezest_scheduling_create_request`, the payload carries an
+`associated_entities` array that links the booking to a PSA record:
+
+```json
+{
+  "associated_entities": [
+    {
+      "type": "ConnectWiseTicket",
+      "id": 12345
+    }
+  ]
+}
+```
+
+Supported PSA types: ConnectWise tickets, Autotask tickets, Halo
+tickets. Always include the PSA association so the tech's PSA shows
+the booking.
+
+## Polling, Not Webhooks
+
+TimeZest's MCP surface is poll-only. To track a booking's lifecycle
+(sent / clicked / booked / canceled), call
+`timezest_scheduling_get` on a cadence. Reasonable cadence:
+
+- Every 1-2 minutes for "active" requests in the first hour.
+- Every 10-15 minutes for the rest of the day.
+- Stop polling once the request is in a terminal state.
+
+Do not assume a webhook will arrive — none does at the MCP layer.
+
+## Error Handling
+
+| Status | Meaning | Action |
+|--------|---------|--------|
+| 401 | Bad/missing Bearer token | Re-check `TIMEZEST_API_TOKEN` |
+| 403 | Token valid but not authorized for the agent/team | Check token scope |
+| 404 | Unknown agent / team / scheduling request | Re-list to confirm |
+| 422 | Bad payload (missing PSA association, invalid appointment_type) | Validate input |
+
+## Best Practices
+
+- Always pass a PSA `associated_entities` entry — a booking with no
+  PSA association is hard to find later.
+- Resolve the agent and appointment_type via list calls before
+  creating a request; do not hard-code IDs.
+- For "book against this ticket" workflows, accept the PSA ticket ID
+  as the primary input and resolve agent/team/appointment from
+  context.
+
+## Related Skills
+
+- [scheduling](../scheduling/SKILL.md) - Booking technicians against PSA tickets

--- a/msp-claude-plugins/timezest/timezest/skills/scheduling/SKILL.md
+++ b/msp-claude-plugins/timezest/timezest/skills/scheduling/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: "TimeZest Scheduling"
+when_to_use: "When booking a technician's time against a PSA ticket through TimeZest, checking status of a scheduling request, or canceling a pending request"
+description: >
+  Use this skill to book a technician against a ConnectWise / Autotask
+  / Halo PSA ticket via TimeZest — resolving the right agent and
+  appointment type, creating a scheduling request, polling its status,
+  and canceling when needed.
+triggers:
+  - timezest book
+  - timezest schedule
+  - book a tech
+  - schedule a technician
+  - timezest appointment
+  - send timezest link
+  - timezest cancel
+---
+
+# TimeZest Scheduling
+
+The "book a tech against this PSA ticket" workflow is what TimeZest
+exists for. This skill walks the canonical flow: resolve the agent,
+resolve the appointment type, create the scheduling request with the
+PSA association, then poll for the customer's response.
+
+## API Tools
+
+### Resolve the actors
+
+| Tool | Purpose |
+|------|---------|
+| `timezest_agents_list` | List available technicians |
+| `timezest_agents_get` | Detail for a specific agent |
+| `timezest_teams_list` | List teams (round-robin / shared availability) |
+| `timezest_teams_get` | Detail for a specific team |
+| `timezest_appointment_types_list` | List bookable appointment types |
+| `timezest_appointment_types_get` | Detail for one appointment type |
+| `timezest_resources_list` | List resources (rooms / shared assets) |
+
+### Manage scheduling requests
+
+| Tool | Purpose |
+|------|---------|
+| `timezest_scheduling_list` | List recent scheduling requests |
+| `timezest_scheduling_get` | Pull current state of one request |
+| `timezest_scheduling_create_request` | Create a new request (sends customer link) |
+| `timezest_scheduling_cancel` | Cancel a pending request |
+
+## Common Workflows
+
+### Book a tech against a PSA ticket
+
+1. Resolve the technician:
+   - If a name was given, call `timezest_agents_list` and match.
+   - If a team was given, call `timezest_teams_list`.
+2. Resolve the appointment type:
+   - Call `timezest_appointment_types_list` and pick the one that
+     matches the ticket type (e.g. "Onsite Visit", "Remote Session").
+3. Create the request:
+   - Call `timezest_scheduling_create_request` with:
+     - `agent_id` or `team_id`
+     - `appointment_type_id`
+     - `associated_entities` linking to the PSA ticket
+4. Capture the returned scheduling request ID for follow-up.
+
+### Track a pending request
+
+1. Call `timezest_scheduling_get` with the request ID.
+2. Inspect the state to determine: sent / clicked / booked / canceled
+   / expired.
+3. If the request has been clicked but not booked after a reasonable
+   window, surface that to the dispatcher — the link may need to be
+   resent.
+
+### Cancel a request
+
+1. Call `timezest_scheduling_get` to confirm current state.
+2. Call `timezest_scheduling_cancel` to revoke the customer link.
+3. Notify the originator (dispatcher or AM).
+
+### List recent activity
+
+1. Call `timezest_scheduling_list`.
+2. Group by status to give dispatch a queue view: how many sent,
+   how many waiting on the customer, how many booked today.
+
+## Edge Cases
+
+- **No availability** - If an agent has no slots in the requested
+  window, TimeZest still creates a request but the customer will
+  see "no times available". Surface the agent's calendar gap to the
+  dispatcher.
+- **Multiple PSA systems** - One MSP may run more than one PSA in
+  parallel. Always set the correct `associated_entities.type`.
+- **Cancellation race** - A customer may book a slot in the same
+  second a dispatcher cancels. Always re-fetch state after a cancel
+  call.
+
+## Best Practices
+
+- Never create a scheduling request without a PSA association.
+- Resolve agent and appointment_type by name through list calls in
+  the same session; do not cache IDs across days.
+- Treat the scheduling request as the source of truth, not the PSA
+  ticket - the PSA only sees the booking after it is confirmed.
+
+## Related Skills
+
+- [api-patterns](../api-patterns/SKILL.md) - Auth, polling, and PSA association


### PR DESCRIPTION
## Summary
Adds Claude Code plugins for the 4 Wave 1 MCP gateway vendors registered in [wyre-technology/mcp-gateway#75](https://github.com/wyre-technology/mcp-gateway/pull/75).

Mirrors the existing `threatlocker` plugin shape: `.claude-plugin/plugin.json`, `skills/api-patterns/`, `skills/<primary-domain>/`, `commands/search-*.md`, `.mcp.json`, `README.md`.

## What's added

| Vendor | Category | Primary skill | Tools surfaced |
|---|---|---|---|
| **Blackpoint Cyber** (CompassOne MDR) | security | `incident-response` | 14 functional (tenants, assets, detections, vulnerabilities) — 7 stub domains explicitly excluded |
| **Crewhu** | productivity | `surveys` | 18 (CSAT/NPS, recognition, gamification) |
| **ImmyBot** | rmm | `software-deployment` | ~60 across 7 domains (computers, software, deployments, scripts, tenants, maintenance_sessions, tasks) |
| **TimeZest** | productivity | `scheduling` | 14 (PSA-coupled scheduling) |

All tool names referenced in skill docs are pulled directly from the MCP servers' `domains/*.ts` definitions — no inventions.

## Marketplace

`marketplace.json` bumped 1.1.1 → 1.2.0 with 4 new entries.

## Auth headers (post-fix)

Each `.mcp.json` matches the gateway's `headerMapping` from [mcp-gateway#75](https://github.com/wyre-technology/mcp-gateway/pull/75):

| Vendor | Gateway env var | Gateway header |
|---|---|---|
| blackpoint | `BLACKPOINT_API_TOKEN` | `X-Blackpoint-Api-Token` |
| crewhu | `X_CREWHU_APITOKEN` | `X-Crewhu-Api-Token` |
| immybot | `IMMYBOT_INSTANCE_SUBDOMAIN`, `IMMYBOT_TENANT_ID`, `IMMYBOT_CLIENT_ID`, `IMMYBOT_CLIENT_SECRET` | 4 separate `X-Immybot-*` headers (OAuth client credentials via Entra ID) |
| timezest | `TIMEZEST_API_TOKEN` | `X-Timezest-Api-Token` |

Initial scaffold defaulted blackpoint and timezest to `Authorization: Bearer` (upstream-API form). Follow-up commit corrected them to the gateway-facing header. Skill docs updated to match.

## Test plan
- [ ] Once gateway PR #75 merges + deploys, `/plugin install <vendor>` from this marketplace should connect cleanly via `https://mcp.wyretechnology.com/v1/<vendor>/mcp`
- [ ] Each plugin's primary skill should match real tool names (verified against MCP server `domains/*.ts`)

## Related
- Gateway registration: wyre-technology/mcp-gateway#75
- SDKs: `@wyre-technology/node-{blackpoint,crewhu,immybot,timezest}@1.0.0` on GH Packages
- Container images: `ghcr.io/wyre-technology/{blackpoint,crewhu,immybot,timezest}-mcp:1.0.0`