### PR TITLE
chore(ci): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,12 +26,12 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: "20"
           cache: npm
@@ -40,7 +40,7 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3.0.1
         with:
           path: msp-claude-plugins/docs/dist
 
@@ -53,14 +53,14 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4.0.5
 
   notify-gateway:
     needs: deploy
     runs-on: ubuntu-latest
     steps:
       - name: Trigger mcp-gateway rebuild
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0  # v3.0.0
         with:
           token: ${{ secrets.GATEWAY_DISPATCH_TOKEN }}
           repository: wyre-technology/mcp-gateway


### PR DESCRIPTION
## Summary
- Pin every `uses:` reference in `.github/workflows/*` to a full commit SHA with a trailing semver comment.
- Defense against tag-repointing supply-chain attacks if a third-party action maintainer is compromised.

Closes #74
Closes #75

Note: issue #73 (ThreatLocker MCP endpoint) belongs to the `threatlocker-mcp` repo, not this one — addressing separately.

## Test plan
- [ ] CI: workflows still resolve and run on this PR (deploy-docs path filter won't trigger; claude.yml triggers only on @claude mentions).
- [ ] Manually verify each pinned SHA matches the commented semver via `gh api`.