### PR TITLE
feat: add microsoft-graph and azure-mcp plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "msp-claude-plugins",
   "description": "Community-driven Claude Code plugins for Managed Service Providers. Integrates with PSA, RMM, and documentation tools.",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "owner": {
     "name": "Aaron Sachs"
   },
@@ -708,6 +708,34 @@
         "gateway",
         "orchestration",
         "cross-vendor",
+        "msp"
+      ]
+    },
+    {
+      "name": "microsoft-graph",
+      "source": "./msp-claude-plugins/microsoft-graph/microsoft-graph",
+      "description": "Microsoft Graph Enterprise MCP - read-only natural-language queries over Microsoft Entra identity and directory data: users, groups, applications, devices, and admin reporting (public preview)",
+      "version": "1.0.0",
+      "category": "productivity",
+      "tags": [
+        "microsoft-graph",
+        "entra",
+        "identity",
+        "m365",
+        "msp"
+      ]
+    },
+    {
+      "name": "azure-mcp",
+      "source": "./msp-claude-plugins/azure-mcp/azure-mcp",
+      "description": "Azure MCP Server - read-only Azure observability, cost, and resource-health analysis in natural language: monitoring, pricing, quota, advisor, resource health, diagnostics",
+      "version": "1.0.0",
+      "category": "monitoring",
+      "tags": [
+        "azure",
+        "cloud",
+        "observability",
+        "cost",
         "msp"
       ]
     }

--- a/msp-claude-plugins/azure-mcp/azure-mcp/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/azure-mcp/azure-mcp/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "azure-mcp",
+  "version": "1.0.0",
+  "description": "Claude plugins for the Azure MCP Server — read-only Azure observability, cost, and resource health in natural language: Monitor metrics and Log Analytics KQL, retail pricing, quotas, Advisor recommendations, Resource Health, AppLens diagnostics, and subscription/resource-group inventory across tenants",
+  "author": {
+    "name": "MSP Claude Plugins Community"
+  },
+  "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
+  "repository": "https://github.com/wyre-technology/msp-claude-plugins",
+  "license": "Apache-2.0"
+}

--- a/msp-claude-plugins/azure-mcp/azure-mcp/README.md
+++ b/msp-claude-plugins/azure-mcp/azure-mcp/README.md
@@ -1,6 +1,6 @@
 # Azure MCP Plugin
 
-Claude plugins for the **Azure MCP Server** — Microsoft's official MCP server (`mcr.microsoft.com/azure-sdk/azure-mcp`) for operating Azure resources in natural language.
+Claude plugins for the **Azure MCP Server** — Microsoft's official MCP server (`mcr.microsoft.com/azure-sdk/azure-mcp`) for observing Azure resources in natural language.
 
 This plugin orients Claude around the `azure-mcp` vendor as deployed in the **WYRE MCP Gateway**: a WYRE-built sidecar that runs the Azure MCP Server with per-tenant credential isolation. Each connecting MSP supplies its own Azure **service principal**, and the gateway scopes every request to that tenant.
 

--- a/msp-claude-plugins/azure-mcp/azure-mcp/README.md
+++ b/msp-claude-plugins/azure-mcp/azure-mcp/README.md
@@ -1,0 +1,61 @@
+# Azure MCP Plugin
+
+Claude plugins for the **Azure MCP Server** — Microsoft's official MCP server (`mcr.microsoft.com/azure-sdk/azure-mcp`) for operating Azure resources in natural language.
+
+This plugin orients Claude around the `azure-mcp` vendor as deployed in the **WYRE MCP Gateway**: a WYRE-built sidecar that runs the Azure MCP Server with per-tenant credential isolation. Each connecting MSP supplies its own Azure **service principal**, and the gateway scopes every request to that tenant.
+
+> **Read-only by design.** The gateway runs the Azure MCP Server with `--read-only` and a deliberately constrained namespace allowlist. As shipped, this plugin is an Azure **observability, cost, and resource-health** tool. It cannot provision, modify, or delete Azure infrastructure.
+
+## What's in this plugin
+
+### Skills (3)
+
+| Skill | Coverage |
+|-------|----------|
+| `connection` | Connecting `azure-mcp` through the WYRE gateway, registering an Azure service principal, and least-privilege RBAC guidance |
+| `observability` | `monitor` (metrics, Log Analytics KQL, alerts), `resourcehealth`, `applens`, `advisor` |
+| `cost-and-capacity` | `pricing`, `quota`, `subscription`, `group` |
+
+### Agents (1)
+
+- **`azure-ops-analyst`** — investigates resource health, summarizes cost and Advisor findings, and reports observability posture. A diagnostician and reporter — never an operator.
+
+### Commands (2)
+
+- **`/azure-mcp:azure-cost`** — cost and pricing analysis (Advisor cost recommendations + retail pricing + subscription scoping)
+- **`/azure-mcp:azure-diagnostics`** — resource health and diagnostics triage (Resource Health + AppLens + Monitor alerts)
+
+## Enabled namespaces
+
+The gateway deployment enables exactly **eight** read-leaning namespaces on day one. Tool names follow the Azure MCP Server's namespace convention (`azmcp` / `azure_mcp` prefixes) — described here at the capability level.
+
+| Namespace | What it does |
+|-----------|--------------|
+| `monitor` | Azure Monitor — metrics, Log Analytics / KQL queries, alert state |
+| `pricing` | Azure retail pricing lookups |
+| `quota` | Subscription quota and usage limits |
+| `advisor` | Azure Advisor recommendations — cost, security, reliability, performance, operational excellence |
+| `resourcehealth` | Resource Health — availability and status of Azure resources |
+| `applens` | AppLens diagnostics — deep diagnostics for app/resource problems |
+| `subscription` | List and inspect Azure subscriptions |
+| `group` | List and inspect resource groups |
+
+### Deliberately excluded
+
+Write- and delete-capable namespaces — `storage`, `keyvault`, `compute`, `role`, `aks`, and others — are **not enabled**. They are excluded on purpose so the connector cannot mutate Azure infrastructure or read secret material. Do not document or attempt those operations through this plugin.
+
+## How to connect
+
+1. In your Azure tenant, register (or reuse) an Azure AD **service principal** — an app registration with a client secret.
+2. Grant the service principal **least-privilege, Reader-tier RBAC** at subscription scope — `Reader` plus `Cost Management Reader` is sufficient for all eight enabled namespaces. No write or contributor roles are needed.
+3. In the WYRE MCP Gateway connection UI, connect the **`azure-mcp`** vendor and supply: **Tenant ID**, **Service Principal Client ID**, and **Service Principal Client Secret**.
+4. The gateway routes and authenticates Azure MCP tools through your gateway session, scoped to the credentials you supplied.
+
+See the `connection` skill for the full step-by-step, including the exact RBAC roles and the security rationale.
+
+## Resources
+
+- Azure MCP Server: https://github.com/Azure/azure-mcp
+- Azure MCP Server image: `mcr.microsoft.com/azure-sdk/azure-mcp`
+- WYRE MCP Gateway: https://mcp.wyre.ai
+- Azure RBAC built-in roles: https://learn.microsoft.com/azure/role-based-access-control/built-in-roles

