### PR TITLE
feat: register ironscales + mimecast plugins, add hosted/standalone badge

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "msp-claude-plugins",
   "description": "Community-driven Claude Code plugins for Managed Service Providers. Integrates with PSA, RMM, and documentation tools.",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "owner": {
     "name": "Aaron Sachs"
   },
@@ -604,6 +604,34 @@
         "xero",
         "accounting",
         "billing",
+        "msp"
+      ]
+    },
+    {
+      "name": "ironscales",
+      "source": "./msp-claude-plugins/ironscales/ironscales",
+      "description": "Claude plugins for IRONSCALES - AI-powered anti-phishing, incident triage, email classification, and crowdsourced threat intelligence",
+      "version": "0.1.0",
+      "category": "email-security",
+      "tags": [
+        "ironscales",
+        "email-security",
+        "phishing",
+        "anti-phishing",
+        "msp"
+      ]
+    },
+    {
+      "name": "mimecast",
+      "source": "./msp-claude-plugins/mimecast/mimecast",
+      "description": "Claude plugins for Mimecast Email Security - message tracking, threat intelligence, queue management, and email security operations",
+      "version": "0.1.0",
+      "category": "email-security",
+      "tags": [
+        "mimecast",
+        "email-security",
+        "message-tracking",
+        "threat-intelligence",
         "msp"
       ]
     },

