### PR TITLE
docs: add wyre-gateway-troubleshooting skill + surface in docs

### DIFF
--- a/msp-claude-plugins/docs/src/pages/getting-started/gateway.astro
+++ b/msp-claude-plugins/docs/src/pages/getting-started/gateway.astro
@@ -258,6 +258,16 @@ const claudeDesktopPerVendor = `// claude_desktop_config.json — per-vendor (le
     <li><strong>No credential exposure</strong> — vendor API keys never leave the gateway; injected as HTTP headers on the internal network</li>
   </ul>
 
+  <h2>If something goes wrong</h2>
+  <p>
+    Common issues — missing tools after adding a vendor, "Failed to update tool access" when saving
+    allowlists, OAuth failures — are documented in the
+    <a href={`${baseUrl}getting-started/troubleshooting/`}>Troubleshooting guide</a>. If you'd rather
+    have Claude diagnose the issue, install the
+    <a href={`${baseUrl}getting-started/troubleshooting/#triage-with-claude`}><code>wyre-gateway-troubleshooting</code> skill</a>
+    from the shared-skills plugin.
+  </p>
+
   <h2>Local Alternative</h2>
   <p>
     If you prefer to keep credentials on your own machine, you can run individual MCP servers

--- a/msp-claude-plugins/docs/src/pages/getting-started/troubleshooting.astro
+++ b/msp-claude-plugins/docs/src/pages/getting-started/troubleshooting.astro
@@ -9,7 +9,8 @@ const baseUrl = import.meta.env.BASE_URL;
   <p class="lead text-lg text-[var(--muted)] mb-8">
     Common issues and fixes for the WYRE MCP Gateway. If your issue isn't listed here,
     check the <a href="https://mcp.wyre.ai/health/vendors" target="_blank" rel="noopener noreferrer">vendor health dashboard</a>
-    for upstream outages.
+    for upstream outages. Prefer to have Claude triage it for you?
+    <a href="#triage-with-claude">Use the <code>wyre-gateway-troubleshooting</code> skill</a>.
   </p>
 
   <h2 id="invalid-oauth-html">"Invalid OAuth error response: Unexpected token '&lt;'"</h2>
@@ -106,8 +107,88 @@ const baseUrl = import.meta.env.BASE_URL;
   </p>
   <ol>
     <li>Verify your credentials are saved at <a href="https://mcp.wyre.ai" target="_blank" rel="noopener noreferrer">mcp.wyre.ai</a> — log in and check the credentials page</li>
-    <li>Restart Claude Desktop or re-establish the MCP connection in Claude Code (<code>/mcp</code>)</li>
+    <li>
+      <strong>Fully quit and reopen Claude Desktop</strong> (<code>Cmd+Q</code> on macOS, then relaunch).
+      Claude registers the gateway's tool catalog at the moment its MCP client connects and does <em>not</em>
+      refresh while a session is live — adding a new vendor in the Wyre dashboard will not push tools into
+      a running Claude session. In Claude Code, use <code>/mcp</code> and reconnect the gateway entry.
+    </li>
     <li>The unified endpoint only lists tools for vendors where you have valid credentials — if credentials are expired or invalid, that vendor is silently skipped</li>
     <li>If using org/team credentials, ensure you have the correct role and the vendor's tools are in your team's allowlist</li>
   </ol>