--- a/msp-claude-plugins/azure-mcp/azure-mcp/agents/azure-ops-analyst.md
+++ b/msp-claude-plugins/azure-mcp/azure-mcp/agents/azure-ops-analyst.md
@@ -1,0 +1,40 @@
+---
+name: azure-ops-analyst
+description: Use this agent when an MSP engineer, service manager, or cloud lead needs a read-only Azure operations investigation — resource health triage, cost and Azure Advisor analysis, quota/capacity headroom checks, and observability-posture reporting across subscriptions. This agent is a diagnostician and reporter, never an operator — the azure-mcp connector is read-only and the agent must never claim to have changed, provisioned, or deleted Azure resources. Trigger for health investigations, cost reviews, capacity checks, and posture summaries. Examples - "Why is this App Service degraded?", "Summarize Advisor cost recommendations for the prod subscription", "Do we have vCPU headroom to scale out in eastus?", "Give me an observability posture report for these subscriptions", "Triage the alerts that fired overnight". If asked to fix, resize, restart, or provision anything, the agent states the connector is read-only and that the operation is out of scope rather than attempting it.
+tools: ["Bash", "Read", "Write", "Glob", "Grep"]
+model: inherit
+---
+
+You are an expert Azure operations analyst working through the `azure-mcp` connector in the WYRE MCP Gateway. Your job is to turn raw Azure telemetry — Resource Health, AppLens diagnostics, Monitor metrics and logs, Advisor recommendations, pricing, quotas, and inventory — into a clear, prioritized operations picture for an MSP managing Azure on behalf of clients. You are the bridge between "Azure shows a lot of signal" and "here is what is actually wrong, what it will cost, and what to do next."
+
+## Hard guardrail — this connector is read-only
+
+The `azure-mcp` connector is deployed read-only. The gateway runs the Azure MCP Server with `--read-only` and enables only eight read-leaning namespaces: `monitor`, `pricing`, `quota`, `advisor`, `resourcehealth`, `applens`, `subscription`, `group`. Write- and delete-capable namespaces (`storage`, `keyvault`, `compute`, `role`, `aks`, and others) are not available.
+
+This is non-negotiable:
+
+- **Never claim to have changed, provisioned, resized, restarted, deleted, or remediated any Azure resource.** You cannot, and the connector cannot.
+- **If a user asks for a write/modify/delete/provision operation, do not attempt it and do not pretend to.** State plainly: "The `azure-mcp` connector is read-only — it cannot perform that operation. I can investigate and recommend, but the change has to go through a write-capable path." Then deliver the investigation and recommendation instead.
+- **Frame every recommendation as advice, not action.** "Advisor recommends right-sizing this VM" — not "I right-sized this VM." When you report a recommended fix, make explicit that executing it is outside your scope.
+
+You are a diagnostician and reporter. That is the whole job, and it is a valuable one.
+
+## How you work
+
+You operate at two zoom levels: a single-resource or single-subscription deep-dive when something is in the spotlight, and a multi-subscription sweep when comparing posture across a portfolio. You always start with the `subscription` namespace to ground yourself in what the connected service principal can actually see — never assume scope.
+
+For **health investigations**, you start with `resourcehealth` to get the platform's verdict and reason classification. If the reason is platform-initiated, you say so and stop chasing a customer-side cause — the fix, if any, is failover or waiting. If the resource is degraded with a customer-side or unclear cause, you run `applens` detectors to find the failing detector and dependency chain, then confirm and quantify impact with `monitor` metrics and a bounded Log Analytics KQL query. You check `monitor` alerts to see whether the incident was caught — a real incident with no fired alert is an alerting-coverage gap you flag.
+
+For **cost analysis**, you pull `advisor` recommendations filtered to the Cost category, sort by impact and estimated savings, and use `pricing` to quantify the spread between current and recommended configurations. You are always explicit that `pricing` returns retail list rates — not the customer's discounted EA/CSP/MCA pricing and not actual billed consumption. You never present a retail estimate as a guaranteed cost.
+
+For **capacity checks**, you use `quota` to compare requested or projected capacity against `limit - usage` for the relevant provider and region. You flag quotas above ~80% utilization as proactive quota-increase candidates — and note that the increase itself is a support/write action you cannot perform.
+
+For **posture sweeps**, you traverse subscriptions via `subscription`, map resource groups via `group`, and produce a per-subscription scorecard: Advisor finding counts by category, resources in a degraded health state, alert-coverage gaps, and quota pressure. You sort by risk so the MSP can triage in priority order.
+
+## Reporting standards
+
+Your reports are actionable, not just descriptive. Every finding carries: severity/impact, affected resources, the likely cause, and a recommended next step — with the explicit note that you can recommend but not execute. You separate findings that need same-day attention (resource unavailable, fired critical alerts, quota fully exhausted blocking growth) from findings that can be planned and batched (Cost and Operational Excellence Advisor items, sub-critical right-sizing).
+
+When you produce client-facing language, you translate Azure jargon into plain terms — "the resource Azure reports as Unavailable" becomes "the client's web application has been down since 02:14" — and you keep raw IDs and KQL in a technical appendix.
+
+You validate before reporting: Advisor recommendations refresh on a delay, so a recommendation may lag a recent change; Resource Health can briefly read `Unknown` during a transition. When a signal looks transient, you re-check before escalating it as a finding. You always state the subscription, scope, and time window you analyzed so the report is reproducible.

--- a/msp-claude-plugins/azure-mcp/azure-mcp/commands/azure-cost.md
+++ b/msp-claude-plugins/azure-mcp/azure-mcp/commands/azure-cost.md
@@ -1,0 +1,39 @@
+---
+name: azure-cost
+description: Azure cost and pricing analysis for a subscription — Advisor cost recommendations, retail pricing lookups, and quota-driven right-sizing signals, scoped to one subscription
+arguments:
+  - name: subscription
+    description: Azure subscription ID or display name to analyze
+    required: true
+  - name: detail
+    description: summary (default) — top findings and estimated savings; full — every recommendation and price; executive — client-facing cost summary
+    required: false
+---
+
+# Azure Cost Analysis
+
+Produces a read-only cost picture for a single Azure subscription. Suitable for monthly cost reviews, pre-QBR prep, right-sizing investigations, and "why is this subscription expensive?" questions.
+
+This command is **read-only** — it analyzes and recommends; it never changes resources, SKUs, or reservations.
+
+## What it does
+
+1. **Scope** — resolve the subscription via the `subscription` namespace; confirm it is `Enabled`.
+2. **Advisor cost recommendations** — pull `advisor` recommendations filtered to the **Cost** category, sorted by impact (High first) and estimated annual savings. These are the concrete optimization opportunities: idle resources, underutilized VMs, reservation/savings-plan candidates.
+3. **Retail pricing** — for the SKUs implicated in the recommendations (or SKUs the user asks about), look up retail meter rates via the `pricing` namespace to quantify the spread between current and recommended configurations.
+4. **Capacity signal** — optionally check `quota` headroom; quotas near their limit hint at over-provisioning or imminent scaling cost.
+
+## Detail levels
+
+- **summary** (default): top cost recommendations, estimated total savings, one-line cost verdict
+- **full**: every Advisor cost recommendation with affected resources, plus the retail price for each relevant SKU
+- **executive**: plain-language cost summary suitable for a client-facing email — savings framed in currency, not SKU jargon
+
+## Important caveats
+
+- Retail pricing is **list price** — not the customer's EA/CSP/MCA-discounted rate and not actual billed consumption. Present figures as estimates and state the currency and region.
+- This command **cannot apply** any recommendation — resizing, deleting idle resources, or buying reservations are write operations outside this read-only connector. Report the opportunity and hand off to a write-capable path.
+
+## When to use the agent instead
+
+For multi-subscription cost comparison, narrative reporting, or combining cost with health/Advisor posture, delegate to the `azure-ops-analyst` agent. This command produces the cost data for one subscription; the agent produces the cross-subscription story.

--- a/msp-claude-plugins/azure-mcp/azure-mcp/commands/azure-diagnostics.md
+++ b/msp-claude-plugins/azure-mcp/azure-mcp/commands/azure-diagnostics.md
@@ -1,0 +1,42 @@
+---
+name: azure-diagnostics
+description: Resource health and diagnostics triage for an Azure resource or subscription — Resource Health status, AppLens deep diagnostics, and Azure Monitor alert state
+arguments:
+  - name: target
+    description: Azure resource ID, resource group, or subscription ID to triage
+    required: true
+  - name: window
+    description: Lookback window for alerts and metrics (e.g. 1h, 24h, 7d) — defaults to 24h
+    required: false
+---
+
+# Azure Diagnostics Triage
+
+Runs a focused, read-only diagnostics pass over an Azure resource, resource group, or subscription. Use it for "is something wrong with [resource]?" investigations, incident triage, and post-incident review.
+
+This command is **read-only** — it diagnoses and reports; it never restarts, reconfigures, or remediates a resource.
+
+## What it checks
+
+1. **Resource Health** — `resourcehealth` for the current availability state (`Available` / `Degraded` / `Unavailable` / `Unknown`) and the reason classification (platform-initiated, customer-initiated, unplanned). Surfaces any active subscription-level health events.
+2. **AppLens diagnostics** — when Resource Health is degraded or the picture is unclear, run `applens` detectors against the resource to identify the tripped detector, the failing dependency, and Microsoft's recommended mitigation.
+3. **Monitor alerts** — `monitor` to list alert rules covering the target and their fired/resolved state within the lookback window.
+4. **Supporting metrics** — pull relevant `monitor` metric series (and, where useful, a bounded Log Analytics KQL query) around the incident window to confirm and quantify impact.
+
+## Output
+
+A triage report covering:
+
+- **Verdict** — healthy, degraded, or unavailable, with the most likely cause
+- **Azure-side vs. customer-side** — whether a platform-initiated event explains the symptom (nothing to fix customer-side) or a customer-side cause needs action
+- **Evidence** — the AppLens detector results, fired alerts, and metric/log excerpts that support the verdict
+- **Recommended next steps** — what to do, explicitly noting that any fix happens through a separate write-capable path, not this connector
+
+## Caveats
+
+- **Read-only.** This command cannot acknowledge alerts, restart resources, or apply fixes. It identifies the problem and the recommended action; execution is out of scope for the `azure-mcp` connector.
+- Scope the `window` to the incident — a wide window dilutes the signal and slows queries.
+
+## When to use the agent instead
+
+For correlating diagnostics across multiple resources, producing a narrative incident summary, or combining health with cost/Advisor posture, delegate to the `azure-ops-analyst` agent.

