### PR TITLE
fix(docs): drop redundant 'MSP platforms' stat, fix FAQ over-claim on hosted MCP

### DIFF
--- a/msp-claude-plugins/docs/src/pages/index.astro
+++ b/msp-claude-plugins/docs/src/pages/index.astro
@@ -16,7 +16,7 @@ const gatewayUrl = import.meta.env.GATEWAY_URL || 'https://mcp.wyre.ai';
 const pluginCount = plugins.length;
 const skillCount = plugins.flatMap(p => p.skills).length;
 const subagentCount = plugins.flatMap(p => p.agents).length;
-const platformCount = pluginCount;
+const commandCount = plugins.flatMap(p => p.commands).length;
 const vendorNames = plugins.map(p => p.name).join(', ');
 
 // Short, punchy prompt examples for the typewriter — demonstrating real value
@@ -42,7 +42,7 @@ const faqs = [
   },
   {
     question: "What PSA and RMM tools are supported?",
-    answer: `Currently supported platforms include ${vendorNames}. All ${pluginCount} have MCP server integrations.`
+    answer: `Currently supported platforms include ${vendorNames}. Each plugin ships skills, commands, and a self-hostable MCP server. Most are also available as hosted integrations on the WYRE Gateway — see each plugin's page for status.`
   },
   {
     question: "Are MSP Claude Plugins free?",
@@ -107,9 +107,9 @@ const features = [
       <!-- Animated stat counters -->
       <p class="text-lg font-semibold max-w-2xl mx-auto mb-4">
         <span class="counter" data-target={pluginCount}>{pluginCount}</span> plugins &middot;
-        <span class="counter" data-target={platformCount}>{platformCount}</span> MSP platforms &middot;
-        <span class="counter" data-target={skillCount} data-suffix="+">{skillCount}+</span> specialized skills &middot;
-        <span class="counter" data-target={subagentCount}>{subagentCount}</span> subagents
+        <span class="counter" data-target={skillCount}>{skillCount}</span> specialized skills &middot;
+        <span class="counter" data-target={subagentCount}>{subagentCount}</span> subagents &middot;
+        <span class="counter" data-target={commandCount}>{commandCount}</span> commands
       </p>
 
       <!-- Typewriter prompt examples -->

--- a/msp-claude-plugins/docs/src/pages/index.astro
+++ b/msp-claude-plugins/docs/src/pages/index.astro
@@ -42,7 +42,7 @@ const faqs = [
   },
   {
     question: "What PSA and RMM tools are supported?",
-    answer: `Currently supported platforms include ${vendorNames}. Each plugin ships skills, commands, and a self-hostable MCP server. Most are also available as hosted integrations on the WYRE Gateway — see each plugin's page for status.`
+    answer: `Currently supported platforms include ${vendorNames}. Each plugin ships skills, commands, and a self-hostable MCP server. Most are also available as hosted integrations on the WYRE Gateway.`
   },
   {
     question: "Are MSP Claude Plugins free?",


### PR DESCRIPTION
## Summary

UX-audit fix for finding **C-3** (vendor / plugin count drift) — see [review on wyre-mcp-gateway-platform PR #37](https://github.com/wyre-technology/wyre-mcp-gateway-platform/pull/37).

Two related issues on the homepage:

### 1. Hero stat \"MSP platforms\" was a duplicate of \"plugins\"

```ts
// before
const platformCount = pluginCount;  // literally the same number
```

The hero rendered: \"46 plugins · 46 MSP platforms · 195+ skills · N subagents\" — two of those four counts were the same number. Replaced \"MSP platforms\" with the more useful **commands** count, so the four stats are now genuinely distinct: plugins, skills, subagents, commands.

### 2. FAQ Q3 over-claimed hosted MCP coverage

> \"All N have MCP server integrations.\"

Every plugin ships a *self-hostable* MCP server, but only a subset are also available as *hosted* integrations on the WYRE Gateway. Today it's 39 hosted vs 46 published plugins. Reworded:

> Each plugin ships skills, commands, and a self-hostable MCP server. Most are also available as hosted integrations on the WYRE Gateway — see each plugin's page for status.

This avoids committing to a number that drifts and is honest about the self-host vs hosted distinction.

## Audit findings (out of scope, filing as follow-ups)

The msp-plugin-drift-audit skill surfaced two stale dirs that aren't in marketplace.json:

| Dir | Files | State |
|---|---|---|
| `msp-claude-plugins/ironscales/ironscales` | 2 agents | Scaffolded, no `plugin.json` — incomplete |
| `msp-claude-plugins/mimecast/mimecast` | 2 agents | Scaffolded, no `plugin.json` — incomplete |

These should either be completed + registered, or deleted. Not blocking this PR.

The deeper structural fix — a single source of truth for vendor lists shared across `msp-claude-plugins` (marketing) and `mcp-gateway` (hosted registry) — would be a separate cross-repo refactor. Today both repos hand-maintain their own list and the gateway VENDORS count drifts; today's snapshot has 39 in `vendor-config.ts` but it's not surfaced anywhere on mcp.wyre.ai.

## Test plan

- [ ] `npm run dev` and verify the hero now shows four distinct numbers (plugins · skills · subagents · commands)
- [ ] Open the FAQ accordion and verify Q3 reads accurately