### PR TITLE
fix(a11y): aria-labels, main landmark, contrast, heading-order, link-text

### DIFF
--- a/msp-claude-plugins/docs/src/components/Feedback.astro
+++ b/msp-claude-plugins/docs/src/components/Feedback.astro
@@ -32,7 +32,7 @@ const roadmapUrl = 'https://github.com/orgs/wyre-technology/projects/1';
 
 <div class="mt-12 pt-8 border-t border-[var(--border)]">
   <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-    <p class="text-sm text-[var(--muted)]">Was this page helpful? See our <a href={roadmapUrl} target="_blank" rel="noopener noreferrer" class="text-accent hover:underline">roadmap</a>.</p>
+    <p class="text-sm text-[var(--muted)]">Was this page helpful? See our <a href={roadmapUrl} target="_blank" rel="noopener noreferrer" class="text-accent underline">roadmap</a>.</p>
     <div class="flex items-center gap-3">
       <a
         href={`${issueBase}?${feedbackParams.toString()}`}

--- a/msp-claude-plugins/docs/src/components/Header.astro
+++ b/msp-claude-plugins/docs/src/components/Header.astro
@@ -106,6 +106,7 @@ function isExactActive(href?: string): boolean {
 
         <button
           id="search-button"
+          aria-label="Search documentation"
           class="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-[var(--border)] text-[var(--muted)] hover:text-[var(--text)] hover:border-[var(--text)] transition-colors"
         >
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -116,7 +117,7 @@ function isExactActive(href?: string): boolean {
           <kbd class="hidden sm:inline text-xs bg-[var(--border)] px-1.5 py-0.5 rounded">Ctrl K</kbd>
         </button>
 
-        <button data-theme-toggle class="p-2 rounded-lg hover:bg-[var(--border)] transition-colors">
+        <button data-theme-toggle aria-label="Toggle dark mode" class="p-2 rounded-lg hover:bg-[var(--border)] transition-colors">
           <svg class="w-5 h-5 hidden dark:block" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <circle cx="12" cy="12" r="5"/>
             <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/>
@@ -130,6 +131,7 @@ function isExactActive(href?: string): boolean {
           href="https://github.com/wyre-technology/msp-claude-plugins"
           target="_blank"
           rel="noopener noreferrer"
+          aria-label="View on GitHub"
           class="p-2 rounded-lg hover:bg-[var(--border)] transition-colors"
         >
           <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">

--- a/msp-claude-plugins/docs/src/components/InstallCommand.astro
+++ b/msp-claude-plugins/docs/src/components/InstallCommand.astro
@@ -21,6 +21,7 @@ const sizeClasses = {
   <button
     class="copy-btn ml-4 p-1.5 rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
     data-command={command}
+    aria-label="Copy install command to clipboard"
   >
     <svg class="copy-icon w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>

--- a/msp-claude-plugins/docs/src/components/McpServerCard.astro
+++ b/msp-claude-plugins/docs/src/components/McpServerCard.astro
@@ -59,7 +59,7 @@ const totalTools = server.domains.reduce((sum, d) => sum + d.tools.length, 0);
     <span>{server.domains.length} domains · {totalTools} tools</span>
     <span class="inline-flex items-center gap-2">
       {server.mcpbAvailable && (
-        <a href={`${server.repoUrl}/releases`} target="_blank" rel="noopener noreferrer" class="text-accent hover:underline" onclick="event.stopPropagation()">
+        <a href={`${server.repoUrl}/releases`} target="_blank" rel="noopener noreferrer" class="text-accent underline" onclick="event.stopPropagation()">
           MCPB
         </a>
       )}

--- a/msp-claude-plugins/docs/src/pages/index.astro
+++ b/msp-claude-plugins/docs/src/pages/index.astro
@@ -126,7 +126,7 @@ const features = [
             <svg class="w-5 h-5 text-green-600 dark:text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
             <span class="text-xs font-semibold uppercase tracking-wider text-green-600 dark:text-green-500">Recommended</span>
           </div>
-          <h3 class="text-xl font-bold mb-2">Use the Hosted Gateway</h3>
+          <h2 class="text-xl font-bold mb-2">Use the Hosted Gateway</h2>
           <p class="text-[var(--muted)] text-sm mb-4">
             Connect your MSP tools to Claude Desktop in minutes. No servers to manage — just add your API credentials and go.
           </p>
@@ -139,7 +139,7 @@ const features = [
             <svg class="w-5 h-5 text-[var(--muted)]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
             <span class="text-xs font-semibold uppercase tracking-wider text-[var(--muted)]">Self-Host</span>
           </div>
-          <h3 class="text-xl font-bold mb-2">Run Your Own MCP Servers</h3>
+          <h2 class="text-xl font-bold mb-2">Run Your Own MCP Servers</h2>
           <p class="text-[var(--muted)] text-sm mb-4">
             Full control with local MCP servers. Install the plugin collection and configure each integration yourself.
           </p>
@@ -231,7 +231,7 @@ const features = [
           </ul>
           <div class="flex flex-wrap gap-3">
             <a href={`${gatewayUrl}/auth/choose`} class="btn btn-primary text-sm">Get Started</a>
-            <a href={`${baseUrl}getting-started/gateway/`} class="btn btn-secondary text-sm">Learn More</a>
+            <a href={`${baseUrl}getting-started/gateway/`} class="btn btn-secondary text-sm">Learn more about the gateway</a>
           </div>
         </div>
 
@@ -335,7 +335,7 @@ const features = [
       </div>
 
       <p class="text-center text-sm text-[var(--muted)] mt-8">
-        Need a custom plan? <a href="mailto:sales@wyre.ai" class="text-accent hover:underline">Get in touch.</a>
+        Need a custom plan? <a href="mailto:sales@wyre.ai" class="text-accent underline">Get in touch.</a>
       </p>
     </div>
   </section>
@@ -380,7 +380,7 @@ const features = [
         </div>
 
         <p class="text-sm text-[var(--muted)]">
-          Or <a href={`${baseUrl}getting-started/installation/`} class="text-accent hover:underline">
+          Or <a href={`${baseUrl}getting-started/installation/`} class="text-accent underline">
             install individual plugins
           </a> if you only need one.
         </p>

--- a/msp-claude-plugins/docs/src/pages/index.astro
+++ b/msp-claude-plugins/docs/src/pages/index.astro
@@ -95,6 +95,7 @@ const features = [
   <OrganizationSchema />
   <Header />
 
+  <main id="main">
   <!-- Hero Section -->
   <section class="py-20 lg:py-32 bg-gradient-to-b from-cyan-50 to-transparent dark:from-cyan-950/20">
     <div class="container text-center">
@@ -386,6 +387,7 @@ const features = [
       </div>
     </div>
   </section>
+  </main>
 
   <Footer />
 </BaseLayout>

--- a/msp-claude-plugins/docs/src/pages/mcp-servers/[id].astro
+++ b/msp-claude-plugins/docs/src/pages/mcp-servers/[id].astro
@@ -83,7 +83,7 @@ const totalTools = server.domains.reduce((sum, d) => sum + d.tools.length, 0);
       <p class="text-sm font-medium mb-1">🔗 Companion Plugin</p>
       <p class="text-sm text-[var(--muted)]">
         Pair this MCP server with the{' '}
-        <a href={`${baseUrl}plugins/${companionPlugin.id}/`} class="text-accent hover:underline font-medium">
+        <a href={`${baseUrl}plugins/${companionPlugin.id}/`} class="text-accent underline font-medium">
           {companionPlugin.name} plugin
         </a>{' '}
         for skills, commands, and API knowledge alongside direct API access.

--- a/msp-claude-plugins/docs/src/pages/plugins/[id].astro
+++ b/msp-claude-plugins/docs/src/pages/plugins/[id].astro
@@ -97,7 +97,7 @@ const compatibilityBadges = {
       <p class="text-sm font-medium mb-1">🔌 Recommended MCP Server</p>
       <p class="text-sm text-[var(--muted)]">
         Pair this plugin with the{' '}
-        <a href={`${baseUrl}mcp-servers/${companionMcpServer.id}/`} class="text-accent hover:underline font-medium">
+        <a href={`${baseUrl}mcp-servers/${companionMcpServer.id}/`} class="text-accent underline font-medium">
           {companionMcpServer.name}
         </a>{' '}
         for direct API access alongside skills and commands.

--- a/msp-claude-plugins/docs/src/pages/pricing.astro
+++ b/msp-claude-plugins/docs/src/pages/pricing.astro
@@ -108,7 +108,7 @@ const faqs = [
       </div>
 
       <p class="text-center text-sm text-[var(--muted)] mt-8">
-        Need a custom plan? <a href="mailto:sales@wyre.ai" class="text-accent hover:underline">Get in touch.</a>
+        Need a custom plan? <a href="mailto:sales@wyre.ai" class="text-accent underline">Get in touch.</a>
       </p>
     </div>
   </section>

--- a/msp-claude-plugins/docs/src/pages/pricing.astro
+++ b/msp-claude-plugins/docs/src/pages/pricing.astro
@@ -39,6 +39,7 @@ const faqs = [
 >
   <Header />
 
+  <main id="main">
   <!-- Hero -->
   <section class="py-20 lg:py-28 bg-gradient-to-b from-cyan-50 to-transparent dark:from-cyan-950/20">
     <div class="container text-center">
@@ -173,6 +174,7 @@ const faqs = [
       </div>
     </div>
   </section>
+  </main>
 
   <Footer />
 </BaseLayout>

--- a/msp-claude-plugins/docs/src/pages/privacy.astro
+++ b/msp-claude-plugins/docs/src/pages/privacy.astro
@@ -92,7 +92,7 @@ import Footer from '@/components/Footer.astro';
         <section>
           <h2 class="text-xl font-semibold mb-3">9. Contact</h2>
           <p class="text-[var(--muted)] leading-relaxed">
-            Questions or requests regarding your data? Find us on <a href="https://discord.gg/cCPtPaFw8e" class="text-accent hover:underline">Discord</a> or reply to any email from us.
+            Questions or requests regarding your data? Find us on <a href="https://discord.gg/cCPtPaFw8e" class="text-accent underline">Discord</a> or reply to any email from us.
           </p>
         </section>
 

--- a/msp-claude-plugins/docs/src/pages/terms.astro
+++ b/msp-claude-plugins/docs/src/pages/terms.astro
@@ -186,7 +186,7 @@ import Footer from '@/components/Footer.astro';
         <section>
           <h2 class="text-xl font-semibold mb-3">15. Contact</h2>
           <p class="text-[var(--muted)] leading-relaxed">
-            Questions about these Terms? Reach us at <a href="https://discord.gg/cCPtPaFw8e" class="text-accent hover:underline">Discord</a> or by email at <a href="mailto:legal@wyretechnology.com" class="text-accent hover:underline">legal@wyretechnology.com</a>.
+            Questions about these Terms? Reach us at <a href="https://discord.gg/cCPtPaFw8e" class="text-accent underline">Discord</a> or by email at <a href="mailto:legal@wyretechnology.com" class="text-accent underline">legal@wyretechnology.com</a>.
           </p>
         </section>
 

--- a/msp-claude-plugins/docs/src/styles/global.css
+++ b/msp-claude-plugins/docs/src/styles/global.css
@@ -49,7 +49,9 @@
   }
 
   .btn-primary {
-    @apply bg-accent text-white hover:bg-accent-hover;
+    /* Dark text on the cyan accent (#00C9DB) yields ~8:1 contrast and passes WCAG AA;
+       white text was 2.02:1 and failed. */
+    @apply bg-accent text-neutral-900 hover:bg-accent-hover;
   }
 
   .btn-secondary {
@@ -137,7 +139,7 @@
   }
 
   .prose a {
-    @apply text-accent hover:underline;
+    @apply text-accent underline;
   }
 
   .prose blockquote {


### PR DESCRIPTION
## Summary

Two-commit PR addressing the concrete Lighthouse a11y failures from the 2026-05 UX audit ([finding D-5](https://github.com/wyre-technology/wyre-mcp-gateway-platform/pull/37)). mcp.wyre.ai Lighthouse desktop a11y was 78 with 7 failed audits; this PR addresses **all 7**.

## Commits

### a4cd980 — aria-labels + main landmark
- **`button-name`** — search, theme-toggle, and copy-install-command buttons (icon-only) had no accessible name. Added aria-labels.
- **`link-name`** — GitHub icon link in `Header.astro` had no accessible name. Added `aria-label="View on GitHub"`.
- **`landmark-one-main`** — `index.astro` and `pricing.astro` had no `<main>`. Wrapped section content in `<main id="main">`. (`404`, `terms`, `privacy` already had main; `DocsLayout` provides one for nested pages.)

### 4c83604 — contrast + heading-order + link-text
- **`color-contrast`** — `.btn-primary` was `bg-accent text-white` = white on `#00C9DB` cyan = 2.02:1 (fails WCAG AA 4.5:1). Switched text to `text-neutral-900` (~8:1). Affects every primary button on the docs site.
- **`heading-order`** — `index.astro` jumped from `<h1>` directly to `<h3>` with no intervening `<h2>`. Promoted the two install-path card headings (Hosted Gateway / Self-Host) from `<h3>` to `<h2>` with the same visual styling (`text-xl font-bold`).
- **`link-text`** — `"Learn More"` anchor was generic. Replaced with `"Learn more about the gateway"`.
- **`link-in-text-block`** — inline `text-accent hover:underline` links rendered cyan on muted-gray text with only-on-hover underline; failed both the 3:1 link-vs-text contrast rule and the "don't rely on color alone" rule. Made underline always-on across the docs site (8 files swept).

## Test plan

- [ ] `npm run dev` and verify the cyan primary buttons now show dark text — confirm visual is acceptable
- [ ] Run Lighthouse against `/` and `/pricing/` — expect a11y to jump from 78 to ≥95
- [ ] Tab through the header — confirm focus shows a name on every interactive element
- [ ] Verify the `<h1>` → `<h2>` → `<h3>` order on `/` (use a heading-outliner extension or browser dev tools)

## Brand note

The `text-white` → `text-neutral-900` change on `.btn-primary` is the most visible diff. If the brand authority decides white-on-cyan is required, the alternative is to darken `--accent` itself (e.g. `#0095a3`) until contrast passes — happy to take that direction instead.