--- a/msp-claude-plugins/azure-mcp/azure-mcp/skills/connection/SKILL.md
+++ b/msp-claude-plugins/azure-mcp/azure-mcp/skills/connection/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: "azure-mcp-connection"
+description: "Use this skill when connecting the azure-mcp vendor through the WYRE MCP Gateway — registering an Azure service principal, supplying tenantId/clientId/clientSecret, and granting least-privilege Reader-tier RBAC. Covers the read-only deployment model and why broader write roles must not be granted."
+when_to_use: "When setting up or troubleshooting the azure-mcp connector — creating an Azure service principal, choosing RBAC roles, or explaining the read-only constraint to an MSP onboarding a tenant"
+triggers:
+  - connect azure mcp
+  - azure mcp setup
+  - azure service principal
+  - azure mcp credentials
+  - azure rbac for mcp
+  - azure connector
+  - azure mcp permissions
+  - register azure app
+  - least privilege azure
+---
+
+# Azure MCP Connection
+
+The `azure-mcp` vendor runs Microsoft's official Azure MCP Server (`mcr.microsoft.com/azure-sdk/azure-mcp`) as a WYRE-built sidecar inside the MCP gateway. Each connecting MSP supplies its own Azure **service principal**; the gateway isolates credentials per tenant and scopes every request to the principal you registered.
+
+## Read-only deployment — read this first
+
+The gateway runs the Azure MCP Server with the `--read-only` flag and a deliberately constrained namespace allowlist. Day-one the connector exposes exactly eight read-leaning namespaces:
+
+```
+monitor   pricing   quota   advisor   resourcehealth   applens   subscription   group
+```
+
+Write- and delete-capable namespaces (`storage`, `keyvault`, `compute`, `role`, `aks`, and others) are **not enabled**. This is intentional defense-in-depth: even if a service principal were over-privileged, the gateway cannot route a mutating call. As shipped, `azure-mcp` is an Azure observability, cost, and resource-health tool — nothing it does changes infrastructure.
+
+Because the deployment is read-only, the service principal you connect should also be read-only. Grant Reader-tier roles and nothing more.
+
+## Step 1 — Register an Azure service principal
+
+In the Azure tenant you want to manage, create an Azure AD **app registration** with a client secret. Either the portal (**Microsoft Entra ID → App registrations → New registration**) or the CLI works:
+
+```
+az ad sp create-for-rbac \
+  --name "wyre-azure-mcp" \
+  --role "Reader" \
+  --scopes "/subscriptions/<subscription-id>"
+```
+
+This emits three values you will need for the gateway:
+
+- `tenant`   → **Tenant ID**
+- `appId`    → **Service Principal Client ID**
+- `password` → **Service Principal Client Secret** (shown once — capture it now)
+
+If you reuse an existing app registration, generate a fresh client secret under **Certificates & secrets** and note its expiry — the connector stops working when the secret lapses.
+
+## Step 2 — Grant least-privilege RBAC
+
+Assign **Reader-tier roles only**, at **subscription scope** (or management-group scope to cover several subscriptions). These two built-in roles cover all eight enabled namespaces:
+
+| Role | Why it is needed | Covers |
+|------|------------------|--------|
+| `Reader` | Read-only visibility into resources, metrics, health, and inventory | `monitor`, `resourcehealth`, `applens`, `advisor`, `subscription`, `group` |
+| `Cost Management Reader` | Read access to cost, pricing, and usage data | `pricing`, `quota`, cost-focused `advisor` recommendations |
+
+```
+az role assignment create \
+  --assignee "<service-principal-client-id>" \
+  --role "Reader" \
+  --scope "/subscriptions/<subscription-id>"
+
+az role assignment create \
+  --assignee "<service-principal-client-id>" \
+  --role "Cost Management Reader" \
+  --scope "/subscriptions/<subscription-id>"
+```
+
+For Log Analytics KQL queries via the `monitor` namespace, `Reader` on the subscription is sufficient because it inherits to the workspace. If a workspace lives outside the granted scope, add `Log Analytics Reader` on that specific workspace — still a Reader-tier role.
+
+### Do not grant write roles
+
+`Contributor`, `Owner`, `User Access Administrator`, `Key Vault Secrets User`, and similar write/secret roles are **unnecessary and must not be granted**. The connector cannot use them — the gateway runs `--read-only` and the write namespaces are not in the allowlist. Granting them only widens the blast radius of a leaked secret with zero functional benefit. Least privilege here is both a security control and a no-cost decision.
+
+## Step 3 — Connect in the WYRE gateway
+
+In the gateway connection UI, choose the **`azure-mcp`** vendor and supply:
+
+1. **Tenant ID** — the directory the service principal lives in
+2. **Service Principal Client ID** — the app registration's `appId`
+3. **Service Principal Client Secret** — the secret from Step 1
+
+The gateway authenticates the Azure MCP sidecar with these credentials and routes the eight enabled namespaces' tools into your session. No Azure credentials are stored client-side.
+
+## Verifying the connection
+
+After connecting, confirm the connector is live with a harmless read:
+
+1. List subscriptions (`subscription` namespace) — confirms the service principal authenticated and has at least Reader visibility.
+2. List resource groups (`group` namespace) for one subscription — confirms scope is correct.
+3. If either returns an empty result or an authorization error, the service principal lacks a role assignment at the expected scope, or the client secret has expired — re-check Step 2 and the secret's validity.
+
+## Troubleshooting
+
+- **`AuthorizationFailed` / empty subscription list** — no `Reader` assignment at the subscription/management-group scope, or the assignment hasn't propagated yet (allow a few minutes).
+- **Cost or pricing tools return nothing** — `Cost Management Reader` is missing.
+- **Connector worked, then stopped** — the client secret expired. Generate a new one and update the gateway connection.
+- **A user asks for a write/provision/delete operation** — that is out of scope for this connector by design. Explain that `azure-mcp` is a read-only deployment and the relevant namespace is not enabled; do not attempt a workaround.

--- a/msp-claude-plugins/azure-mcp/azure-mcp/skills/cost-and-capacity/SKILL.md
+++ b/msp-claude-plugins/azure-mcp/azure-mcp/skills/cost-and-capacity/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: "azure-mcp-cost-and-capacity"
+description: "Use this skill for Azure cost, pricing, capacity, and inventory work through the azure-mcp connector — retail pricing lookups, subscription quota and usage-limit checks, and listing/inspecting subscriptions and resource groups. All read-only."
+when_to_use: "When estimating Azure cost, checking quota headroom before scaling a deployment, or taking inventory of subscriptions and resource groups"
+triggers:
+  - azure pricing
+  - azure cost estimate
+  - retail price azure
+  - azure quota
+  - azure usage limits
+  - quota check
+  - azure subscriptions
+  - resource groups
+  - azure inventory
+  - pre-deployment check
+---
+
+# Azure Cost & Capacity
+
+This skill covers the cost, capacity, and inventory side of the `azure-mcp` connector: the `pricing`, `quota`, `subscription`, and `group` namespaces. All four are **read-only** — they answer "what would this cost", "do we have headroom", and "what exists", never "provision this".
+
+Tool names follow the Azure MCP Server's namespace convention (`azmcp` / `azure_mcp` prefixes, grouped under `pricing`, `quota`, `subscription`, `group`). Invoke them by capability.
+
+## Namespace surface
+
+### `subscription` — subscription inventory
+
+Lists the Azure subscriptions the connected service principal can see, with their IDs, display names, and state (`Enabled`, `Disabled`, `Warned`). This is almost always the **first call** in any workflow — nearly every other namespace needs a subscription ID for scope.
+
+### `group` — resource-group inventory
+
+Lists and inspects resource groups within a subscription: name, location, tags, and provisioning state. Use it to map the shape of an environment, find resources by tag, or pick the right scope for a pricing or quota question.
+
+### `pricing` — Azure retail pricing
+
+Looks up Azure **retail** prices from the public Azure Retail Prices API — meter rates by service, SKU, region, and currency. This gives list pricing, not the customer's negotiated or EA/CSP pricing, and not actual billed consumption. Treat its output as an estimate baseline.
+
+### `quota` — quota & usage limits
+
+Reports subscription quotas and current usage for a resource provider and region — e.g. vCPU quota for a VM family, public IP count, network interface count. Each entry shows the limit, current usage, and therefore the remaining headroom.
+
+## Workflow patterns
+
+### Pre-deployment quota check
+
+Before someone scales a deployment or stands up new resources, confirm there is headroom:
+
+1. **`subscription`** — resolve the target subscription ID.
+2. **`quota`** — pull quota and current usage for the relevant provider and region (e.g. `Microsoft.Compute` vCPUs in `eastus`).
+3. Compare requested capacity against `limit - usage`. If headroom is insufficient, report the exact shortfall and the region — a quota increase is a separate, write/support action outside this connector.
+
+Catching this before deployment avoids a half-failed rollout when Azure rejects the request at `limit`.
+
+### Cost estimation
+
+When asked "what would X cost":
+
+1. **`subscription`** / **`group`** — establish scope and region (region materially changes price).
+2. **`pricing`** — look up the retail meter rate for each SKU involved (compute size, storage tier, bandwidth).
+3. Multiply by expected quantity and runtime to produce an estimate.
+4. **State the assumptions plainly** — this is *retail list pricing* in a stated currency and region. Actual billing depends on the customer's agreement (EA/CSP/MCA discounts), reservations, and real consumption. Never present a retail estimate as the customer's actual or guaranteed cost.
+
+For what a customer *actually spent*, that is consumption/billing data — the `pricing` namespace does not provide it. Cost-saving opportunities on existing spend come from Azure Advisor's Cost recommendations (see the `observability` skill).
+
+### Subscription & resource-group inventory
+
+For an environment audit or onboarding discovery:
+
+1. **`subscription`** — enumerate all visible subscriptions; flag any `Disabled` or `Warned`.
+2. **`group`** — for each subscription, list resource groups with their locations and tags.
+3. Cross-reference tags against the MSP's tagging standard — untagged or mistagged groups are governance findings worth surfacing.
+
+### Capacity headroom report
+
+Run `quota` across the key providers (`Microsoft.Compute`, `Microsoft.Network`, `Microsoft.Storage`) for the regions a customer uses, and produce a headroom table. Quotas above ~80% usage are worth a proactive quota-increase request before they block growth.
+
+## Constraints & caveats
+
+- **Read-only.** This skill estimates, checks, and inventories. It cannot raise a quota, create a subscription or resource group, or apply pricing changes. Quota increases go through an Azure support/quota request — out of scope for this connector.
+- **Retail vs. actual price.** `pricing` returns public retail rates only. It is an estimation baseline, never the customer's billed amount.
+- **Scope first.** Resolve subscription (and often resource group) before pricing or quota calls — they are scoped operations.
+- **Visibility is RBAC-bounded.** `subscription` only shows subscriptions where the service principal holds a role assignment. A "missing" subscription usually means a missing Reader assignment, not a deleted subscription.

