### PR TITLE
fix(docs): extend mcp-servers/[id].astro categoryColors for accounting/network/sales enums

### DIFF
--- a/msp-claude-plugins/docs/src/pages/mcp-servers/[id].astro
+++ b/msp-claude-plugins/docs/src/pages/mcp-servers/[id].astro
@@ -19,14 +19,20 @@ const categoryColors = {
   psa: 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-400',
   rmm: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
   documentation: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
-  security: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+  security: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+  accounting: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+  network: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400',
+  sales: 'bg-pink-100 text-pink-700 dark:bg-pink-900/30 dark:text-pink-400'
 };
 
 const categoryLabels = {
   psa: 'PSA',
   rmm: 'RMM',
   documentation: 'Documentation',
-  security: 'Security'
+  security: 'Security',
+  accounting: 'Accounting',
+  network: 'Network',
+  sales: 'Sales'
 };
 
 const totalTools = server.domains.reduce((sum, d) => sum + d.tools.length, 0);


### PR DESCRIPTION
## Summary

`McpServer.category` allows 7 enum values, but `[id].astro` only had `categoryColors` + `categoryLabels` entries for 4 (psa/rmm/documentation/security). The other 3 (accounting/network/sales) rendered with an empty CSS class + undefined label hint. Pre-existing — affected xero (accounting), domotz (network), salesbuildr (sales), and now sherweb (sales) from PR #94.

This PR adds the 3 missing entries:

- **accounting** → amber badge
- **network** → indigo badge  
- **sales** → pink badge

Color choices visually distinct from the existing 4 (cyan/green/purple/red), same swatch pattern (`bg-{color}-100 text-{color}-700 dark:bg-{color}-900/30 dark:text-{color}-400`).

## Verified locally

- `npm run build` clean (Pagefind 100 pages)
- xero (accounting): amber badge HTML present
- domotz (network): indigo badge HTML present
- sherweb (sales): pink badge HTML present

## Walter 5-area (skipped per community-repo conventions)

Pure CSS/data change in a single .astro file. Zero runtime/credential/data surface.

## Context

Surfaced as non-blocking observation by boss reviewing PR #94. Out of scope for that PR; this is the small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)