### PR TITLE
feat(autotask/tickets): document ticket history audit-trail tools

### DIFF
--- a/msp-claude-plugins/kaseya/autotask/skills/tickets/SKILL.md
+++ b/msp-claude-plugins/kaseya/autotask/skills/tickets/SKILL.md
@@ -23,6 +23,11 @@ triggers:
   - sla calculation
   - ticket metrics
   - ticket kpi
+  - ticket history
+  - ticket audit trail
+  - status transition
+  - who changed
+  - when did ticket
 ---
 
 # Autotask Ticket Management
@@ -351,6 +356,30 @@ Args: {
 ```
 Tool: autotask_get_ticket_details
 Args: { "ticketId": 54321 }
+```
+
+### Get Ticket History (Audit Trail)
+
+Use this to answer **status transition** and **change attribution** questions — e.g. "when did this ticket move from In Progress to Waiting Customer?", "who changed the priority?", "how long did it sit in NEW before someone picked it up?". Each row is one audited field change on the ticket.
+
+```
+Tool: autotask_search_ticket_history
+Args: { "ticketId": 54321, "pageSize": 100 }
+```
+
+**Required:** `ticketId` (Autotask does not support unscoped history queries — there is no way to ask "show me every status transition across all tickets" without enumerating ticket IDs and looping). `pageSize` defaults to 50, max 500.
+
+Returns an array of history entries. Field set is picklist-dependent; common fields include `id`, `ticketID`, `resourceID` (who made the change), `dateChanged`, and field-specific before/after columns. For status transitions, look for changes where the audited field is `status` and compare the before/after picklist IDs against the status codes table above.
+
+**Workflow for "find tickets that went from status X to status Y":**
+1. `autotask_search_tickets` with the relevant filters (company, date range, current status) to get candidate ticket IDs.
+2. For each candidate, call `autotask_search_ticket_history` and look for a status-field change where old=X and new=Y.
+3. This is a fan-out pattern. On large tenants, scope the initial search tightly (by company, date, or assigned resource) before looping.
+
+To fetch a single history entry by its ID:
+```
+Tool: autotask_get_ticket_history
+Args: { "historyId": 987654 }
 ```
 
 ### Add a Ticket Note


### PR DESCRIPTION
Companion to **wyre-technology/autotask-mcp#95**, which exposes `autotask_get_ticket_history` and `autotask_search_ticket_history`.

## Why this exists

The MCP-side PR makes the tools *available*. This PR makes Claude actually *reach for them*. Without skill coverage, the tools appear in `tools/list` but the model has no semantic hook telling it \"audit trail / status transition questions → use these.\" Community report explicitly involved Claude saying \"TicketHistory is not an exposed skill.\"

## Changes

- **New triggers**: `ticket history`, `ticket audit trail`, `status transition`, `who changed`, `when did ticket`.
- **MCP Tool Reference**: new section under `Get Ticket Details` covering both tools, with an example for the fan-out workflow (\"find tickets that went from status X to Y\") which was the original community use case.
- **`ticketId` constraint surfaced up front** so Claude doesn't try unscoped queries that the API rejects.

## Test plan

- [x] Skill frontmatter still valid (triggers list extended, no schema change)
- [x] No conflicting / duplicate trigger phrases with sibling skills
- [ ] Manually verify on next install that asking \"who changed the priority on ticket 12345?\" triggers the tickets skill and reaches for `autotask_search_ticket_history`

## Sequencing

This skill PR is safe to merge before or after autotask-mcp#95 — the worst case if merged first is that Claude tries to call tools the deployed gateway hasn't picked up yet, which fails cleanly with `tool not found`. Once the autotask-mcp release rolls out to the gateway, it just works.