--- a/msp-claude-plugins/azure-mcp/azure-mcp/skills/observability/SKILL.md
+++ b/msp-claude-plugins/azure-mcp/azure-mcp/skills/observability/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: "azure-mcp-observability"
+description: "Use this skill for Azure observability, diagnostics, and resource-health work through the azure-mcp connector — pulling Azure Monitor metrics, running Log Analytics KQL queries, checking alert state, reading Resource Health status, triaging AppLens diagnostics, and reviewing Azure Advisor recommendations. All read-only."
+when_to_use: "When investigating a degraded or unhealthy Azure resource, querying logs/metrics, checking alerts, or triaging Advisor recommendations across a subscription"
+triggers:
+  - azure monitor
+  - log analytics
+  - kql query
+  - azure metrics
+  - azure alerts
+  - resource health
+  - azure resource down
+  - applens
+  - azure diagnostics
+  - azure advisor
+  - azure recommendations
+---
+
+# Azure Observability & Diagnostics
+
+This skill covers the monitoring, diagnostics, and health side of the `azure-mcp` connector: the `monitor`, `resourcehealth`, `applens`, and `advisor` namespaces. All four are **read-only** — they observe and report on Azure, they never change it.
+
+Tool names follow the Azure MCP Server's namespace convention (`azmcp` / `azure_mcp` prefixes, e.g. tools grouped under `monitor`, `resourcehealth`, `applens`, `advisor`). Describe and invoke them by capability — the connector exposes one or more tools per namespace.
+
+## Namespace surface
+
+### `monitor` — Azure Monitor
+
+Azure Monitor is the workhorse. Capabilities:
+
+- **Metrics** — query platform and custom metric series for a resource (CPU, memory, request count, latency, throttling, etc.) over a time window.
+- **Log Analytics / KQL** — run Kusto Query Language queries against a Log Analytics workspace. This is how you reach application traces, `AzureDiagnostics`, `AzureActivity`, sign-in logs, and any custom tables.
+- **Alerts** — list configured alert rules and their current fired/resolved state.
+
+KQL queries should be scoped tightly — always include a `where TimeGenerated > ago(...)` bound and a column projection so results stay small and fast.
+
+### `resourcehealth` — Resource Health
+
+Reports the platform-reported availability of an Azure resource: `Available`, `Degraded`, `Unavailable`, or `Unknown`, plus the reason (platform-initiated, customer-initiated, or unplanned) and any active health events on the subscription. This is the fastest "is it Azure's fault" check.
+
+### `applens` — AppLens diagnostics
+
+AppLens runs Microsoft's deep diagnostic detectors against a resource — the same engine behind the Azure portal's "Diagnose and solve problems" blade. Use it when Resource Health says a resource is degraded but you need the *why*: which detector tripped, what dependency failed, what the recommended mitigation is.
+
+### `advisor` — Azure Advisor
+
+Azure Advisor produces recommendations across five categories: **Cost**, **Security**, **Reliability**, **Performance**, and **Operational Excellence**. Each recommendation has an impact rating (High/Medium/Low) and affected resources. The `advisor` namespace lists and filters these.
+
+## Workflow patterns
+
+### Investigating a degraded resource
+
+1. **`resourcehealth`** — check the resource's current health state. If `Unavailable`/`Degraded` with a *platform-initiated* reason, it's an Azure-side event — capture the event ID and stop; there's nothing to fix on the customer side beyond waiting or failing over.
+2. **`applens`** — if Resource Health is `Available` or the reason is customer-initiated, run AppLens detectors to find the failing detector and its dependency chain.
+3. **`monitor` metrics** — pull the relevant metric series around the incident window (e.g. CPU/memory for a VM, HTTP 5xx and response time for an App Service) to confirm and quantify the impact.
+4. **`monitor` Log Analytics** — run a targeted KQL query against the workspace for error-level traces in the same window.
+5. **`monitor` alerts** — confirm whether an alert rule already fired; if the incident was real but no alert fired, that's an alerting-coverage gap worth flagging.
+
+### Pulling KQL query results
+
+When asked for log data, write a bounded KQL query and run it through the `monitor` namespace's Log Analytics capability:
+
+```kql
+AzureDiagnostics
+| where TimeGenerated > ago(1h)
+| where Level == "Error"
+| project TimeGenerated, ResourceId, OperationName, Message
+| order by TimeGenerated desc
+| take 100
+```
+
+Always include a time bound, a `project` to limit columns, and a `take`/`limit`. Report the workspace and time range alongside results so the query is reproducible.
+
+### Triaging Advisor recommendations
+
+1. **`advisor`** — list recommendations for the subscription, then group by category.
+2. Sort within each category by impact (High first) and by number of affected resources.
+3. Separate **Reliability** and **Security** findings (act soon) from **Cost** and **Operational Excellence** (plan and batch).
+4. For each High-impact item, name the affected resources and the recommended action — but remember the connector cannot apply the fix. Report the recommendation; the actual remediation happens through a separate, write-capable path.
+
+### Alert-coverage review
+
+Use `monitor` alerts to list configured alert rules for a subscription, then compare against the critical resources you see via the `group` and `subscription` namespaces. Resources with no alert rule covering availability or error rate are coverage gaps.
+
+## Constraints & caveats
+
+- **Read-only.** Nothing in this skill changes Azure. You can read metrics, logs, health, and recommendations — you cannot acknowledge alerts, apply Advisor fixes, or restart resources. If asked to act on a finding, state that clearly and hand off.
+- **Scope.** Most calls need a subscription ID and often a resource ID or resource group — resolve these first via the `subscription` and `group` namespaces (see the `cost-and-capacity` skill).
+- **KQL workspace access.** Log Analytics queries require the service principal to have Reader inheritance to the workspace. If a query returns an authorization error, the workspace is outside the granted RBAC scope.
+- **Advisor freshness.** Advisor recommendations refresh periodically, not in real time — a recommendation may lag a recent change by hours.

--- a/msp-claude-plugins/docs/src/data/plugins.ts
+++ b/msp-claude-plugins/docs/src/data/plugins.ts
@@ -1977,6 +1977,70 @@ export const plugins: Plugin[] = [
     },
     path: 'wyre-gateway',
     compatibility: { claudeCode: true, claudeDesktop: true, validated: false }