+
+  <hr class="my-8" />
+
+  <h2 id="failed-to-update-tool-access">"Failed to update tool access" on the Tool Allowlists page</h2>
+  <p>
+    When you toggle which vendor tools are available for admins or members and click Save, the gateway returns
+    a generic alert: <em>"Failed to update tool access."</em> The most common cause is a permissions mismatch.
+  </p>
+  <h3>Cause</h3>
+  <p>
+    Saving or clearing a tool allowlist requires the <strong>org owner</strong> role. Admins can open the
+    Tool Allowlists page and see every vendor with all tools checked (the "allow all" default), but any
+    Save or Reset action returns <code>403 Requires owner role or higher</code> — which the UI surfaces as
+    the generic alert.
+  </p>
+  <h3>Fix</h3>
+  <ol>
+    <li>Confirm which user is the org owner: <strong>Organization → Members</strong>. The owner has the highest privilege level and is typically the user who created the organization.</li>
+    <li>If you are not the owner, ask them to make the allowlist change for you, or have them transfer ownership.</li>
+    <li>If you <em>are</em> signed in as the owner and still see this error, contact <a href="mailto:hello@wyre.ai">hello@wyre.ai</a> with your org name and the vendor you were editing.</li>
+  </ol>
+  <p class="text-sm text-[var(--muted)]">
+    Note: every vendor's tools appearing as "checked" on a fresh org is expected. With no allowlist saved,
+    the gateway permits every tool for that role; the checkboxes reflect the effective default, not a stored
+    configuration.
+  </p>
+
+  <hr class="my-8" />
+
+  <h2 id="triage-with-claude">Triage with Claude (the <code>wyre-gateway-troubleshooting</code> skill)</h2>
+  <p>
+    If you'd rather not walk through this page yourself, the WYRE skill set includes a
+    <code>wyre-gateway-troubleshooting</code> skill that teaches Claude how to diagnose the same
+    issues described above — missing tools, "Failed to update tool access" errors, OAuth failures,
+    expired credentials, and the request flow through the gateway.
+  </p>
+
+  <h3>Install the shared skills plugin</h3>
+  <pre class="bg-[var(--surface-2)] border border-[var(--border)] rounded p-3 text-sm overflow-x-auto"><code>/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin install shared-skills</code></pre>
+  <p class="text-sm text-[var(--muted)] mt-2">
+    Run these in Claude Code. The skill becomes available immediately — no restart needed.
+    Already have the marketplace added? Just run <code>/plugin install shared-skills</code>.
+  </p>
+
+  <h3>Trigger phrases</h3>
+  <p>
+    Once installed, Claude will pick up the skill automatically when you describe a gateway problem.
+    Phrases that reliably trigger it:
+  </p>
+  <ul>
+    <li>"My WYRE gateway tools aren't showing up in Claude"</li>
+    <li>"I get 'Failed to update tool access' when I try to save"</li>
+    <li>"OAuth is failing on mcp.wyre.ai"</li>
+    <li>"Why is my IT Glue (or Autotask, CIPP, etc.) connection not working?"</li>
+    <li>"Help me troubleshoot the WYRE gateway"</li>
+  </ul>
+
+  <h3>What the skill does</h3>
+  <p>
+    The skill walks Claude through the five-layer request path
+    (Claude → mcp-remote → gateway → vendor container → vendor API), asks you targeted
+    questions to localize the failure, and gives you the fix specific to your symptom.
+    For permission-related errors it identifies whether the user is the org owner; for
+    missing tools it confirms the credentials are saved and points you at the
+    Cmd+Q-and-reopen step. If the issue requires WYRE support, the skill prepares the
+    information we need (org name, vendor slug, exact error, timestamp) so the
+    handoff is fast.
+  </p>
+  <p class="text-sm text-[var(--muted)]">
+    Source:
+    <a href="https://github.com/wyre-technology/msp-claude-plugins/tree/main/shared/skills/wyre-gateway-troubleshooting" target="_blank" rel="noopener noreferrer">
+      shared/skills/wyre-gateway-troubleshooting
+    </a> in the <code>msp-claude-plugins</code> repository.
+  </p>
 </DocsLayout>

