### PR TITLE
fix(plugins): flip 5 plugins to mcp.wyre.ai; add ThreatLocker to gateway prefix table

### DIFF
--- a/msp-claude-plugins/blackpoint/blackpoint/.mcp.json
+++ b/msp-claude-plugins/blackpoint/blackpoint/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "blackpoint": {
       "type": "http",
-      "url": "https://mcp.wyretechnology.com/v1/blackpoint/mcp",
+      "url": "https://mcp.wyre.ai/v1/blackpoint/mcp",
       "headers": {
         "X-Blackpoint-Api-Token": "${BLACKPOINT_API_TOKEN}"
       }

--- a/msp-claude-plugins/blackpoint/blackpoint/README.md
+++ b/msp-claude-plugins/blackpoint/blackpoint/README.md
@@ -21,7 +21,7 @@ Claude Code plugin for [Blackpoint Cyber](https://blackpointcyber.com) (the Comp
 /plugin install blackpoint
 ```
 
-The plugin connects through the [WYRE MCP Gateway](https://mcp.wyretechnology.com) at `https://mcp.wyretechnology.com/v1/blackpoint/mcp`.
+The plugin connects through the [WYRE MCP Gateway](https://mcp.wyre.ai) at `https://mcp.wyre.ai/v1/blackpoint/mcp`.
 
 ## Configuration
 

--- a/msp-claude-plugins/crewhu/crewhu/.mcp.json
+++ b/msp-claude-plugins/crewhu/crewhu/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "crewhu": {
       "type": "http",
-      "url": "https://mcp.wyretechnology.com/v1/crewhu/mcp",
+      "url": "https://mcp.wyre.ai/v1/crewhu/mcp",
       "headers": {
         "X-Crewhu-Api-Token": "${X_CREWHU_APITOKEN}"
       }

--- a/msp-claude-plugins/crewhu/crewhu/README.md
+++ b/msp-claude-plugins/crewhu/crewhu/README.md
@@ -16,7 +16,7 @@ Claude Code plugin for [Crewhu](https://crewhu.com) - CSAT/NPS surveys, recognit
 /plugin install crewhu
 ```
 
-The plugin connects through the [WYRE MCP Gateway](https://mcp.wyretechnology.com) at `https://mcp.wyretechnology.com/v1/crewhu/mcp`.
+The plugin connects through the [WYRE MCP Gateway](https://mcp.wyre.ai) at `https://mcp.wyre.ai/v1/crewhu/mcp`.
 
 ## Configuration
 

--- a/msp-claude-plugins/docs/src/pages/getting-started/gateway.astro
+++ b/msp-claude-plugins/docs/src/pages/getting-started/gateway.astro
@@ -95,6 +95,7 @@ const claudeDesktopPerVendor = `// claude_desktop_config.json — per-vendor (le
 
       <tr><td>RocketCyber</td><td><code>rocketcyber__</code></td></tr>
       <tr><td>Blumira</td><td><code>blumira__</code></td></tr>
+      <tr><td>ThreatLocker</td><td><code>threatlocker__</code></td></tr>
       <tr><td>Microsoft 365</td><td><code>m365__</code></td></tr>
     </tbody>
   </table>

--- a/msp-claude-plugins/immybot/immybot/.mcp.json
+++ b/msp-claude-plugins/immybot/immybot/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "immybot": {
       "type": "http",
-      "url": "https://mcp.wyretechnology.com/v1/immybot/mcp",
+      "url": "https://mcp.wyre.ai/v1/immybot/mcp",
       "headers": {
         "X-Immybot-Instance-Subdomain": "${IMMYBOT_INSTANCE_SUBDOMAIN}",
         "X-Immybot-Tenant-Id": "${IMMYBOT_TENANT_ID}",

--- a/msp-claude-plugins/immybot/immybot/README.md
+++ b/msp-claude-plugins/immybot/immybot/README.md
@@ -18,7 +18,7 @@ Claude Code plugin for [ImmyBot](https://immy.bot) - desired-state Windows softw
 /plugin install immybot
 ```
 
-The plugin connects through the [WYRE MCP Gateway](https://mcp.wyretechnology.com) at `https://mcp.wyretechnology.com/v1/immybot/mcp`.
+The plugin connects through the [WYRE MCP Gateway](https://mcp.wyre.ai) at `https://mcp.wyre.ai/v1/immybot/mcp`.
 
 ## Configuration
 

--- a/msp-claude-plugins/threatlocker/threatlocker/.mcp.json
+++ b/msp-claude-plugins/threatlocker/threatlocker/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "threatlocker": {
       "type": "http",
-      "url": "https://mcp.wyretechnology.com/v1/threatlocker/mcp",
+      "url": "https://mcp.wyre.ai/v1/threatlocker/mcp",
       "headers": {
         "X-Threatlocker-Api-Key": "${THREATLOCKER_API_KEY}",
         "X-Threatlocker-Organization-Id": "${THREATLOCKER_ORGANIZATION_ID}"

--- a/msp-claude-plugins/threatlocker/threatlocker/README.md
+++ b/msp-claude-plugins/threatlocker/threatlocker/README.md
@@ -23,7 +23,7 @@ Install via the [MSP Claude Plugins marketplace](https://github.com/wyre-technol
 /plugin install threatlocker
 ```
 
-The plugin connects through the [WYRE MCP Gateway](https://mcp.wyretechnology.com) at `https://mcp.wyretechnology.com/v1/threatlocker/mcp`.
+The plugin connects through the [WYRE MCP Gateway](https://mcp.wyre.ai) at `https://mcp.wyre.ai/v1/threatlocker/mcp`.
 
 ## Configuration
 

--- a/msp-claude-plugins/timezest/timezest/.mcp.json
+++ b/msp-claude-plugins/timezest/timezest/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "timezest": {
       "type": "http",
-      "url": "https://mcp.wyretechnology.com/v1/timezest/mcp",
+      "url": "https://mcp.wyre.ai/v1/timezest/mcp",
       "headers": {
         "X-Timezest-Api-Token": "${TIMEZEST_API_TOKEN}"
       }

--- a/msp-claude-plugins/timezest/timezest/README.md
+++ b/msp-claude-plugins/timezest/timezest/README.md
@@ -16,7 +16,7 @@ Claude Code plugin for [TimeZest](https://timezest.com) - PSA-coupled customer s
 /plugin install timezest
 ```
 
-The plugin connects through the [WYRE MCP Gateway](https://mcp.wyretechnology.com) at `https://mcp.wyretechnology.com/v1/timezest/mcp`.
+The plugin connects through the [WYRE MCP Gateway](https://mcp.wyre.ai) at `https://mcp.wyre.ai/v1/timezest/mcp`.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- Closes #73
- Flip 5 plugin configs from legacy \`mcp.wyretechnology.com\` to canonical \`mcp.wyre.ai\` (matching every other plugin after PR #67): \`blackpoint\`, \`crewhu\`, \`immybot\`, \`threatlocker\`, \`timezest\`
- Add ThreatLocker to the vendor tool-prefix table on the gateway docs page

## Why
Issue #73 reported the ThreatLocker config didn't match the rest of the plugins. Root cause: the threatlocker (and 4 sibling) \`.mcp.json\` files were authored before PR #67 flipped the canonical host. The reporter's pasted config was correct (\`mcp.wyre.ai\`) — our shipped config was wrong.

## Test plan
- [ ] Visual diff on \`getting-started/gateway.astro\` shows the new ThreatLocker row
- [ ] No remaining \`mcp.wyretechnology.com\` references in the repo (\`grep -r mcp.wyretechnology.com\` returns nothing)