+  },
+  {
+    id: 'microsoft-graph',
+    name: 'Microsoft Graph',
+    vendor: 'Microsoft-graph',
+    description: 'Microsoft Graph Enterprise MCP - read-only natural-language queries over Microsoft Entra identity and directory data: users, groups, applications, devices, and admin reporting (public preview)',
+    category: 'productivity',
+    maturity: 'beta',
+    features: [
+      'Connection',
+      'Querying'
+    ],
+    skills: [
+      { name: 'connection', description: 'Use this skill when connecting the Microsoft Graph MCP Server for Enterprise to the Wyre MCP Gateway — registering the BYOC multi-tenant Entra app, supplying tenantId/clientId/clientSecret, and (the part everyone misses) granting per-tenant admin consent for the MCP.* delegated permissions out of band.' },
+      { name: 'querying', description: 'Use this skill when answering identity or directory questions against a client\'s Microsoft Entra tenant via the Microsoft Graph MCP Server for Enterprise.' }
+    ],
+    agents: [
+      { name: 'entra-reporting-analyst', description: 'Use this agent when an MSP technician, service-desk analyst, account manager, or vCISO needs to answer questions about a client\'s Microsoft Entra (Azure AD) identity and directory data — user and license counts, MFA registration gaps, guest inventory, inactive accounts, app inventory, directory roles, sign-in activity.' }
+    ],
+    commands: [
+      { name: '/entra-audit', description: 'Run a read-only Microsoft Entra identity hygiene audit via the Graph Enterprise MCP — inactive user accounts, admins without MFA registered, unassigned/wasted licenses, and a guest user inventory' },
+      { name: '/entra-report', description: 'Conversational Microsoft Entra directory reporting via the Graph Enterprise MCP — license usage, user and group counts, application inventory, and directory composition, formatted for client check-ins and QBRs' }
+    ],
+    apiInfo: {
+      baseUrl: '',
+      auth: '',
+      rateLimit: '',
+      docsUrl: ''
+    },
+    path: 'microsoft-graph/microsoft-graph',
+    compatibility: { claudeCode: true, claudeDesktop: true, validated: false }
+  },
+  {
+    id: 'azure-mcp',
+    name: 'Azure Mcp',
+    vendor: 'Azure-mcp',
+    description: 'Azure MCP Server - read-only Azure observability, cost, and resource-health analysis in natural language: monitoring, pricing, quota, advisor, resource health, diagnostics',
+    category: 'monitoring',
+    maturity: 'beta',
+    features: [
+      'Connection',
+      'Cost And Capacity',
+      'Observability'
+    ],
+    skills: [
+      { name: 'connection', description: 'Use this skill when connecting the azure-mcp vendor through the WYRE MCP Gateway — registering an Azure service principal, supplying tenantId/clientId/clientSecret, and granting least-privilege Reader-tier RBAC.' },
+      { name: 'cost-and-capacity', description: 'Use this skill for Azure cost, pricing, capacity, and inventory work through the azure-mcp connector — retail pricing lookups, subscription quota and usage-limit checks, and listing/inspecting subscriptions and resource groups.' },
+      { name: 'observability', description: 'Use this skill for Azure observability, diagnostics, and resource-health work through the azure-mcp connector — pulling Azure Monitor metrics, running Log Analytics KQL queries, checking alert state, reading Resource Health status, triaging AppLens diagnostics, and reviewing Azure Advisor recommendations.' }
+    ],
+    agents: [
+      { name: 'azure-ops-analyst', description: 'Use this agent when an MSP engineer, service manager, or cloud lead needs a read-only Azure operations investigation — resource health triage, cost and Azure Advisor analysis, quota/capacity headroom checks, and observability-posture reporting across subscriptions.' }
+    ],
+    commands: [
+      { name: '/azure-cost', description: 'Azure cost and pricing analysis for a subscription — Advisor cost recommendations, retail pricing lookups, and quota-driven right-sizing signals, scoped to one subscription' },
+      { name: '/azure-diagnostics', description: 'Resource health and diagnostics triage for an Azure resource or subscription — Resource Health status, AppLens deep diagnostics, and Azure Monitor alert state' }
+    ],
+    apiInfo: {
+      baseUrl: '',
+      auth: '',
+      rateLimit: '',
+      docsUrl: ''
+    },
+    path: 'azure-mcp/azure-mcp',
+    compatibility: { claudeCode: true, claudeDesktop: true, validated: false }
   }
 ];
 

--- a/msp-claude-plugins/microsoft-graph/microsoft-graph/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/microsoft-graph/microsoft-graph/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "microsoft-graph",
+  "version": "1.0.0",
+  "description": "Claude plugins for the Microsoft Graph MCP Server for Enterprise (public preview) — query a client's Microsoft Entra identity and directory data (users, groups, applications, devices, admin reporting) in natural language. Read-only, RBAC-honoring access via a RAG-backed suggest-queries workflow.",
+  "author": {
+    "name": "MSP Claude Plugins Community"
+  },
+  "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
+  "repository": "https://github.com/wyre-technology/msp-claude-plugins",
+  "license": "Apache-2.0"
+}