--- a/msp-claude-plugins/shared/skills/wyre-gateway-troubleshooting/SKILL.md
+++ b/msp-claude-plugins/shared/skills/wyre-gateway-troubleshooting/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: WYRE MCP Gateway Troubleshooting
+description: >
+  Diagnose and resolve common issues with the WYRE MCP Gateway — missing
+  vendor tools, OAuth failures, "Failed to update tool access" errors,
+  expired credentials, and the request flow through mcp-remote → gateway →
+  vendor container → external API.
+when_to_use: "When a user reports that vendor tools are missing in Claude, Tool Allowlists changes won't save, OAuth is failing on the WYRE gateway, or a tool call returns an unexpected error."
+version: 1.0.0
+triggers:
+  - wyre gateway not working
+  - mcp gateway troubleshooting
+  - tools missing in claude
+  - failed to update tool access
+  - vendor tools not appearing
+  - mcp.wyre.ai issues
+  - claude not seeing tools
+  - oauth invalid_token gateway
+  - gateway 403
+dependencies: []
+---
+
+# WYRE MCP Gateway Troubleshooting
+
+This skill walks through the most common failure modes in the WYRE MCP Gateway and how to resolve them. Use it whenever a user is in the gateway dashboard or in Claude Desktop / Claude Code and something isn't behaving as expected.
+
+The gateway request path has five layers — identify which layer is failing first:
+
+```
+Claude Desktop / Code  →  mcp-remote  →  WYRE Gateway  →  Vendor Container  →  Vendor API
+        (1)                  (2)             (3)              (4)                (5)
+```
+
+Most user-reported issues are at layer 1 (Claude's tool registration cache) or layer 3 (gateway permissions / credentials). Layers 4 and 5 generally surface as a tool call returning an error after a tool has already been registered.
+
+---
+
+## Symptom: Newly added vendor's tools don't appear in Claude
+
+**Most common cause: Claude has not refreshed its tool list.**
+
+Claude registers the gateway's tool catalog at the moment its MCP client connects, and does **not** refresh while a session is live. Adding a vendor in the Wyre dashboard will not push new tools into a running Claude session.
+
+**Fix:**
+
+1. Verify the vendor connection is saved at [mcp.wyre.ai](https://mcp.wyre.ai) — open **Plugins** and confirm the vendor shows as connected with a recent test result.
+2. **Fully quit Claude Desktop (Cmd+Q on macOS) and reopen it.** Closing the window is not enough — the MCP client process keeps running.
+3. In Claude Code, run `/mcp`, find the gateway entry, and reconnect it. (Restarting the whole CLI also works.)
+4. Start a new conversation. The first tool list request will trigger the gateway to re-aggregate vendor tools and register them with Claude.
+
+**If tools still don't appear after a full restart:**
+
+- The vendor's credentials may have failed validation. Open **Plugins**, click the vendor, and run the connection test. Re-enter credentials if the test fails.
+- For OAuth-based vendors (Xero, QuickBooks, HubSpot, M365), the OAuth token may have expired. Click **Reconnect** to re-authorize.
+- The unified endpoint silently skips vendors with invalid credentials, so a single bad vendor will not block the others — but you also will not see an error toast for the failure.
+
+---
+
+## Symptom: "Failed to update tool access" when saving the Tool Allowlists page
+
+**Cause:** Saving or clearing a tool allowlist requires the **org owner** role. Admins can view the Tool Allowlists page and will see every vendor's tools displayed as "checked" (the allow-all default), but any Save or Reset action returns `403 Requires owner role or higher`. The UI surfaces this as the generic "Failed to update tool access" alert.
+
+**Fix:**
+
+1. Open **Organization → Members** and identify the org owner. The owner is typically the user who originally created the organization.
+2. If you are not the owner, ask the owner to make the allowlist change for you, or have them transfer ownership.
+3. If you *are* signed in as the owner and the error persists, escalate to `hello@wyre.ai` with your org name and the vendor you were editing.
+
+**Important context to share with users:**
+
+- A fresh org will show every vendor tool as checked. That is **expected** and means "allow all" — there is no saved allowlist row, so the gateway permits every tool for that role. Don't read it as "an allowlist already exists."
+- Members and admins are subject to allowlists if configured; owners are never restricted by allowlists.
+
+---
+
+## Symptom: OAuth fails — "Invalid OAuth error response: Unexpected token '<'"
+
+**Cause:** The OAuth discovery or token endpoint returned HTML (typically a Cloudflare error page) instead of JSON. The gateway is briefly unreachable.
+
+**Fix:**
+
+1. Check the gateway health: `curl https://mcp.wyre.ai/health` should return `{"status":"ok"}`.
+2. Check vendor health: `https://mcp.wyre.ai/health/vendors`.
+3. Wait 60–120 seconds and retry — most deployments complete within a minute.
+4. If `/health` is failing for more than 2 minutes, contact `hello@wyre.ai`.
+
+---
+
+## Symptom: A tool call returns a credential or authentication error
+
+This means the tool was registered (so layers 1–3 are fine) but layer 4 or 5 rejected the call.
+
+**Walk through:**
+
+1. Confirm credentials in the dashboard. Open **Plugins**, click the vendor, run **Test Connection**. If the test fails, re-enter credentials.
+2. Vendor OAuth tokens have limited lifespans. If the dashboard shows a "Reconnect" prompt for the vendor, the OAuth token expired — click **Reconnect** to re-authorize.
+3. Some vendors (e.g., Autotask, Datto) silently drop requests from non-allowlisted IPs. If the test connection works from the dashboard but tool calls time out, ask WYRE support to confirm the gateway's egress IP is on the vendor's allowlist.
+
+---
+
+## Symptom: Connection refused on the OAuth callback (`localhost:NNNNN`)
+
+**Cause:** `mcp-remote` opens a local listener for the OAuth callback. With multiple per-vendor entries in `claude_desktop_config.json`, the listeners can race and time out.
+
+**Fix:**
+
+1. Use the unified endpoint — replace per-vendor `mcp-remote` entries with a single entry pointing to `https://mcp.wyre.ai/v1/mcp`. One OAuth flow instead of many.
+2. Kill stale `mcp-remote` processes: `pkill -f mcp-remote`.
+3. Restart Claude Desktop.
+
+---
+
+## Diagnostic Quick Reference
+
+| Symptom | First thing to check |
+|---|---|
+| No tools at all in Claude | Cmd+Q Claude, reopen, start new conversation |
+| One vendor's tools missing | Plugins page → run Test Connection for that vendor |
+| "Failed to update tool access" | Org role — only owners can save tool allowlists |
+| "Invalid OAuth error response" / HTML | `curl https://mcp.wyre.ai/health` |
+| Tool call returns expired/invalid auth | Plugins → Reconnect for the vendor |
+| Tool call times out (no error body) | Vendor IP allowlist — contact WYRE support |
+
+---
+
+## What to escalate to WYRE support
+
+Before escalating, capture:
+
+1. **Org name** and approximate **time** of the failure (UTC if possible).
+2. **Vendor slug** (e.g., `itglue`, `autotask`, `cipp`).
+3. **Exact error message** as it appeared (screenshot is best).
+4. **What you have already tried** — restarting Claude, reconnecting the vendor, etc.
+
+Send to `hello@wyre.ai`. The gateway logs every request with a `reqId`, so a precise timestamp lets us correlate.


### PR DESCRIPTION
## Summary

- Adds a new public skill at `shared/skills/wyre-gateway-troubleshooting/SKILL.md` that teaches Claude how to diagnose common WYRE MCP Gateway issues — missing tools after adding a vendor, "Failed to update tool access" 403s, OAuth HTML errors, expired credentials, callback failures — and walks the user through the fix specific to their symptom.
- Surfaces the skill in three places on the docs site (per Option C of the docs review):
  - `troubleshooting.astro` lead paragraph: one-line nudge anchored to the full callout below.
  - `troubleshooting.astro` end of page: full **Triage with Claude** section with install commands, trigger phrases, an explanation of what the skill does, and a link to the source on GitHub. Also adds two new troubleshooting entries on the page (live-session tool registration cache, "Failed to update tool access" 403).
  - `gateway.astro` setup guide: short "If something goes wrong" section at the end of the steps pointing to the troubleshooting page + skill.

## Background — what triggered this

IT Partners support email on 2026-05-08 hit two related issues — Claude not showing newly added IT Glue tools (live-session cache; needs Cmd+Q) and "Failed to update tool access" on the allowlists page (owner-only write guard). Neither had an in-product or doc-side surface where they could self-serve. The skill closes that gap.

## Follow-up — separate PR

Auto-generation of `docs/src/data/plugins.ts` currently skips `shared-skills` ([generate-plugins.ts:394](https://github.com/wyre-technology/msp-claude-plugins/blob/main/msp-claude-plugins/docs/scripts/generate-plugins.ts#L394)). A follow-up PR will update the generator to emit a `sharedSkills.ts` data export and add a "Cross-cutting / Shared" section to `/skills` and `/plugins` so shared skills are first-class in the docs index. Kept separate to avoid mixing the type/data-shape change with this docs-only PR.

## Test plan

- [ ] `npm run dev` in `docs/`; visit `/getting-started/troubleshooting/` and verify both the top one-liner and the bottom "Triage with Claude" section render
- [ ] Click the top anchor link `#triage-with-claude` and confirm it scrolls to the full section
- [ ] Visit `/getting-started/gateway/` and verify the new "If something goes wrong" link section at the end
- [ ] Confirm `shared/skills/wyre-gateway-troubleshooting/SKILL.md` parses (frontmatter is valid YAML)