### PR TITLE
fix(autotask): correct inverted priority mapping in slash commands

### DIFF
--- a/msp-claude-plugins/kaseya/autotask/commands/create-ticket.md
+++ b/msp-claude-plugins/kaseya/autotask/commands/create-ticket.md
@@ -15,7 +15,7 @@ arguments:
     description: Queue name or ID (defaults to Service Desk)
     required: false
   - name: priority
-    description: Priority level 1-4 (1=Critical, 4=Low, default 3)
+    description: Priority level 1-4 (4=Critical, 3=High, 2=Medium, 1=Low; default 2=Medium). Note - lower numbers = lower urgency in Autotask.
     required: false
   - name: contact
     description: Contact name or email
@@ -79,7 +79,7 @@ Create a new service ticket in Autotask PSA with specified details.
 | title | string | Yes | - | Brief summary (max 255 chars) |
 | description | string | No | - | Detailed issue description |
 | queue | string/int | No | Service Desk | Target queue |
-| priority | int | No | 3 (Medium) | 1=Critical to 4=Low |
+| priority | int | No | 2 (Medium) | 4=Critical, 3=High, 2=Medium, 1=Low |
 | contact | string | No | - | Contact name or email |
 
 ## Examples
@@ -93,13 +93,13 @@ Create a new service ticket in Autotask PSA with specified details.
 ### With Full Details
 
 ```
-/create-ticket "Acme Corp" "Email not working" --description "Multiple users unable to send/receive since 9am" --priority 2 --contact "john.smith@acme.com" --queue "Service Desk"
+/create-ticket "Acme Corp" "Email not working" --description "Multiple users unable to send/receive since 9am" --priority 3 --contact "john.smith@acme.com" --queue "Service Desk"
 ```
 
 ### Using Company ID
 
 ```
-/create-ticket 12345 "Server offline" --priority 1
+/create-ticket 12345 "Server offline" --priority 4
 ```
 
 ## Output
@@ -110,7 +110,7 @@ Create a new service ticket in Autotask PSA with specified details.
 Ticket Number: T20240215.0042
 Ticket ID: 54321
 Company: Acme Corporation
-Priority: High (2)
+Priority: High (3)
 Queue: Service Desk
 Contract: Managed Services Agreement (Active)
 

--- a/msp-claude-plugins/kaseya/autotask/commands/my-tickets.md
+++ b/msp-claude-plugins/kaseya/autotask/commands/my-tickets.md
@@ -6,7 +6,7 @@ arguments:
     description: Filter by status (e.g., "Open", "In Progress", "Waiting Customer")
     required: false
   - name: priority
-    description: Filter by priority (1=Critical, 2=High, 3=Medium, 4=Low)
+    description: Filter by priority (4=Critical, 3=High, 2=Medium, 1=Low). Note - lower numbers = lower urgency in Autotask.
     required: false
   - name: queue
     description: Filter by queue name
@@ -80,13 +80,13 @@ List all tickets currently assigned to you with filtering and sorting options fo
 ### High Priority Tickets
 
 ```
-/my-tickets --priority 2
+/my-tickets --priority 3
 ```
 
 ### Critical Priority (Urgent)
 
 ```
-/my-tickets --priority 1
+/my-tickets --priority 4
 ```
 
 ### Sorted by Due Date
@@ -219,10 +219,10 @@ Available statuses:
 Error: Invalid priority: 5
 
 Valid priorities:
-- 1 (Critical)
-- 2 (High)
-- 3 (Medium)
-- 4 (Low)
+- 4 (Critical)
+- 3 (High)
+- 2 (Medium)
+- 1 (Low)
 ```
 
 ### Invalid Sort Field

--- a/msp-claude-plugins/kaseya/autotask/commands/update-ticket.md
+++ b/msp-claude-plugins/kaseya/autotask/commands/update-ticket.md
@@ -9,7 +9,7 @@ arguments:
     description: New status (e.g., "In Progress", "Waiting Customer", "Complete")
     required: false
   - name: priority
-    description: Priority level 1-4 (1=Critical, 2=High, 3=Medium, 4=Low)
+    description: Priority level 1-4 (4=Critical, 3=High, 2=Medium, 1=Low). Note - lower numbers = lower urgency in Autotask.
     required: false
   - name: queue
     description: Queue name to move ticket to
@@ -79,7 +79,7 @@ Update fields on an existing Autotask ticket including status, priority, queue, 
 ### Change Priority and Status
 
 ```
-/update-ticket 12345 --status "In Progress" --priority 2
+/update-ticket 12345 --status "In Progress" --priority 3
 ```
 
 ### Move to Different Queue
@@ -110,11 +110,11 @@ Company: Acme Corporation
 
 Changes Applied:
   Status: New -> In Progress
-  Priority: Medium (3) -> High (2)
+  Priority: Medium (2) -> High (3)
 
 Current State:
   Status: In Progress
-  Priority: High (2)
+  Priority: High (3)
   Queue: Service Desk
   Assignee: John Technician
   Due Date: 2026-02-10 17:00
@@ -153,10 +153,10 @@ Available statuses:
 Error: Invalid priority: 5
 
 Valid priorities:
-- 1 (Critical)
-- 2 (High)
-- 3 (Medium)
-- 4 (Low)
+- 4 (Critical)
+- 3 (High)
+- 2 (Medium)
+- 1 (Low)
 ```
 
 ### Permission Denied


### PR DESCRIPTION
Closes #92

## Summary

The `kaseya/autotask` slash commands documented priority as `1=Critical / 4=Low`, contradicting:
- `kaseya/autotask/skills/tickets/SKILL.md` ("In Autotask, lower numbers = lower priority. Priority 4 is most urgent.")
- `shared/skills/incident-correlation/VENDOR-MAPPINGS.md` ("Autotask uses 4=Critical")
- The `TicketPriority` enum in [autotask-mcp `src/types/autotask.ts`](https://github.com/wyre-technology/autotask-mcp/blob/main/src/types/autotask.ts) — `Low=1, Medium=2, High=3, Critical=4`

A user running `/create-ticket --priority 1` expecting **Critical** would instead create a **Low** ticket — a real SLA / on-call routing risk.

## Changes

Corrected mapping (and dependent examples, default value, and output samples) across the three Autotask ticket commands:

| File | What changed |
|------|--------------|
| `commands/create-ticket.md` | Frontmatter, parameter table, two examples, output sample. Also corrected default from `3 (Medium)` to `2 (Medium)` per skill (under correct mapping, `3=High`). |
| `commands/update-ticket.md` | Frontmatter, example, before/after output, valid-priorities error list. |
| `commands/my-tickets.md` | Frontmatter, High/Critical example commands, valid-priorities error list. |

## Intentionally untouched

- `halopsa/halopsa/commands/*` — HaloPSA natively uses `1=Critical` (per VENDOR-MAPPINGS skill).
- `connectwise/manage/commands/*` — different vendor, separate convention; out of scope for this issue.
- `kaseya/autotask/prd/expanded-commands-prd.md` — planning doc, not runtime.

## Test plan

- [x] `grep -rn "1=Critical" msp-claude-plugins/kaseya/autotask/commands/` returns no results
- [x] Each updated command's priority text now matches `skills/tickets/SKILL.md`
- [x] Examples and output samples are internally consistent (priority number ↔ label)