### PR TITLE
docs: customer-facing billing help section

### DIFF
--- a/msp-claude-plugins/docs/src/components/Sidebar.astro
+++ b/msp-claude-plugins/docs/src/components/Sidebar.astro
@@ -77,6 +77,17 @@ const sidebarItems: SidebarItem[] = [
         ],
       },
       {
+        label: 'Billing',
+        children: [
+          { label: 'Overview', href: `${baseUrl}getting-started/billing/` },
+          { label: 'Plan comparison', href: `${baseUrl}getting-started/billing/plans/` },
+          { label: 'Plan changes & upgrades', href: `${baseUrl}getting-started/billing/plan-changes/` },
+          { label: 'Payment & invoices', href: `${baseUrl}getting-started/billing/payment-and-invoices/` },
+          { label: 'Refund policy', href: `${baseUrl}getting-started/billing/refunds/` },
+          { label: 'Double-charge troubleshooting', href: `${baseUrl}getting-started/billing/double-charge/` },
+        ],
+      },
+      {
         label: 'Clients',
         children: [
           { label: 'Claude Code (coming soon)', href: '#' },

--- a/msp-claude-plugins/docs/src/pages/getting-started/billing/double-charge.astro
+++ b/msp-claude-plugins/docs/src/pages/getting-started/billing/double-charge.astro
@@ -1,0 +1,95 @@
+---
+import DocsLayout from '@/layouts/DocsLayout.astro';
+
+const baseUrl = import.meta.env.BASE_URL;
+---
+<DocsLayout title="I think I was double-charged" description="Self-diagnosis and escalation steps if your WYRE MCP Gateway billing looks wrong.">
+  <h1>"I think I was double-charged"</h1>
+
+  <p class="lead text-lg text-[var(--muted)] mb-8">
+    Sorry — billing surprises are the worst. This page walks through what to check, what's usually
+    going on, and exactly what to send us so we can fix it fast.
+  </p>
+
+  <h2>First, a quick gut check</h2>
+  <p>
+    A few situations look like a double-charge but aren't:
+  </p>
+  <ul>
+    <li>
+      <strong>A pending hold plus a settled charge.</strong> Some banks show an authorization and the
+      final charge as two line items for a day or two before they merge. The actual amount taken is
+      the larger of the two, not the sum.
+    </li>
+    <li>
+      <strong>An upgrade proration.</strong> If you upgraded mid-cycle, you'll see a small prorated
+      charge today <em>and</em> your normal renewal on your usual billing date. Both are expected.
+      See <a href={`${baseUrl}getting-started/billing/plan-changes/`}>plan changes & upgrades</a>.
+    </li>
+    <li>
+      <strong>A retried failed payment.</strong> If your card briefly declined, Stripe retries.
+      You'll see the failed attempt and then the successful one — only the successful one actually
+      took money.
+    </li>
+  </ul>
+  <p>
+    If your situation looks like one of those, you're good. If not, keep going.
+  </p>
+
+  <h2>Check your invoices</h2>
+  <ol>
+    <li>Sign in at <a href="https://mcp.wyre.ai">mcp.wyre.ai</a>.</li>
+    <li>Open <strong>Settings → Billing → Manage in Stripe</strong>.</li>
+    <li>Scroll to "Invoice history" and look for two paid invoices close together in time.</li>
+  </ol>
+  <p>
+    If you see two paid invoices and your plan/features didn't actually change to match what you paid
+    for, something went wrong on our end. Skip to "What to send us."
+  </p>
+
+  <h2>Compare against your plan</h2>
+  <p>
+    Open <strong>Settings → Billing</strong> in the dashboard. Your current plan is shown at the top.
+    Sanity check:
+  </p>
+  <ul>
+    <li>Is the plan name what you expected (Pro vs Business)?</li>
+    <li>Do the seat count and connection limits match the
+      <a href={`${baseUrl}getting-started/billing/plans/`}>tier you paid for</a>?</li>
+    <li>If you upgraded recently — say, Pro to Business — and you're still seeing Pro limits, that's
+      a real bug, not your imagination. We want to know.</li>
+  </ul>
+
+  <h2>What to send us</h2>
+  <p>
+    Email <a href="mailto:support@wyretechnology.com">support@wyretechnology.com</a> with:
+  </p>
+  <ul>
+    <li><strong>Your account email and org name.</strong></li>
+    <li>
+      <strong>The two charges you're worried about</strong> — invoice numbers from the Stripe portal
+      (they look like <code>INV-1234</code>), or the date and amount of each charge from your card
+      statement.
+    </li>
+    <li>
+      <strong>What plan you think you should be on</strong> versus what the dashboard is showing.
+    </li>
+    <li>
+      <strong>What you were trying to do</strong> when it happened (upgrade, add a seat, etc.) and
+      roughly when.
+    </li>
+  </ul>
+  <p>
+    With that, we can usually have an answer within the same business day. If it turns out we did
+    bill you twice — or charged you for an upgrade that didn't deliver — we'll issue a refund for the
+    unused portion immediately. See <a href={`${baseUrl}getting-started/billing/refunds/`}>refund
+    policy</a> for the details, including timing.
+  </p>
+
+  <h2>The short version</h2>
+  <p>
+    If it looks wrong, it might be wrong, and that's on us — not you. We'd rather investigate a
+    false alarm than leave a real bug sitting on your card. Just send us the two invoice numbers and
+    we'll take it from there.
+  </p>
+</DocsLayout>

--- a/msp-claude-plugins/docs/src/pages/getting-started/billing/index.astro
+++ b/msp-claude-plugins/docs/src/pages/getting-started/billing/index.astro
@@ -1,0 +1,30 @@
+---
+import DocsLayout from '@/layouts/DocsLayout.astro';
+
+const baseUrl = import.meta.env.BASE_URL;
+---
+<DocsLayout title="Billing & plans" description="Help with billing, plan changes, refunds, payment methods, and invoices for the WYRE MCP Gateway.">
+  <h1>Billing & plans</h1>
+
+  <p class="lead text-lg text-[var(--muted)] mb-8">
+    Everything you need to manage your WYRE MCP Gateway subscription — changing plans, updating
+    your card, downloading invoices, and getting help if something looks wrong on a charge.
+  </p>
+
+  <h2>In this section</h2>
+  <ul>
+    <li><a href={`${baseUrl}getting-started/billing/plans/`}>Plan comparison</a> — what Free, Pro, and Business each include.</li>
+    <li><a href={`${baseUrl}getting-started/billing/plan-changes/`}>Plan changes & upgrades</a> — how upgrades, downgrades, and proration work.</li>
+    <li><a href={`${baseUrl}getting-started/billing/payment-and-invoices/`}>Payment method & invoices</a> — update your card and download receipts.</li>
+    <li><a href={`${baseUrl}getting-started/billing/refunds/`}>Refund policy</a> — when we refund and what to expect.</li>
+    <li><a href={`${baseUrl}getting-started/billing/double-charge/`}>"I think I was double-charged"</a> — what to check and how to get it fixed quickly.</li>
+  </ul>
+
+  <h2>Need a human?</h2>
+  <p>
+    Anything billing-related, email <a href="mailto:support@wyretechnology.com">support@wyretechnology.com</a>.
+    Include your account email and the org name and we'll have an answer the same day in most cases.
+    Sales questions (custom plans, Enterprise, annual contracts) go to
+    <a href="mailto:sales@wyre.ai">sales@wyre.ai</a>.
+  </p>
+</DocsLayout>

--- a/msp-claude-plugins/docs/src/pages/getting-started/billing/payment-and-invoices.astro
+++ b/msp-claude-plugins/docs/src/pages/getting-started/billing/payment-and-invoices.astro
@@ -1,0 +1,73 @@
+---
+import DocsLayout from '@/layouts/DocsLayout.astro';
+
+const baseUrl = import.meta.env.BASE_URL;
+---
+<DocsLayout title="Payment method & invoices" description="How to update your card and download invoices for the WYRE MCP Gateway.">
+  <h1>Payment method & invoices</h1>
+
+  <p class="lead text-lg text-[var(--muted)] mb-8">
+    Payments are handled by Stripe. Card details, invoices, and receipts all live in the Stripe
+    customer portal we link to from your dashboard.
+  </p>
+
+  <h2>Update your card</h2>
+  <ol>
+    <li>Sign in at <a href="https://mcp.wyre.ai">mcp.wyre.ai</a>.</li>
+    <li>Open <strong>Settings → Billing</strong>.</li>
+    <li>Click <strong>Manage in Stripe</strong> — that opens the Stripe customer portal.</li>
+    <li>Add or replace your card. New cards apply to your next charge automatically.</li>
+  </ol>
+  <p>
+    If a payment recently failed, updating the card here will also retry the open invoice within a
+    few minutes.
+  </p>
+
+  <h2>Download invoices and receipts</h2>
+  <p>
+    Every successful charge produces a Stripe-hosted invoice with a PDF and a receipt. You can grab
+    them two ways:
+  </p>
+  <ul>
+    <li>
+      <strong>From the Stripe customer portal</strong> (above) — every invoice you've ever been issued
+      is there, with PDF downloads.
+    </li>
+    <li>
+      <strong>From the email Stripe sends</strong> after each successful payment — the "View invoice"
+      link is the same Stripe-hosted invoice URL (it looks like
+      <code>https://invoice.stripe.com/i/&hellip;</code>) and never expires.
+    </li>
+  </ul>
+
+  <h3>Need the invoice addressed to a different name or VAT/tax ID?</h3>
+  <p>
+    You can edit your billing name, address, and tax ID directly in the Stripe customer portal under
+    "Billing information." Changes apply to future invoices. For a corrected past invoice, email
+    <a href="mailto:support@wyretechnology.com">support@wyretechnology.com</a> and we'll re-issue it.
+  </p>
+
+  <h2>What if my card was declined?</h2>
+  <p>
+    Stripe automatically retries failed cards a few times over the following week. While that's
+    happening:
+  </p>
+  <ul>
+    <li>Your plan stays active — you won't be cut off mid-day for a temporary decline.</li>
+    <li>You'll get an email with a link to retry the invoice with a new card.</li>
+    <li>You can also retry from <strong>Settings → Billing → Manage in Stripe</strong>.</li>
+  </ul>
+  <p>
+    If retries fail for the whole grace period, the subscription cancels and your org drops to the
+    Free tier. Re-subscribing picks up right where you left off.
+  </p>
+
+  <hr class="my-8" />
+
+  <p class="text-sm text-[var(--muted)]">
+    Can't find an invoice or something doesn't add up? Email
+    <a href="mailto:support@wyretechnology.com">support@wyretechnology.com</a>. See also
+    <a href={`${baseUrl}getting-started/billing/double-charge/`}>"I think I was double-charged"</a>
+    and <a href={`${baseUrl}getting-started/billing/refunds/`}>refund policy</a>.
+  </p>
+</DocsLayout>

--- a/msp-claude-plugins/docs/src/pages/getting-started/billing/plan-changes.astro
+++ b/msp-claude-plugins/docs/src/pages/getting-started/billing/plan-changes.astro
@@ -1,0 +1,86 @@
+---
+import DocsLayout from '@/layouts/DocsLayout.astro';
+
+const baseUrl = import.meta.env.BASE_URL;
+---
+<DocsLayout title="Plan changes & upgrades" description="How upgrades, downgrades, and proration work on the WYRE MCP Gateway.">
+  <h1>Plan changes & upgrades</h1>
+
+  <p class="lead text-lg text-[var(--muted)] mb-8">
+    Change plans any time from the billing page in your dashboard. Here's exactly what to expect on
+    your card, your features, and your next invoice.
+  </p>
+
+  <h2>How to change your plan</h2>
+  <ol>
+    <li>Sign in at <a href="https://mcp.wyre.ai">mcp.wyre.ai</a>.</li>
+    <li>Open <strong>Settings → Billing</strong>.</li>
+    <li>Pick the tier you want and confirm.</li>
+  </ol>
+  <p>
+    The new tier is live the moment Stripe confirms the charge — usually within a few seconds. Your
+    limits (seats, connections, credits) update right away.
+  </p>
+
+  <h2>Upgrades</h2>
+  <p>
+    When you upgrade (Free → Pro, or Pro → Business), we modify your existing subscription in place.
+    A few things follow from that:
+  </p>
+  <ul>
+    <li>You get a single, prorated charge today for the difference between the old plan and the new plan, covering the rest of your current billing period.</li>
+    <li>Your billing date doesn't change.</li>
+    <li>Your new features, seat count, and credit allowance unlock immediately.</li>
+    <li>You stay on the same Stripe customer and the same subscription — no duplicate invoices, no second account to manage.</li>
+  </ul>
+
+  <h3>Worked example</h3>
+  <p>
+    You're on Pro ($49/user/mo) with one seat, and you're 10 days into a 30-day billing cycle. You
+    upgrade to Business ($99/user/mo). Roughly:
+  </p>
+  <ul>
+    <li>Pro had ~20 days of unused time left (~$32.67 of credit).</li>
+    <li>Business for those same 20 days costs ~$66.</li>
+    <li>You're charged the difference, ~$33.33, today.</li>
+    <li>On your normal billing date, you get a full Business invoice as usual.</li>
+  </ul>
+  <p class="text-sm text-[var(--muted)]">
+    Stripe handles the proration math; the exact number on your invoice may differ by a few cents.
+  </p>
+
+  <h2>Downgrades</h2>
+  <p>
+    Downgrades (Business → Pro, Pro → Free) take effect at the end of your current billing period.
+    You keep your current tier's features and limits through the period you've already paid for, then
+    drop to the new tier on the next renewal. You're never charged the new tier's price retroactively.
+  </p>
+  <p>
+    Heads up: if your team is over the limits of the new tier (e.g. 5 users dropping to Pro's 3-user
+    cap), excess seats stop being billed but the extra users will lose access on the renewal date.
+    Let us know before you downgrade if you want help handling this gracefully.
+  </p>
+
+  <h2>Cancellations</h2>
+  <p>
+    Cancelling drops you to the Free tier at the end of the current billing period. Your data and
+    connections stay; only the paid features turn off. You can re-subscribe any time and pick up
+    where you left off.
+  </p>
+
+  <h2>Seat changes mid-cycle</h2>
+  <p>
+    Adding or removing a user mid-cycle prorates against the rest of the period. Adding a seat
+    charges the prorated amount immediately. Removing a seat credits the unused portion toward your
+    next invoice.
+  </p>
+
+  <hr class="my-8" />
+
+  <p class="text-sm text-[var(--muted)]">
+    Need help with a change you've already started?
+    Email <a href="mailto:support@wyretechnology.com">support@wyretechnology.com</a> with your org
+    name. See also <a href={`${baseUrl}getting-started/billing/double-charge/`}>"I think I was
+    double-charged"</a> if something looks off after an upgrade.
+  </p>
+</DocsLayout>

--- a/msp-claude-plugins/docs/src/pages/getting-started/billing/plans.astro
+++ b/msp-claude-plugins/docs/src/pages/getting-started/billing/plans.astro
@@ -32,7 +32,7 @@ const baseUrl = import.meta.env.BASE_URL;
         </tr>
         <tr>
           <td>Personal vendor connections</td>
-          <td>1</td>
+          <td>3</td>
           <td>3 per user</td>
           <td>Unlimited</td>
         </tr>
@@ -44,8 +44,8 @@ const baseUrl = import.meta.env.BASE_URL;
         </tr>
         <tr>
           <td>Credits per month</td>
-          <td>200</td>
-          <td>2,000 per seat</td>
+          <td>500</td>
+          <td>1,500 per seat</td>
           <td>4,000 per seat (pooled)</td>
         </tr>
         <tr>

--- a/msp-claude-plugins/docs/src/pages/getting-started/billing/plans.astro
+++ b/msp-claude-plugins/docs/src/pages/getting-started/billing/plans.astro
@@ -1,0 +1,118 @@
+---
+import DocsLayout from '@/layouts/DocsLayout.astro';
+
+const baseUrl = import.meta.env.BASE_URL;
+---
+<DocsLayout title="Plan comparison" description="What's included in Free, Pro, and Business plans on the WYRE MCP Gateway.">
+  <h1>Plan comparison</h1>
+
+  <p class="lead text-lg text-[var(--muted)] mb-8">
+    A quick reference for what each tier includes. For the full side-by-side and current pricing,
+    see the <a href={`${baseUrl}pricing/`}>pricing page</a>.
+  </p>
+
+  <h2>At a glance</h2>
+
+  <div class="overflow-x-auto">
+    <table>
+      <thead>
+        <tr>
+          <th>What you get</th>
+          <th>Free</th>
+          <th>Pro</th>
+          <th>Business</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Users</td>
+          <td>1</td>
+          <td>Up to 3</td>
+          <td>5+</td>
+        </tr>
+        <tr>
+          <td>Personal vendor connections</td>
+          <td>1</td>
+          <td>3 per user</td>
+          <td>Unlimited</td>
+        </tr>
+        <tr>
+          <td>Shared / org connections</td>
+          <td>—</td>
+          <td>5</td>
+          <td>Unlimited</td>
+        </tr>
+        <tr>
+          <td>Credits per month</td>
+          <td>200</td>
+          <td>2,000 per seat</td>
+          <td>4,000 per seat (pooled)</td>
+        </tr>
+        <tr>
+          <td>Team roles & invites</td>
+          <td>—</td>
+          <td>Yes</td>
+          <td>Yes</td>
+        </tr>
+        <tr>
+          <td>Tool allowlists</td>
+          <td>—</td>
+          <td>Yes</td>
+          <td>Yes</td>
+        </tr>
+        <tr>
+          <td>Audit log & log shipping</td>
+          <td>—</td>
+          <td>—</td>
+          <td>Yes</td>
+        </tr>
+        <tr>
+          <td>Service accounts (headless API clients)</td>
+          <td>—</td>
+          <td>—</td>
+          <td>Yes</td>
+        </tr>
+        <tr>
+          <td>Support</td>
+          <td>Community</td>
+          <td>Email</td>
+          <td>Dedicated</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <p class="text-sm text-[var(--muted)] mt-2">
+    1 credit = 1 successful tool call to a connected vendor. Failed calls and tool browsing don't count.
+  </p>
+
+  <h2>What's a "connection"?</h2>
+  <p>
+    A connection is one set of API credentials for one vendor — for example, your Autotask API user
+    or your HaloPSA token. Connecting Autotask + ConnectWise + HaloPSA = three connections.
+  </p>
+  <ul>
+    <li><strong>Personal</strong> connections use credentials you set up, and only you can call them.</li>
+    <li><strong>Shared / org</strong> connections are set up once by an admin and available to everyone on the team.</li>
+  </ul>
+
+  <h2>What happens if I hit my credit limit?</h2>
+  <p>
+    Tool calls return a friendly "credit limit reached" error until the next monthly reset, or until
+    you either purchase a credit block ($10 per 1,000 credits, no expiry) or move up a tier. Browsing
+    tools, reading docs, and managing connections always remain free.
+  </p>
+
+  <h2>Need something custom?</h2>
+  <p>
+    Larger teams, SSO/SAML, SCIM, custom credit packages, or contract terms are part of Enterprise.
+    Email <a href="mailto:sales@wyre.ai">sales@wyre.ai</a> and we'll put together a plan.
+  </p>
+
+  <hr class="my-8" />
+
+  <p class="text-sm text-[var(--muted)]">
+    Questions about your specific account? Email
+    <a href="mailto:support@wyretechnology.com">support@wyretechnology.com</a>.
+  </p>
+</DocsLayout>

--- a/msp-claude-plugins/docs/src/pages/getting-started/billing/refunds.astro
+++ b/msp-claude-plugins/docs/src/pages/getting-started/billing/refunds.astro
@@ -1,0 +1,73 @@
+---
+import DocsLayout from '@/layouts/DocsLayout.astro';
+
+const baseUrl = import.meta.env.BASE_URL;
+---
+<DocsLayout title="Refund policy" description="When WYRE refunds charges on the MCP Gateway and what to expect.">
+  <h1>Refund policy</h1>
+
+  <p class="lead text-lg text-[var(--muted)] mb-8">
+    Short version: if we billed you for something you didn't actually get, we refund. If you used the
+    service and changed your mind later, we'll usually cancel future renewals instead. Either way,
+    we'd rather you reach out than stew on it — email
+    <a href="mailto:support@wyretechnology.com">support@wyretechnology.com</a> and we'll sort it.
+  </p>
+
+  <h2>When we refund</h2>
+  <ul>
+    <li>
+      <strong>You were billed for something we didn't deliver.</strong> For example, an upgrade that
+      didn't actually apply your new tier's features. Refunded in full or prorated against the unused
+      time, whichever fits.
+    </li>
+    <li>
+      <strong>You cancelled and were billed for the period after.</strong> If a cancellation didn't
+      register on our side and you were charged for the next cycle, we refund the prorated unused
+      portion.
+    </li>
+    <li>
+      <strong>You changed your mind within 7 days of subscribing.</strong> Full refund of the most
+      recent charge, no questions.
+    </li>
+  </ul>
+
+  <h2>When we don't refund</h2>
+  <ul>
+    <li>
+      <strong>You used the service for months and want a refund for past billing periods.</strong>
+      We'll cancel future renewals immediately so you aren't billed again, but we don't refund usage
+      that already happened.
+    </li>
+    <li>
+      <strong>Credit blocks that have been partially consumed.</strong> Unused credit blocks
+      themselves don't expire — they roll forward — so you keep what you've already bought.
+    </li>
+  </ul>
+
+  <p>
+    Edge cases exist and we use judgement. If your situation isn't covered above, just ask.
+  </p>
+
+  <h2>How refunds get to you</h2>
+  <p>
+    Refunds go back to the original card via Stripe. Once we issue the refund, expect it on your
+    statement in <strong>5–10 business days</strong> depending on your bank — some are faster, a few
+    are slower. We'll send you a confirmation email the moment it's issued.
+  </p>
+
+  <h2>How to request one</h2>
+  <p>
+    Email <a href="mailto:support@wyretechnology.com">support@wyretechnology.com</a> with:
+  </p>
+  <ul>
+    <li>The account email and org name.</li>
+    <li>The invoice or charge in question (the Stripe receipt link or the date and amount).</li>
+    <li>A sentence on what went wrong.</li>
+  </ul>
+  <p>
+    Most refunds are handled the same day. If the situation needs investigation — for example, a
+    suspected double-charge — see the
+    <a href={`${baseUrl}getting-started/billing/double-charge/`}>"I think I was double-charged"</a>
+    page for what to send so we can move faster.
+  </p>
+</DocsLayout>


### PR DESCRIPTION
## Summary

Adds a customer-facing billing help section at `/getting-started/billing/` on mcp.wyre.ai, sourced from this repo's Astro docs site. Triggered by yesterday's Billy incident (Pro->Business upgrade silently failed via duplicate Stripe customer, fixed in `mcp-gateway` PR #121) — we now have an internal engineering runbook for billing issues, and this PR is the matching public-facing help docs.

## Pages added

- `getting-started/billing/index.astro` — section landing page.
- `getting-started/billing/plans.astro` — Free vs Pro vs Business at-a-glance comparison.
- `getting-started/billing/plan-changes.astro` — how upgrades/downgrades/proration work, including the post-PR-121 in-place subscription behavior with a worked proration example.
- `getting-started/billing/payment-and-invoices.astro` — update card, download invoices from the Stripe customer portal, retry failed payments.
- `getting-started/billing/refunds.astro` — when we refund and when we don't, framed for customers (matches the runbook's refund matrix). Uses "5-10 business days depending on your bank" language.
- `getting-started/billing/double-charge.astro` — the Billy-style self-diagnose-or-escalate flow: rule out pending holds / proration / retried declines, then exactly what to send support.

Also wires a new "Billing" subsection into the Gateway nav in `Sidebar.astro`.

## Style / tone

- Matches the existing customer-facing voice in `getting-started/` (warm, plain English, owns problems).
- Sentence-case headings to match surrounding pages.
- No emoji.
- Internal links between the five new pages.
- Each page ends with a support contact (`support@wyretechnology.com`).

## Test plan

- [ ] `npm run build` in `msp-claude-plugins/docs/` — could not run locally; `npm install` failed on `sharp@0.34.5` trying to build from source. CI should build cleanly.
- [ ] Visual check on the dev site: new "Billing" group appears under Gateway in the sidebar and all six pages render inside `DocsLayout`.
- [ ] Confirm internal cross-links resolve.
- [ ] Confirm Free-tier numbers in `plans.astro` (1 user, 1 personal connection, 200 credits/mo) — inferred for the customer-facing table; the existing `PricingMatrix` doesn't have a Free column. Adjust if a different Free shape is correct.

## Open questions

- Existing `PricingMatrix` on the pricing page doesn't include Free; I added Free to the docs comparison table to match the task. Happy to drop or align.
- Proration worked-example uses round numbers; Stripe's actual math may differ by a few cents (noted in the page).