### PR TITLE
docs: surface shared skills in /skills index (auto-generated)

### DIFF
--- a/msp-claude-plugins/docs/scripts/generate-plugins.ts
+++ b/msp-claude-plugins/docs/scripts/generate-plugins.ts
@@ -13,6 +13,7 @@ const DOCS_DIR = path.resolve(import.meta.dirname, '..');
 const REPO_ROOT = path.resolve(DOCS_DIR, '..', '..');
 const MARKETPLACE_PATH = path.join(REPO_ROOT, '.claude-plugin', 'marketplace.json');
 const OUTPUT_PATH = path.join(DOCS_DIR, 'src', 'data', 'plugins.ts');
+const OUTPUT_PATH_SHARED = path.join(DOCS_DIR, 'src', 'data', 'sharedSkills.ts');
 
 // ── Category mapping ───────────────────────────────────────────────────
 const VALID_CATEGORIES = new Set([
@@ -391,9 +392,27 @@ function main(): void {
   const pluginEntries: string[] = [];
   const allCategories = new Set<string>();
 
+  let sharedSkillsEmitted = 0;
+
   for (const entry of marketplace.plugins) {
-    // Skip shared-skills
-    if (entry.name === 'shared-skills') continue;
+    // shared-skills is rendered as cross-cutting content, not a vendor plugin.
+    // Emit it to a separate sharedSkills.ts so /skills can surface it without
+    // forcing a `Plugin`-shaped entry into plugins.ts.
+    if (entry.name === 'shared-skills') {
+      const sharedDir = path.join(REPO_ROOT, 'msp-claude-plugins', derivePath(entry.source));
+      const sharedSkills = scanSkills(sharedDir);
+      const sharedJsonPath = path.join(sharedDir, '.claude-plugin', 'plugin.json');
+      const sharedJson: { description?: string; version?: string } | null = fs.existsSync(sharedJsonPath)
+        ? JSON.parse(fs.readFileSync(sharedJsonPath, 'utf-8'))
+        : null;
+      writeSharedSkills(sharedSkills, {
+        description: sharedJson?.description || entry.description,
+        version: sharedJson?.version,
+        installSlug: entry.name,
+      });
+      sharedSkillsEmitted = sharedSkills.length;
+      continue;
+    }
 
     const pluginRelPath = derivePath(entry.source);
     const pluginDir = path.join(REPO_ROOT, 'msp-claude-plugins', pluginRelPath);
@@ -539,6 +558,48 @@ export function getPluginsByVendor(vendor: string): Plugin[] {
   fs.writeFileSync(OUTPUT_PATH, output, 'utf-8');
   console.log(`Generated ${OUTPUT_PATH} with ${pluginEntries.length} plugins`);
   console.log(`Categories: ${Array.from(allCategories).sort().join(', ')}`);
+  if (sharedSkillsEmitted > 0) {
+    console.log(`Generated ${OUTPUT_PATH_SHARED} with ${sharedSkillsEmitted} shared skills`);
+  }
+}
+
+interface SharedSkillsMeta {
+  description: string;
+  version?: string;
+  installSlug: string;
+}
+
+function writeSharedSkills(skills: SkillEntry[], meta: SharedSkillsMeta): void {
+  const skillsArr = skills
+    .map(s => `  { name: '${escapeQuotes(s.name)}', description: ${quote(s.description)} }`)
+    .join(',\n');
+
+  const output = `// Auto-generated — do not edit manually. Run \`npm run generate\` to update.
+
+export interface SharedSkill {
+  name: string;
+  description: string;
+}
+
+/**
+ * Cross-cutting skills that are not tied to a single vendor. Distributed
+ * via the \`${meta.installSlug}\` marketplace entry; install with:
+ *
+ *   /plugin marketplace add wyre-technology/msp-claude-plugins
+ *   /plugin install ${meta.installSlug}
+ */
+export const sharedSkills: SharedSkill[] = [
+${skillsArr}
+];
+
+export const sharedSkillsMeta = {
+  installSlug: '${escapeQuotes(meta.installSlug)}',
+  description: ${quote(meta.description)},
+  version: ${meta.version ? `'${escapeQuotes(meta.version)}'` : 'undefined'},
+};
+`;
+
+  fs.writeFileSync(OUTPUT_PATH_SHARED, output, 'utf-8');
 }
 
 function escapeQuotes(s: string): string {

--- a/msp-claude-plugins/docs/src/data/sharedSkills.ts
+++ b/msp-claude-plugins/docs/src/data/sharedSkills.ts
@@ -16,7 +16,8 @@ export const sharedSkills: SharedSkill[] = [
   { name: 'billing-reconciliation', description: 'Reconcile cloud marketplace subscriptions (Pax8) against accounting invoices (Xero, QuickBooks Online) to identify billing gaps, unbilled...' },
   { name: 'incident-correlation', description: 'Use this skill when correlating data across multiple vendor tools during incident investigation.' },
   { name: 'msp-terminology', description: 'Use this skill when interpreting MSP-specific terminology, acronyms, and concepts.' },
-  { name: 'ticket-triage', description: 'Use this skill when triaging tickets in any PSA - determining priority, categorization, routing, and initial response.' }
+  { name: 'ticket-triage', description: 'Use this skill when triaging tickets in any PSA - determining priority, categorization, routing, and initial response.' },
+  { name: 'wyre-gateway-troubleshooting', description: 'Diagnose and resolve common issues with the WYRE MCP Gateway — missing vendor tools, OAuth failures, "Failed to update tool access" errors, expired credentials, and the request flow through mcp-remote → gateway → vendor container → external API.' }
 ];
 
 export const sharedSkillsMeta = {

--- a/msp-claude-plugins/docs/src/data/sharedSkills.ts
+++ b/msp-claude-plugins/docs/src/data/sharedSkills.ts
@@ -1,0 +1,26 @@
+// Auto-generated — do not edit manually. Run `npm run generate` to update.
+
+export interface SharedSkill {
+  name: string;
+  description: string;
+}
+
+/**
+ * Cross-cutting skills that are not tied to a single vendor. Distributed
+ * via the `shared-skills` marketplace entry; install with:
+ *
+ *   /plugin marketplace add wyre-technology/msp-claude-plugins
+ *   /plugin install shared-skills
+ */
+export const sharedSkills: SharedSkill[] = [
+  { name: 'billing-reconciliation', description: 'Reconcile cloud marketplace subscriptions (Pax8) against accounting invoices (Xero, QuickBooks Online) to identify billing gaps, unbilled...' },
+  { name: 'incident-correlation', description: 'Use this skill when correlating data across multiple vendor tools during incident investigation.' },
+  { name: 'msp-terminology', description: 'Use this skill when interpreting MSP-specific terminology, acronyms, and concepts.' },
+  { name: 'ticket-triage', description: 'Use this skill when triaging tickets in any PSA - determining priority, categorization, routing, and initial response.' }
+];
+
+export const sharedSkillsMeta = {
+  installSlug: 'shared-skills',
+  description: 'Vendor-agnostic MSP skills — terminology, ticket triage, incident correlation, and billing reconciliation',
+  version: '1.1.1',
+};

--- a/msp-claude-plugins/docs/src/pages/skills/index.astro
+++ b/msp-claude-plugins/docs/src/pages/skills/index.astro
@@ -1,6 +1,7 @@
 ---
 import DocsLayout from '@/layouts/DocsLayout.astro';
 import { plugins } from '@/data/plugins';
+import { sharedSkills, sharedSkillsMeta } from '@/data/sharedSkills';
 
 const baseUrl = import.meta.env.BASE_URL;
 
@@ -79,9 +80,34 @@ const allSkills = plugins.flatMap(p =>
 
   <p class="lead text-lg text-[var(--muted)] mb-8">
     Skills provide domain knowledge that teaches Claude about MSP platforms,
-    terminology, and best practices. There are {allSkills.length} skills across
-    all plugins.
+    terminology, and best practices. There are {allSkills.length} per-vendor skills
+    across all plugins, plus {sharedSkills.length} cross-cutting shared skills.
   </p>
+
+  <h2 id="cross-cutting">Cross-cutting / Shared Skills</h2>
+
+  <p class="text-[var(--muted)]">
+    Vendor-agnostic skills distributed via the <code>{sharedSkillsMeta.installSlug}</code> plugin.
+    Install with <code>/plugin install {sharedSkillsMeta.installSlug}</code> after adding the
+    marketplace.
+  </p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Skill</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      {sharedSkills.map(skill => (
+        <tr>
+          <td><code>{skill.name}</code></td>
+          <td>{skill.description}</td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
 
   <h2>What are Skills?</h2>
 


### PR DESCRIPTION
## Summary

`/skills` only ever rendered per-vendor skills. The four cross-cutting skills in `shared/skills/*` (billing-reconciliation, incident-correlation, msp-terminology, ticket-triage) were invisible in the docs because `generate-plugins.ts:394` explicitly skipped the `shared-skills` marketplace entry. They could only be discovered by browsing the GitHub repo.

This PR surfaces them as first-class content on the docs site.

## Approach

Emit shared skills to a **separate** data file rather than forcing them into the per-vendor `Plugin` shape. Shared skills have no vendor, no API info, and no maturity classification — coercing them through `Plugin` would mean either nullable fields, fake values, or a wider type union. A sibling data file keeps the existing types clean and gives shared skills a purpose-built shape.

## Changes

- **`generate-plugins.ts`** — replaced the unconditional `continue` skip with a carve-out that scans `shared/skills/*` and writes `src/data/sharedSkills.ts`. `plugins.ts` is regenerated identically (49 entries, no diff).
- **`src/data/sharedSkills.ts`** (new, auto-generated) — exports `SharedSkill` interface, `sharedSkills` array, and `sharedSkillsMeta` with install slug + description.
- **`src/pages/skills/index.astro`** — imports the new data, adds a "Cross-cutting / Shared Skills" section above "Skills by Category" with install instructions and a name/description table. The lead paragraph now mentions the cross-cutting count alongside the per-vendor count.

## Coordination with #90

The companion PR #90 adds a fifth shared skill (`wyre-gateway-troubleshooting`). Once #90 lands, a `npm run generate` will pick it up and `sharedSkills.ts` will grow by one entry. The `shared/.claude-plugin/plugin.json` description will also want a refresh after #90 to mention the new skill — left for a follow-up commit on #90 to avoid merge conflicts here.

This PR can land before or after #90 — they don't block each other. If #90 lands first, anyone running the generator on this branch will get the 5-entry version.

## Test plan

- [ ] `npm run dev` in `docs/`; visit `/skills/` and verify the "Cross-cutting / Shared Skills" section renders above "Skills by Category"
- [ ] Confirm the four shared skills appear with descriptions
- [ ] `npm run generate` from a clean tree and diff `plugins.ts` — should be identical to current main
- [ ] `npm run build` succeeds with no type errors from the new `@/data/sharedSkills` import