--- a/msp-claude-plugins/docs/src/data/plugins.ts
+++ b/msp-claude-plugins/docs/src/data/plugins.ts
@@ -1783,6 +1783,73 @@ export const plugins: Plugin[] = [
     compatibility: { claudeCode: true, claudeDesktop: true, validated: false }
   },
   {
+    id: 'ironscales',
+    name: 'Ironscales',
+    vendor: 'Ironscales',
+    description: 'Claude plugins for IRONSCALES - AI-powered anti-phishing, incident triage, email classification, and crowdsourced threat intelligence',
+    category: 'email-security',
+    maturity: 'beta',
+    features: [
+      'Incident Management'
+    ],
+    skills: [
+      { name: 'incidents', description: 'Use this skill when working with Ironscales phishing incidents — listing and triaging incidents, classifying emails as phishing/spam/legitimate, taking remediation actions, managing sender allowlists, and viewing company statistics.' },
+      { name: 'api-patterns', description: 'Use this skill when working with Ironscales MCP tools — available tools, API key and company ID authentication, pagination, rate limiting, and error handling.' }
+    ],
+    agents: [
+      { name: 'crowdsourced-intel-harvester', description: 'Use this agent when harvesting and analyzing crowdsourced threat intelligence from IRONSCALES\' global network — identifying trending attack types, surfacing indicators seeing increased reports, comparing client threat profiles to industry peers, and generating intelligence briefings from the collective signal.' },
+      { name: 'phishing-responder', description: 'Use this agent when responding to user-reported phishing emails in IRONSCALES, triaging the incident queue, classifying emails, coordinating quarantine and remediation, or reviewing security statistics for MSP clients.' }
+    ],
+    commands: [
+      { name: '/classify-email', description: 'Classify a specific Ironscales incident email as phishing, spam, or legitimate' },
+      { name: '/triage-incidents', description: 'Triage open Ironscales phishing incidents — list by status, classify, and remediate' }
+    ],
+    apiInfo: {
+      baseUrl: '',
+      auth: '',
+      rateLimit: '',
+      docsUrl: ''
+    },
+    path: 'ironscales/ironscales',
+    compatibility: { claudeCode: true, claudeDesktop: true, validated: false }
+  },
+  {
+    id: 'mimecast',
+    name: 'Mimecast',
+    vendor: 'Mimecast',
+    description: 'Claude plugins for Mimecast Email Security - message tracking, threat intelligence, queue management, and email security operations',
+    category: 'email-security',
+    maturity: 'beta',
+    features: [
+      'Message Tracking',
+      'Queue Management',
+      'Threat Intelligence'
+    ],
+    skills: [
+      { name: 'message-tracking', description: 'Use this skill when tracking or tracing Mimecast email messages — searching by sender/recipient/subject, retrieving message metadata, placing messages on hold, or releasing held messages.' },
+      { name: 'queue-management', description: 'Use this skill when checking Mimecast email delivery queue status — identifying stuck messages, delivery delays, and backlog conditions.' },
+      { name: 'threat-intelligence', description: 'Use this skill when investigating Mimecast threat activity — TTP logs for URL clicks, malicious attachment analysis, impersonation attempts, threat remediation incidents, and audit events.' },
+      { name: 'api-patterns', description: 'Use this skill when working with Mimecast MCP tools — available tools, OAuth 2.0 client credentials authentication, regional API endpoints, pagination, rate limiting, and error handling.' }
+    ],
+    agents: [
+      { name: 'email-continuity-checker', description: 'Use this agent when verifying Mimecast email continuity and archiving health — not for threat investigation, but for checking continuity mode status, verifying archiving is capturing expected mail volumes, auditing connector health, and confirming restore capability.' },
+      { name: 'email-threat-investigator', description: 'Use this agent when investigating email-borne threats, tracing suspicious messages, analyzing TTP click and attachment logs, auditing Mimecast security posture, or managing held email queues for MSP clients on the Mimecast platform.' }
+    ],
+    commands: [
+      { name: '/check-queue', description: 'Check Mimecast email delivery queue status and identify stuck or deferred messages' },
+      { name: '/review-threats', description: 'Review Mimecast TTP threat logs for URL clicks, malicious attachments, and impersonation attempts' },
+      { name: '/trace-message', description: 'Trace an email through Mimecast by sender, recipient, subject, or date range' }
+    ],
+    apiInfo: {
+      baseUrl: '',
+      auth: '',
+      rateLimit: '',
+      docsUrl: ''
+    },
+    path: 'mimecast/mimecast',
+    compatibility: { claudeCode: true, claudeDesktop: true, validated: false }
+  },
+  {
     id: 'wyre-gateway',
     name: 'Wyre Gateway',
     vendor: 'Wyre-gateway',

--- a/msp-claude-plugins/docs/src/pages/plugins/[id].astro
+++ b/msp-claude-plugins/docs/src/pages/plugins/[id].astro
@@ -62,6 +62,10 @@ const compatibilityBadges = {
     <span class={`text-xs font-medium px-2 py-1 rounded-full ${compatibilityBadges.claudeDesktop.color}`}>
       {compatibilityBadges.claudeDesktop.icon} {compatibilityBadges.claudeDesktop.label}
     </span>
+    {companionMcpServer
+      ? <span class="text-xs font-medium px-2 py-1 rounded-full bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400">🔌 Requires MCP Server</span>
+      : <span class="text-xs font-medium px-2 py-1 rounded-full bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400">Standalone</span>
+    }
     <span class="text-[var(--muted)]">• {plugin.vendor}</span>
   </div>
 

--- a/msp-claude-plugins/ironscales/ironscales/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/ironscales/ironscales/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "ironscales",
+  "version": "0.1.0",
+  "description": "Claude plugins for IRONSCALES - AI-powered anti-phishing, incident triage, email classification, and crowdsourced threat intelligence",
+  "author": {
+    "name": "MSP Claude Plugins Community"
+  },
+  "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
+  "repository": "https://github.com/wyre-technology/msp-claude-plugins",
+  "license": "Apache-2.0"
+}

--- a/msp-claude-plugins/mimecast/mimecast/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/mimecast/mimecast/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "mimecast",
+  "version": "0.1.0",
+  "description": "Claude plugins for Mimecast Email Security - message tracking, threat intelligence, queue management, and email security operations",
+  "author": {
+    "name": "MSP Claude Plugins Community"
+  },
+  "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
+  "repository": "https://github.com/wyre-technology/msp-claude-plugins",
+  "license": "Apache-2.0"
+}


### PR DESCRIPTION
## Summary

- **Drift fix**: Added `plugin.json` for `ironscales` and `mimecast` — both had complete agents, commands, and skills but were missing marketplace registration. Registered both as `email-security` plugins, bumped `marketplace.json` to v1.4.0, regenerated `plugins.ts`: 46 → 48 plugins.
- **Badge**: Added a hosted/standalone badge to the plugin detail page. Plugins with a companion WYRE MCP server show "🔌 Requires MCP Server" (violet); all others show "Standalone" (gray). Drives off the existing `companionMcpServer` variable — no schema changes.

## Test plan

- [ ] Verify ironscales and mimecast appear on the plugins index page
- [ ] Verify each detail page renders correctly with skills, agents, and commands tables populated
- [ ] Verify badge renders on a plugin with a companion MCP server (violet "Requires MCP Server") vs one without (gray "Standalone")
- [ ] Confirm build passes with 0 errors