--- a/msp-claude-plugins/microsoft-graph/microsoft-graph/README.md
+++ b/msp-claude-plugins/microsoft-graph/microsoft-graph/README.md
@@ -1,0 +1,60 @@
+# Microsoft Graph Plugin
+
+Claude plugins for the **Microsoft Graph MCP Server for Enterprise** — Microsoft's hosted MCP server (currently in **public preview**) that lets MSPs query a client's Microsoft Entra (Azure AD) identity and directory data in natural language.
+
+This plugin orients Claude around the `microsoft-graph` vendor on the [Wyre MCP Gateway](https://mcp.wyre.ai). The Graph Enterprise MCP server exposes a small, deliberate tool surface designed for a Retrieval-Augmented-Generation (RAG) query workflow rather than raw API access. Skills and agents in this plugin embed that workflow so Claude answers identity and directory questions correctly instead of inventing Graph endpoints.
+
+> **Public preview.** The Microsoft Graph MCP Server for Enterprise is a Microsoft preview service hosted at `https://mcp.svc.cloud.microsoft/enterprise`. Behavior, the example catalog, and available scopes may change before general availability. Treat output as advisory and verify anything material in the Entra admin center.
+
+## What's in this plugin
+
+### The three tools
+
+The Graph Enterprise MCP server exposes exactly three tools — no more:
+
+| Tool | What it does |
+|------|--------------|
+| `microsoft_graph_suggest_queries` | RAG search over a curated catalog of Microsoft Graph API examples. Given a natural-language intent, it returns candidate Graph API calls that best match. **This is the entry point for almost every task.** |
+| `microsoft_graph_get` | Executes a **read-only** Microsoft Graph API call. Honors the caller's Entra roles, the scopes granted to the connecting app, and Graph throttling. |
+| `microsoft_graph_list_properties` | Returns the schema for a Graph entity (e.g. `user`, `group`, `application`) — available properties and relationships — so the model knows what it can request before constructing a call. |
+
+### Skills (2)
+
+| Skill | Covers |
+|-------|--------|
+| `microsoft-graph-connection` | Connecting `microsoft-graph` through the Wyre gateway, the BYOC Entra app registration, and the out-of-band per-tenant admin consent requirement |
+| `microsoft-graph-querying` | The `suggest_queries → select → get` RAG workflow with worked examples |
+
+### Agents (1)
+
+- **`entra-reporting-analyst`** — a read-only Entra reporting / IT-helpdesk analyst that drives the suggest→select→get loop, answers identity and directory questions, and translates raw Graph JSON into plain-language answers for non-technical readers.
+
+### Commands (2)
+
+- **`/microsoft-graph:entra-audit`** — runs a set of identity hygiene checks (inactive accounts, admins without MFA registered, unassigned licenses, guest inventory)
+- **`/microsoft-graph:entra-report`** — conversational directory reporting (license usage, user/group counts, app inventory) for client check-ins and QBRs
+
+## What it can and cannot do
+
+**Can:** read users, groups, applications, service principals, devices, directory roles, license/subscription data, and admin reporting (sign-in activity, registration details) from a client's Entra tenant — in natural language, scoped to whatever the connecting app and caller are permitted to see.
+
+**Cannot:** write, modify, or delete anything. The Graph Enterprise MCP server is **read-only by design** — `microsoft_graph_get` is the only execution tool and it issues `GET` requests. For changes, use a write-capable tool such as the `cipp` plugin.
+
+## How to connect
+
+The Graph Enterprise MCP server is reached through the Wyre MCP Gateway as the `microsoft-graph` vendor.
+
+1. In the gateway connection UI, connect the **`microsoft-graph`** vendor.
+2. This uses **BYOC (bring-your-own-credentials) Entra OAuth** — each MSP registers its own multi-tenant Entra app (a confidential client) and supplies `tenantId`, `clientId`, and `clientSecret`.
+3. **Critical:** the `MCP.*` delegated permissions the server needs require **per-tenant admin consent granted out of band**. The OAuth connect flow alone is *not* enough — a Global Administrator in each customer tenant must grant admin consent before the connection will return data for that tenant.
+
+The `microsoft-graph-connection` skill documents the full app-registration and admin-consent procedure step by step. Read it before connecting — the admin-consent step is the single most common thing that trips MSPs up.
+
+- **Rate limit:** 100 calls/min/user (in addition to standard Microsoft Graph service throttling).
+- **Licensing:** no extra license cost for the MCP server itself, but the caller still needs appropriate licenses for the data they access (e.g. Microsoft Entra ID P2 for Privileged Identity Management data).
+
+## Resources
+
+- Wyre MCP Gateway: https://mcp.wyre.ai
+- Microsoft Graph documentation: https://learn.microsoft.com/graph
+- Microsoft Entra app registration: https://learn.microsoft.com/entra/identity-platform/quickstart-register-app

--- a/msp-claude-plugins/microsoft-graph/microsoft-graph/agents/entra-reporting-analyst.md
+++ b/msp-claude-plugins/microsoft-graph/microsoft-graph/agents/entra-reporting-analyst.md
@@ -1,0 +1,44 @@
+---
+name: entra-reporting-analyst
+description: Use this agent when an MSP technician, service-desk analyst, account manager, or vCISO needs to answer questions about a client's Microsoft Entra (Azure AD) identity and directory data — user and license counts, MFA registration gaps, guest inventory, inactive accounts, app inventory, directory roles, sign-in activity. Trigger for identity reporting, QBR prep, helpdesk lookups, onboarding directory snapshots, and identity hygiene audits. Examples - "How many users does Contoso have?", "Which admins haven't registered MFA?", "List the guest accounts in this tenant", "Are we paying for licenses nobody uses?", "Pull an Entra directory snapshot for the QBR", "Who has Global Administrator in this tenant?"
+tools: ["Bash", "Read", "Write", "Glob", "Grep"]
+model: inherit
+---
+
+You are an expert Microsoft Entra (Azure AD) reporting and IT-helpdesk analyst working through the Microsoft Graph MCP Server for Enterprise. Your role is to turn natural-language identity and directory questions into correct, well-sourced answers — and to translate raw Microsoft Graph JSON into plain language that a non-technical reader can act on. You are the bridge between "I need to know something about this tenant's directory" and a clear, trustworthy answer.
+
+You are **read-only**. The Graph Enterprise MCP server cannot create, modify, or delete anything — it only issues `GET` requests to Microsoft Graph. You report, audit, and explain; you never change the directory. When a user asks you to *make* a change (disable an account, assign a license, remove a guest), you say clearly that this server is read-only, give them the finding that motivates the change, and point them to a write-capable tool such as the `cipp` plugin or the Entra admin center.
+
+## The query loop is mandatory
+
+You have exactly three tools and they are meant to be used as a pipeline, not independently:
+
+- `microsoft_graph_suggest_queries` — RAG search over a curated catalog of Microsoft Graph API examples. You give it a natural-language intent; it returns candidate Graph API calls.
+- `microsoft_graph_get` — executes a read-only Graph `GET`. It honors the caller's Entra roles, the app's granted scopes, and Graph throttling.
+- `microsoft_graph_list_properties` — returns the schema (properties and relationships) of a Graph entity.
+
+You **always** start with `microsoft_graph_suggest_queries`. You do **not** invent raw Graph endpoints, `$filter` strings, or OData casts from memory — Microsoft Graph is too large and too sharp-edged to guess, and the suggest catalog exists precisely so you don't have to. Your loop is: suggest candidates → select the candidate whose description and parameters best match the question → execute it with `microsoft_graph_get` → if you need to know what properties an entity exposes before refining, call `microsoft_graph_list_properties` → translate the result into a plain-language answer. Selection and translation are your judgment calls; the tools only propose and fetch.
+
+When several suggested candidates look plausible, prefer the one that most directly answers the question with the least data — a count beats a full collection when the user asked "how many." When a question needs two datasets joined (e.g. "inactive accounts that still hold a Copilot license"), run two suggest→get passes and intersect the results yourself; don't expect a single candidate to do the join.
+
+## Capabilities
+
+- Answer point questions about a tenant's directory: user counts, guest counts, group counts, license consumption, app inventory, directory-role membership.
+- Audit identity hygiene: inactive accounts, accounts without MFA registered, admins without MFA, stale guests, licenses assigned to disabled or inactive users.
+- Produce directory snapshots for onboarding handoffs and QBRs — composition and consumption, framed for the audience.
+- Cross-reference datasets (inactive × licensed, admin-role × MFA-unregistered) to surface findings no single query returns.
+- Translate raw Graph JSON into plain-language answers, with GUIDs and JSON hidden unless the reader explicitly wants them.
+
+## Approach
+
+Lead every answer with the direct result — the count, the yes/no, the named list — then supporting detail, then, for audit-style questions, a recommendation. A non-technical reader should get their answer in the first sentence without wading through JSON.
+
+Translate, don't dump. Raw Graph output is never the deliverable. Convert `userPrincipalName` and `displayName` into readable names, SKU part numbers into product names ("ENTERPRISEPACK" → "Microsoft 365 E3"), and role template IDs into role names. Reserve GUIDs and JSON for readers who explicitly ask for the raw data.
+
+Respect the boundaries and name them when they bite. Results are scoped to the signed-in caller's Entra RBAC and the app's granted scopes — if a result looks thinner than expected, consider that it may be a permissions boundary, not missing data, and say so. If queries return nothing for a tenant, suspect that per-tenant admin consent was never granted (the `MCP.*` permissions need out-of-band Global Admin consent per customer tenant — see the `microsoft-graph-connection` skill) rather than assuming the tenant is empty.
+
+Mind the limits. The server allows 100 calls/min/user on top of Graph's own throttling, so don't fan out speculative `get` calls — one well-chosen candidate beats ten guesses. Some data needs licensing the caller may not have (PIM data needs Microsoft Entra ID P2); if a query fails for a licensing reason, say which license is missing rather than reporting "no data."
+
+Treat this as a preview service. The suggest catalog, behavior, and available scopes may change before general availability. Frame material findings as advisory and recommend confirming anything consequential in the Entra admin center before someone acts on it.
+
+When a finding implies a change — a reclaimable license, a guest to remove, an admin to enroll in MFA — present it as a recommendation with the evidence behind it, and explicitly hand off the *doing* to a write-capable tool. You found it; you don't fix it. Draft client-facing language when the finding will be forwarded to a client, so the MSP isn't pasting raw report output into an email: translate "9 accounts with no registered authenticationMethod" into "Nine staff accounts at Contoso don't have multi-factor authentication set up yet — two of them are administrators, which we'd recommend fixing first."

--- a/msp-claude-plugins/microsoft-graph/microsoft-graph/commands/entra-audit.md
+++ b/msp-claude-plugins/microsoft-graph/microsoft-graph/commands/entra-audit.md
@@ -1,0 +1,42 @@
+---
+name: entra-audit
+description: Run a read-only Microsoft Entra identity hygiene audit via the Graph Enterprise MCP — inactive user accounts, admins without MFA registered, unassigned/wasted licenses, and a guest user inventory
+arguments:
+  - name: scope
+    description: Audit area to focus on — all (default), inactive, mfa, licenses, or guests
+    required: false
+  - name: detail
+    description: summary (default), full, or executive — controls report depth
+    required: false
+---
+
+# Entra Identity Hygiene Audit
+
+Runs a focused, **read-only** audit of a client's Microsoft Entra directory through the Microsoft Graph MCP Server for Enterprise. Suitable for client check-ins, post-onboarding validation, pre-QBR prep, security reviews, and "is anything stale in this tenant?" investigations.
+
+Every check goes through the RAG query loop — `microsoft_graph_suggest_queries` to find the right candidate Graph call, then `microsoft_graph_get` to execute it. Never hand-write Graph endpoints; see the `microsoft-graph-querying` skill.
+
+## What it checks
+
+Run each section unless `scope` narrows it:
+
+1. **Inactive accounts** (`scope=inactive`) — `suggest_queries("user accounts with no recent sign-in activity")` → `get`. Lists enabled accounts with no sign-in in the trailing window. Flags licensed inactive accounts as reclaimable spend.
+2. **Admins without MFA registered** (`scope=mfa`) — `suggest_queries("users with privileged directory roles")` and `suggest_queries("users who have not registered for MFA")` → `get` each, then intersect. Any account holding an admin role with no MFA method registered is a top-priority finding.
+3. **Unassigned / wasted licenses** (`scope=licenses`) — `suggest_queries("subscribed SKUs and license consumption")` plus a licensed-but-inactive cross-check → `get`. Reports purchased-but-unassigned seats and licenses held by disabled or inactive accounts.
+4. **Guest user inventory** (`scope=guests`) — `suggest_queries("external guest users in the directory")` → `get`. Lists guest accounts with invitation/external state; flags guests with no recent sign-in as cleanup candidates.
+
+Use `microsoft_graph_list_properties` whenever you need an entity's schema to refine a `$select` (e.g. confirming `user` exposes `signInActivity` or `assignedLicenses`).
+
+## Detail levels
+
+- **summary** (default): pass/fail per section, top 5 findings, one-line hygiene verdict.
+- **full**: every flagged account, every SKU, the complete guest list.
+- **executive**: plain-language posture summary suitable for a client-facing email — no GUIDs, no JSON.
+
+## Output
+
+A prioritized finding list. For each finding give the count, the affected accounts (named, not GUIDs), the risk or cost impact, and a recommended next step. Because this MCP server is read-only, remediation steps are advisory — note which tool actually performs the change (e.g. license reclaim or account disable via the `cipp` plugin or the Entra admin center).
+
+## When to use this vs. the agent
+
+Use this command for a routine, structured hygiene sweep. Delegate to the `entra-reporting-analyst` agent when you need open-ended investigation, cross-tenant comparison, or a narrative report.

--- a/msp-claude-plugins/microsoft-graph/microsoft-graph/commands/entra-report.md
+++ b/msp-claude-plugins/microsoft-graph/microsoft-graph/commands/entra-report.md
@@ -1,0 +1,43 @@
+---
+name: entra-report
+description: Conversational Microsoft Entra directory reporting via the Graph Enterprise MCP — license usage, user and group counts, application inventory, and directory composition, formatted for client check-ins and QBRs
+arguments:
+  - name: topic
+    description: What to report on — overview (default), licenses, users, groups, or apps
+    required: false
+  - name: audience
+    description: technical (default) or executive — controls framing and whether raw detail is shown
+    required: false
+---
+
+# Entra Directory Report
+
+Produces a conversational, **read-only** snapshot of a client's Microsoft Entra directory through the Microsoft Graph MCP Server for Enterprise. Built for client check-ins, Quarterly Business Reviews, onboarding handoffs, and "give me the state of this tenant" requests.
+
+Unlike `/microsoft-graph:entra-audit` (which hunts for problems), this command describes what's *there* — composition and consumption, not findings. All data is gathered through the RAG loop: `microsoft_graph_suggest_queries` → pick the candidate → `microsoft_graph_get`. Never invent Graph endpoints.
+
+## What it reports
+
+Run the sections relevant to `topic` (default `overview` runs all):
+
+1. **License usage** (`topic=licenses`) — `suggest_queries("subscribed SKUs and license consumption")` → `get`. Per-SKU: purchased seats, assigned, available. Highlights near-exhausted SKUs and large pools of unused seats.
+2. **User counts** (`topic=users`) — `suggest_queries("count of all users in the tenant")` and `suggest_queries("count of guest users")` → `get`. Member vs guest split, enabled vs disabled, and recently created accounts.
+3. **Group counts** (`topic=groups`) — `suggest_queries("groups in the directory by type")` → `get`. Security groups, Microsoft 365 groups, distribution lists, and dynamic vs assigned membership.
+4. **Application inventory** (`topic=apps`) — `suggest_queries("registered applications and enterprise applications")` → `get`. App registrations and service principals — useful for spotting unfamiliar third-party apps with directory access.
+
+Use `microsoft_graph_list_properties` when you need an entity's schema to pick the right properties.
+
+## Audience framing
+
+- **technical** (default): counts, SKU part numbers, group types, app display names. Concise tables.
+- **executive**: plain-language narrative — "Contoso has 412 staff accounts and pays for 50 unused Microsoft 365 E3 seats." No GUIDs, no SKU part numbers, no JSON. Lead with the headline, then a short bulleted detail list.
+
+## Output
+
+A directory snapshot organized by section, each with the headline number and a one-line interpretation. For QBR use, close with one or two observations the account team can act on (e.g. "50 unassigned E3 seats — candidate for a true-down at renewal"). Keep it descriptive; this is a status report, not an audit.
+
+## Notes
+
+- Read-only — this reports the directory, it never changes it.
+- Results honor the caller's Entra RBAC; per-tenant admin consent must be in place (see the `microsoft-graph-connection` skill).
+- Preview service — verify anything material in the Entra admin center before acting on it.

--- a/msp-claude-plugins/microsoft-graph/microsoft-graph/skills/connection/SKILL.md
+++ b/msp-claude-plugins/microsoft-graph/microsoft-graph/skills/connection/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: "microsoft-graph-connection"
+description: "Use this skill when connecting the Microsoft Graph MCP Server for Enterprise to the Wyre MCP Gateway — registering the BYOC multi-tenant Entra app, supplying tenantId/clientId/clientSecret, and (the part everyone misses) granting per-tenant admin consent for the MCP.* delegated permissions out of band. Also covers the preview status and the 100 calls/min/user rate limit."
+when_to_use: "When setting up, troubleshooting, or explaining the microsoft-graph connection — Entra app registration, redirect URI, client secret, admin consent failures, or 'why is the tenant returning no data'"
+triggers:
+  - connect microsoft graph
+  - microsoft graph mcp
+  - graph enterprise mcp
+  - entra app registration
+  - admin consent
+  - byoc entra
+  - microsoft graph setup
+  - graph mcp no data
+  - tenant consent
+  - microsoft graph rate limit
+---
+
+# Connecting the Microsoft Graph MCP Server for Enterprise
+
+The Microsoft Graph MCP Server for Enterprise is a Microsoft-hosted MCP server (public **preview**) at `https://mcp.svc.cloud.microsoft/enterprise`. It is reached through the Wyre MCP Gateway as the `microsoft-graph` vendor. Getting it working is a three-part job: register an Entra app, connect it through the gateway, and — the step that breaks most onboardings — grant per-tenant admin consent **out of band**.
+
+Read this whole skill before connecting. The admin-consent requirement is non-obvious and the failure mode (a connection that authenticates fine but returns nothing) looks like a different bug.
+
+## How the connection works
+
+- The gateway exposes a `microsoft-graph` vendor that proxies to `https://mcp.svc.cloud.microsoft/enterprise`.
+- Auth is **BYOC** (bring-your-own-credentials): each MSP registers **its own** multi-tenant Entra app — a confidential client — and supplies `tenantId`, `clientId`, and `clientSecret` in the gateway connection UI.
+- The Entra authority used is `organizations` (the multi-tenant work/school endpoint).
+- The token minted is a **delegated** token scoped to `api://e8c77dc2-69b3-43f4-bc51-3213c9d915b4/.default` — the resource identifier of the Graph Enterprise MCP service.
+- Because the token is delegated, every call runs **as the signed-in user**. The data the server returns is the intersection of what the user is allowed to see (their Entra roles) and what scopes the app was granted.
+
+## Step 1 — Register the BYOC Entra application
+
+In the customer-facing/partner tenant you control, register a multi-tenant app:
+
+1. **Entra admin center → Identity → Applications → App registrations → New registration.**
+2. **Supported account types:** *Accounts in any organizational directory (multitenant)*. This is required — the authority is `organizations`, and you need the app to be consentable in each customer tenant.
+3. **Platform:** add a **Web** platform with a **redirect URI**. Use the redirect URI the Wyre gateway shows in the `microsoft-graph` connection UI (the gateway's OAuth callback). A Web platform is required because this is a confidential client doing an authorization-code flow.
+4. **Certificates & secrets → New client secret.** Record the secret **value** (not the secret ID) immediately — it is shown only once. Set a calendar reminder before it expires; an expired secret produces `invalid_client` on reconnect.
+5. Note the **Application (client) ID** and your **Directory (tenant) ID** from the app's Overview page.
+6. **API permissions:** add the **delegated** `MCP.*` permissions the Graph Enterprise MCP server requires (the permission set is shown when you add the Graph Enterprise MCP / `api://e8c77dc2-...` API as a permission target). These are delegated permissions, not application permissions.
+
+## Step 2 — Connect through the Wyre gateway
+
+1. In the gateway connection UI, choose the **`microsoft-graph`** vendor.
+2. Supply the three BYOC values from Step 1: **`tenantId`**, **`clientId`**, **`clientSecret`**.
+3. Complete the OAuth sign-in. The gateway runs the authorization-code flow against the `organizations` authority and stores the resulting delegated token.
+
+At this point the *connection* exists — but it will still return no data until Step 3 is done for each customer tenant.
+
+## Step 3 — Grant per-tenant admin consent (the step everyone misses)
+
+**This is the single most common reason a Graph MCP connection "works" but returns nothing.**
+
+The `MCP.*` delegated permissions are admin-restricted. The OAuth connect flow in Step 2 authenticates the user and mints a token, but it does **not** by itself grant the tenant-wide consent those permissions need. A **Global Administrator in each customer tenant** must grant admin consent **out of band** — once per customer tenant, before the connection can read that tenant's directory.
+
+Have the customer's Global Admin open the admin-consent URL and approve:
+
+```
+https://login.microsoftonline.com/{customer-tenant-id}/adminconsent?client_id={your-client-id}
+```
+
+- `{customer-tenant-id}` — the customer's Entra tenant ID (or their primary domain).
+- `{your-client-id}` — the Application (client) ID of the BYOC app from Step 1.
+
+After the admin approves, the app gets a service principal in the customer tenant with the `MCP.*` delegated permissions consented tenant-wide. Calls for that tenant will now return data.
+
+If you skip this: `microsoft_graph_get` and `microsoft_graph_suggest_queries` calls will fail or return empty for that tenant even though the gateway connection shows healthy and the token mints fine. Symptom is consent/permission errors (`AADSTS65001` or similar) or a successful auth that yields no directory data.
+
+Repeat Step 3 for every customer tenant you want to query. Steps 1 and 2 are one-time per MSP; Step 3 is per customer tenant.
+
+## Operational limits
+
+- **Preview.** This is a Microsoft public-preview service. The tool surface, the RAG example catalog, and the available scopes may change before GA. Don't build hard automation dependencies on exact behavior yet.
+- **Read-only.** The server only issues `GET` requests to Microsoft Graph. There is no write path — by design.
+- **Rate limit:** 100 calls/min/user, enforced by the MCP server, on top of standard Microsoft Graph service throttling. The RAG `suggest_queries → get` workflow is deliberately call-efficient; lean on it rather than fanning out many speculative `get` calls.
+- **Licensing:** the MCP server itself adds no license cost, but the caller still needs the right Entra licenses for the data they touch. Example: querying Privileged Identity Management (PIM) data requires **Microsoft Entra ID P2** on the tenant and the caller.
+
+## Quick troubleshooting
+
+| Symptom | Likely cause |
+|---------|--------------|
+| Connection authenticates but every query returns empty/permission error | Per-tenant admin consent (Step 3) not granted for that customer tenant |
+| `invalid_client` on connect or reconnect | Client secret expired or the secret **ID** was pasted instead of the secret **value** |
+| Redirect URI mismatch error during sign-in | The Web platform redirect URI in the app registration doesn't match the gateway's callback URL |
+| Works for one tenant, not another | Admin consent granted for the first tenant only — run Step 3 again per tenant |
+| PIM / privileged-role data missing | Tenant or caller lacks Microsoft Entra ID P2 |

--- a/msp-claude-plugins/microsoft-graph/microsoft-graph/skills/querying/SKILL.md
+++ b/msp-claude-plugins/microsoft-graph/microsoft-graph/skills/querying/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: "microsoft-graph-querying"
+description: "Use this skill when answering identity or directory questions against a client's Microsoft Entra tenant via the Microsoft Graph MCP Server for Enterprise. Teaches the RAG query loop — microsoft_graph_suggest_queries to find candidate Graph API calls, pick the best one, then microsoft_graph_get to execute it, with microsoft_graph_list_properties for entity schema. Everything is read-only and honors the caller's RBAC."
+when_to_use: "When asked any question about a tenant's users, groups, applications, devices, licenses, sign-in activity, or directory roles that should be answered through the Microsoft Graph MCP server — count users, find guests, find inactive accounts, audit MFA registration, list app inventory, check license usage"
+triggers:
+  - microsoft graph query
+  - query entra
+  - how many users
+  - guest users
+  - inactive accounts
+  - users without mfa
+  - license usage
+  - app inventory
+  - directory roles
+  - suggest queries
+  - graph get
+  - list properties
+---
+
+# Querying Microsoft Entra with the Graph Enterprise MCP
+
+The Microsoft Graph MCP Server for Enterprise is **not** a raw Graph API passthrough. It is built around a Retrieval-Augmented-Generation (RAG) workflow: you describe what you want, the server hands you vetted candidate API calls from a curated catalog, and you execute the one that fits. Following this loop is the difference between correct answers and made-up endpoints.
+
+## The core rule
+
+**Always start with `microsoft_graph_suggest_queries`. Do not invent raw Graph endpoints.**
+
+Microsoft Graph is enormous and its URL/`$filter`/`$select` syntax is full of sharp edges (advanced query parameters, `ConsistencyLevel` headers, OData casts). The `suggest_queries` tool exists precisely so the model doesn't have to guess. Hand-writing a Graph URL and passing it to `microsoft_graph_get` is an error pattern — even when you "know" the endpoint, route through `suggest_queries` so you get the catalog's correct, tested form.
+
+## The three tools
+
+| Tool | Role in the loop |
+|------|------------------|
+| `microsoft_graph_suggest_queries` | RAG search over a curated catalog of Graph API examples. Input: a natural-language intent. Output: candidate Graph API calls (endpoint, parameters, description) ranked by relevance. |
+| `microsoft_graph_get` | Executes a read-only Graph `GET`. Input: a Graph API call (ideally one returned by `suggest_queries`). Honors the caller's roles, granted scopes, and Graph throttling. |
+| `microsoft_graph_list_properties` | Returns the schema for a Graph entity — its properties and relationships. Use it when you need to know what's selectable before constructing or refining a call. |
+
+## The query loop
+
+```
+1. suggest_queries(intent)   → candidate Graph calls
+2. (model)  select the candidate that best matches the question
+3. get(selected candidate)   → data
+4. (optional) list_properties(entity)  → schema, to refine $select or pick the right entity
+5. (model)  translate the JSON result into a plain-language answer
+```
+
+Steps 2 and 5 are *your* job — `suggest_queries` proposes, the model disposes. When several candidates look plausible, prefer the one whose description most precisely matches the user's intent and whose parameters you can fill confidently. If a candidate needs a property you're unsure exists, call `list_properties` first.
+
+## Worked examples
+
+### "How many users are in the tenant?"
+
+1. `microsoft_graph_suggest_queries("count of all users in the tenant")` → returns candidates such as a call against the `users` collection with a count.
+2. Pick the candidate that returns a count rather than a full user list (cheaper, directly answers the question).
+3. `microsoft_graph_get(<that candidate>)`.
+4. Answer: "Contoso has **412** licensed and unlicensed user accounts in Entra ID."
+
+### "Which users don't have MFA registered?"
+
+1. `microsoft_graph_suggest_queries("users who have not registered for multi-factor authentication")` → expect candidates around authentication-methods registration reporting (admin reporting surface).
+2. The right candidate is typically a user-registration-details report filtered to users where MFA is not registered — not a per-user method enumeration.
+3. `microsoft_graph_get(<that candidate>)`.
+4. If you need to also show each user's department or job title, call `microsoft_graph_list_properties("user")` to confirm those properties, then re-suggest/refine.
+5. Answer with a named list and a count: "9 of 412 accounts have no MFA method registered — including 2 with admin roles, which is the priority to fix."
+
+### "List the guest (external) users."
+
+1. `microsoft_graph_suggest_queries("external guest users in the directory")` → candidates filtering the `users` collection on guest user type.
+2. `microsoft_graph_get(<that candidate>)`.
+3. Answer with the guest accounts, their invitation/external state, and a count. Flag guests with no recent sign-in as cleanup candidates.
+
+### "Find inactive accounts that still hold Copilot licenses."
+
+This needs two reads joined by the model:
+
+1. `microsoft_graph_suggest_queries("user accounts with no recent sign-in activity")` → an inactive-users / sign-in-activity reporting candidate. Run it with `microsoft_graph_get`.
+2. `microsoft_graph_suggest_queries("users assigned a Microsoft 365 Copilot license")` → a licensed-users candidate. Run it with `microsoft_graph_get`.
+3. The model intersects the two result sets: accounts that appear in both are inactive *and* Copilot-licensed — wasted spend.
+4. Answer with the overlap list and the reclaimable license count.
+
+> The example endpoints above are illustrative of what `suggest_queries` typically returns — don't hard-code them. Always run `suggest_queries` for the live, tenant-appropriate candidate.
+
+## Using `list_properties`
+
+Call `microsoft_graph_list_properties` when you need the schema of an entity — for example to know whether `user` exposes `signInActivity`, `assignedLicenses`, or `createdDateTime`, or what relationships `group` has. Use it to:
+
+- choose the right `$select` properties so a `get` returns exactly what the question needs;
+- confirm an entity actually has the field you're about to filter on;
+- decide which entity to query when a question could map to several (`user` vs `servicePrincipal` vs `device`).
+
+## Constraints to respect
+
+- **Read-only.** Everything here reports. There is no way to create, edit, or delete directory objects through this server. If the user asks for a change, say so and point them to a write-capable tool (e.g. the `cipp` plugin).
+- **RBAC-honoring.** Results are scoped to the signed-in caller's Entra roles and the app's granted scopes. If a query returns less than expected, it may be a permissions boundary, not missing data — and per-tenant admin consent must already be in place (see the `microsoft-graph-connection` skill).
+- **Rate limit.** 100 calls/min/user plus Graph's own throttling. Don't fan out speculative `get` calls — `suggest_queries` exists so one good call beats ten guesses.
+- **Preview.** The example catalog and behavior may change; verify anything material in the Entra admin center.
+
+## Presenting results
+
+Raw Graph JSON is not an answer. Always translate: lead with the direct answer (a count, a yes/no, a named list), then supporting detail, then — if it's an audit-style question — a recommendation. Non-technical readers should never see GUIDs or JSON unless they ask.


### PR DESCRIPTION
## Summary

Phase 2 of the Microsoft MCP server integration — the `msp-claude-plugins` plugins for the two vendors wired into the gateway (`wyre-technology/mcp-gateway#159`).

- **`microsoft-graph`** (productivity) — Microsoft Graph Enterprise MCP. Connection skill (BYOC Entra OAuth + the out-of-band per-tenant admin-consent requirement), a querying skill teaching the `suggest_queries → select → get` RAG loop, `/entra-audit` + `/entra-report` commands, and a read-only Entra reporting analyst subagent.
- **`azure-mcp`** (monitoring) — Azure MCP Server. Connection skill (service principal + least-privilege RBAC), observability + cost-and-capacity usage skills covering the 8 read-only namespaces, `/azure-cost` + `/azure-diagnostics` commands, and an Azure ops analyst subagent with hard read-only guardrails.
- `marketplace.json` bumped 1.5.0 → 1.6.0; docs plugin data regenerated (51 plugins).

Both plugins connect through the WYRE gateway (no `.mcp.json`, matching the `cipp` pattern). Built per the `msp-plugin-development` checklist.

## Test Plan

- [x] `marketplace.json` valid; both entries registered with valid categories
- [x] `generate-plugins.ts` runs clean — both plugins in `src/data/plugins.ts`
- [x] All 14 skill/command/agent files have valid frontmatter (mirrored from `cipp`)
- [ ] Full docs `npm run build` — could not run locally (`sharp` native-build failure in this env); CI runs the real build
- [ ] Merge after gateway PR #159 lands (vendors must exist in the gateway first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)