### PR TITLE
fix(plugins): flip 5 plugins to mcp.wyre.ai (closes #73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Gateway URL drift: flipped `blackpoint`, `crewhu`, `immybot`, `timezest`, `threatlocker` plugin READMEs and `.mcp.json` files from `mcp.wyretechnology.com` to canonical `mcp.wyre.ai` (closes #73)
+
 ### Added
 
 - Checkpoint Avanan plugin (email-security): 5 skills + 5 commands for quarantine, threats, policies, incidents, API patterns

--- a/msp-claude-plugins/blackpoint/blackpoint/.mcp.json
+++ b/msp-claude-plugins/blackpoint/blackpoint/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "blackpoint": {
       "type": "http",
-      "url": "https://mcp.wyretechnology.com/v1/blackpoint/mcp",
+      "url": "https://mcp.wyre.ai/v1/blackpoint/mcp",
       "headers": {
         "X-Blackpoint-Api-Token": "${BLACKPOINT_API_TOKEN}"
       }

--- a/msp-claude-plugins/blackpoint/blackpoint/README.md
+++ b/msp-claude-plugins/blackpoint/blackpoint/README.md
@@ -21,7 +21,7 @@ Claude Code plugin for [Blackpoint Cyber](https://blackpointcyber.com) (the Comp
 /plugin install blackpoint
 ```
 
-The plugin connects through the [WYRE MCP Gateway](https://mcp.wyretechnology.com) at `https://mcp.wyretechnology.com/v1/blackpoint/mcp`.
+The plugin connects through the [WYRE MCP Gateway](https://mcp.wyre.ai) at `https://mcp.wyre.ai/v1/blackpoint/mcp`.
 
 ## Configuration
 

--- a/msp-claude-plugins/crewhu/crewhu/.mcp.json
+++ b/msp-claude-plugins/crewhu/crewhu/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "crewhu": {
       "type": "http",
-      "url": "https://mcp.wyretechnology.com/v1/crewhu/mcp",
+      "url": "https://mcp.wyre.ai/v1/crewhu/mcp",
       "headers": {
         "X-Crewhu-Api-Token": "${X_CREWHU_APITOKEN}"
       }

--- a/msp-claude-plugins/crewhu/crewhu/README.md
+++ b/msp-claude-plugins/crewhu/crewhu/README.md
@@ -16,7 +16,7 @@ Claude Code plugin for [Crewhu](https://crewhu.com) - CSAT/NPS surveys, recognit
 /plugin install crewhu
 ```
 
-The plugin connects through the [WYRE MCP Gateway](https://mcp.wyretechnology.com) at `https://mcp.wyretechnology.com/v1/crewhu/mcp`.
+The plugin connects through the [WYRE MCP Gateway](https://mcp.wyre.ai) at `https://mcp.wyre.ai/v1/crewhu/mcp`.
 
 ## Configuration
 

--- a/msp-claude-plugins/immybot/immybot/.mcp.json
+++ b/msp-claude-plugins/immybot/immybot/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "immybot": {
       "type": "http",
-      "url": "https://mcp.wyretechnology.com/v1/immybot/mcp",
+      "url": "https://mcp.wyre.ai/v1/immybot/mcp",
       "headers": {
         "X-Immybot-Instance-Subdomain": "${IMMYBOT_INSTANCE_SUBDOMAIN}",
         "X-Immybot-Tenant-Id": "${IMMYBOT_TENANT_ID}",

--- a/msp-claude-plugins/immybot/immybot/README.md
+++ b/msp-claude-plugins/immybot/immybot/README.md
@@ -18,7 +18,7 @@ Claude Code plugin for [ImmyBot](https://immy.bot) - desired-state Windows softw
 /plugin install immybot
 ```
 
-The plugin connects through the [WYRE MCP Gateway](https://mcp.wyretechnology.com) at `https://mcp.wyretechnology.com/v1/immybot/mcp`.
+The plugin connects through the [WYRE MCP Gateway](https://mcp.wyre.ai) at `https://mcp.wyre.ai/v1/immybot/mcp`.
 
 ## Configuration
 

--- a/msp-claude-plugins/threatlocker/threatlocker/.mcp.json
+++ b/msp-claude-plugins/threatlocker/threatlocker/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "threatlocker": {
       "type": "http",
-      "url": "https://mcp.wyretechnology.com/v1/threatlocker/mcp",
+      "url": "https://mcp.wyre.ai/v1/threatlocker/mcp",
       "headers": {
         "X-Threatlocker-Api-Key": "${THREATLOCKER_API_KEY}",
         "X-Threatlocker-Organization-Id": "${THREATLOCKER_ORGANIZATION_ID}"

--- a/msp-claude-plugins/threatlocker/threatlocker/README.md
+++ b/msp-claude-plugins/threatlocker/threatlocker/README.md
@@ -23,7 +23,7 @@ Install via the [MSP Claude Plugins marketplace](https://github.com/wyre-technol
 /plugin install threatlocker
 ```
 
-The plugin connects through the [WYRE MCP Gateway](https://mcp.wyretechnology.com) at `https://mcp.wyretechnology.com/v1/threatlocker/mcp`.
+The plugin connects through the [WYRE MCP Gateway](https://mcp.wyre.ai) at `https://mcp.wyre.ai/v1/threatlocker/mcp`.
 
 ## Configuration
 

--- a/msp-claude-plugins/timezest/timezest/.mcp.json
+++ b/msp-claude-plugins/timezest/timezest/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "timezest": {
       "type": "http",
-      "url": "https://mcp.wyretechnology.com/v1/timezest/mcp",
+      "url": "https://mcp.wyre.ai/v1/timezest/mcp",
       "headers": {
         "X-Timezest-Api-Token": "${TIMEZEST_API_TOKEN}"
       }

--- a/msp-claude-plugins/timezest/timezest/README.md
+++ b/msp-claude-plugins/timezest/timezest/README.md
@@ -16,7 +16,7 @@ Claude Code plugin for [TimeZest](https://timezest.com) - PSA-coupled customer s
 /plugin install timezest
 ```
 
-The plugin connects through the [WYRE MCP Gateway](https://mcp.wyretechnology.com) at `https://mcp.wyretechnology.com/v1/timezest/mcp`.
+The plugin connects through the [WYRE MCP Gateway](https://mcp.wyre.ai) at `https://mcp.wyre.ai/v1/timezest/mcp`.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

- Mirrors PR #85 for the 5 plugins that didn't get the canonical-URL flip:
  `blackpoint`, `crewhu`, `immybot`, `timezest`, `threatlocker`
- Updates README install snippets and `.mcp.json` server URLs from `mcp.wyretechnology.com` → `mcp.wyre.ai`
- ThreatLocker `.mcp.json` now matches the exact JSON config @jirosgyros pasted in #73

Closes #73.

## Test plan

- [ ] Verify `marketplace.json` still resolves all 5 plugins
- [ ] Smoke test one plugin install (`/plugin install threatlocker`) against the gateway
- [ ] Confirm no other docs reference the old hostname (verified with grep — no remaining hits in repo)