### PR TITLE
fix(add-to-project): call shared reusable workflow

### DIFF
--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -1,4 +1,4 @@
-name: Auto-add to Project Board
+name: Auto-add to project
 
 on:
   issues:
@@ -7,15 +7,6 @@ on:
     types: [opened]
 
 jobs:
-  add-to-project:
-    runs-on: ubuntu-latest
-    permissions:
-      issues: read
-      pull-requests: read
-      projects: write
-    steps:
-      - name: Add to project
-        uses: actions/add-to-project@v1
-        with:
-          project-url: https://github.com/orgs/wyre-technology/projects/1
-          github-token: ${{ secrets.GATEWAY_DISPATCH_TOKEN }}
+  call:
+    uses: wyre-technology/.github/.github/workflows/auto-add-to-project.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Replaces the per-repo PAT-based auto-add-to-project workflow with a thin caller of the shared reusable workflow in `wyre-technology/.github`
- Auth switches from a PAT secret to the new `wyre-projects-bot` GitHub App via org-level `APP_ID` / `APP_PRIVATE_KEY` secrets, forwarded via `secrets: inherit`

## Why
Estate-wide auto-add-to-project failures were caused by the backing PAT expiring/losing SSO authorization. App auth removes that failure mode and consolidates the logic in one repo so future tweaks propagate automatically.

Validated end-to-end on the canary repo `mcp-gateway` (PR #85, merged). Part of a 24-repo fan-out.