### PR TITLE
Advanced Workflows: Compliance Drift Reporter CIPP expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `blackpoint`: +3 subagents (detection-investigator, alert-response-coordinator, exposure-analyst), +3 skills, +4 commands → 5 skills / 3 agents / 5 commands (v1.1.0)
   - `sherweb`: +3 subagents (subscription-provisioner, billing-reconciler, customer-account-auditor) → 4 skills / 3 agents / 4 commands (v0.3.0)
 
+### Changed
+
+- Docs: the **Compliance Drift Reporter** Advanced Workflow now also reports CIPP baseline drift (assigned Standards) and tenant delegated-access health, alongside the existing Liongard configuration-change detections
+
 ### Fixed
 
 - Gateway URL drift: flipped `blackpoint`, `crewhu`, `immybot`, `timezest`, `threatlocker` plugin READMEs and `.mcp.json` files from `mcp.wyretechnology.com` to canonical `mcp.wyre.ai` (closes #73)

--- a/msp-claude-plugins/docs/src/pages/advanced-workflows/agent-routine-catalog.astro
+++ b/msp-claude-plugins/docs/src/pages/advanced-workflows/agent-routine-catalog.astro
@@ -67,7 +67,7 @@ const baseUrl = import.meta.env.BASE_URL;
       <tr><td>sla-uptime-reporter</td><td>betterstack</td><td>✅</td><td>betterstack</td><td>monthly</td><td>SLA achievement report; clean reporter.</td></tr>
       <tr><td>exposure-analyst</td><td>blackpoint</td><td>✅</td><td>blackpoint</td><td>weekly</td><td>Attack-surface / exposure rollup; reporter.</td></tr>
       <tr><td>compliance-reporter</td><td>blumira</td><td>✅</td><td>blumira</td><td>monthly</td><td>SIEM compliance evidence packages; reporter.</td></tr>
-      <tr><td>security-posture-reviewer</td><td>cipp</td><td>✅</td><td>cipp</td><td>monthly</td><td>M365 portfolio posture sweep; auditor.</td></tr>
+      <tr><td>security-posture-reviewer</td><td>cipp</td><td>✅</td><td>cipp</td><td>monthly</td><td>M365 portfolio posture sweep; auditor. CIPP posture is now partly covered by the Compliance Drift Reporter.</td></tr>
       <tr><td>automation-health-checker</td><td>connectwise-automate</td><td>✅</td><td>connectwise-automate</td><td>weekly</td><td>RMM environment health audit.</td></tr>
       <tr><td>project-tracker</td><td>connectwise-manage</td><td>✅</td><td>connectwise-manage</td><td>weekly</td><td>Open-project health review; reporter.</td></tr>
       <tr><td>tenant-policy-auditor</td><td>checkpoint-avanan</td><td>✅</td><td>checkpoint-avanan</td><td>monthly</td><td>Email-policy completeness audit.</td></tr>
@@ -85,7 +85,7 @@ const baseUrl = import.meta.env.BASE_URL;
       <tr><td>rmm-health-auditor</td><td>datto-rmm</td><td>✅</td><td>datto-rmm</td><td>daily</td><td>✅ built — batch 1 (Device Health Auditor).</td></tr>
       <tr><td>asset-documentation-linker</td><td>it-glue</td><td>✅</td><td>itglue</td><td>monthly</td><td>Finds broken IT Glue object linkages.</td></tr>
       <tr><td>documentation-auditor</td><td>it-glue</td><td>✅</td><td>itglue</td><td>monthly</td><td>IT Glue completeness/freshness audit.</td></tr>
-      <tr><td>compliance-drift-reporter</td><td>liongard</td><td>✅</td><td>liongard</td><td>weekly</td><td>✅ built — batch 1 (Compliance Drift Reporter).</td></tr>
+      <tr><td>compliance-drift-reporter</td><td>liongard</td><td>✅</td><td>liongard, cipp</td><td>weekly</td><td>✅ built — batch 1, expanded to CIPP baseline + posture drift.</td></tr>
       <tr><td>identity-auditor</td><td>m365</td><td>✅</td><td>m365</td><td>monthly</td><td>M365 tenant security audit; auditor.</td></tr>
       <tr><td>license-auditor</td><td>m365</td><td>✅</td><td>m365</td><td>monthly</td><td>✅ built — batch 1 (M365 License Auditor).</td></tr>
       <tr><td>email-continuity-checker</td><td>mimecast</td><td>✅</td><td>mimecast</td><td>daily</td><td>Continuity/archive health check.</td></tr>

--- a/msp-claude-plugins/docs/src/pages/advanced-workflows/compliance-drift-reporter.astro
+++ b/msp-claude-plugins/docs/src/pages/advanced-workflows/compliance-drift-reporter.astro
@@ -5,77 +5,86 @@ const baseUrl = import.meta.env.BASE_URL;
 
 // Prompts kept as consts so literal braces / angle brackets render verbatim
 // (.astro treats { } as expressions — a const string sidesteps all escaping).
-const buildPrompt = `Build me a scheduled Compliance Drift Reporter agent. Do all of this end to end:
+const buildPrompt = `Build me the expanded Compliance Drift Reporter — a scheduled agent that combines Liongard configuration-change detections with CIPP baseline and posture data. Do all of this end to end:
 
-1. Confirm the WYRE MCP Gateway works and Liongard is reachable: call
-   liongard_detections_list with a recent 7-day startDate/endDate and a small
-   pageSize (5), and check it returns a Data.Detections array plus a
-   Data.Pagination envelope.
-2. Note the shape of a detection. Each detection carries a very large
-   ChangeDetection field (5KB-44KB each); the routine must read only the small
-   metadata - ID, SystemName, Name, Date, SystemType - and never read or echo
-   ChangeDetection. A 7-day window can easily yield hundreds of detections, so
-   the routine paginates at pageSize 5 and caps at the 25 most recent.
-3. Confirm a Slack connector is connected. Note the destination channel name
-   and ID (e.g. #sw-dev). If Slack does not show in the /schedule connector
-   list, read its connector_uuid and url from an existing routine that already
-   uses Slack (RemoteTrigger list -> get -> mcp_connections).
-4. Create a Claude-managed scheduled routine named "Compliance Drift Reporter":
-   - Schedule: weekly, cron "0 12 * * 1" (Monday 08:00 America/New_York =
-     12:00 UTC). Faster-than-hourly cadences are rejected.
-   - Attach TWO connectors, each with permitted_tools populated:
-       * WYRE MCP Gateway: liongard_detections_list
-       * Slack: slack_create_canvas, slack_send_message
-     An empty permitted_tools list = the routine runs with no tools.
-   - Routine prompt: every run, collect the last 7 days of Liongard detections
-     (the configuration-change events that are the drift signal), group them by
-     system, publish the report as a Slack canvas, and post a one-line summary
-     linking the canvas. Use the exact routine prompt below.
-5. Trigger a manual run and verify: a canvas titled "Compliance Drift - <date>"
-   was created, a one-line summary landed in the destination channel, and the
-   total count matches Data.Pagination.TotalRows for the window.`;
+1. Confirm the WYRE MCP Gateway works:
+   - Liongard: call liongard_detections_list with a recent 7-day startDate/endDate and pageSize 5; confirm a Data.Detections array plus a Data.Pagination envelope.
+   - CIPP tenants: call cipp_list_tenants; confirm a flat array of tenant objects, each with customerId, displayName, defaultDomainName, GraphErrorCount and Excluded.
+   - CIPP standards: call cipp_list_standards with tenantFilter "allTenants"; note whether it returns assigned baselines or an empty array. An empty array is expected until baselines are assigned in CIPP - it is not an error.
+   Do NOT call cipp_list_bpa: the Best Practice Analyser is deprecated and returns HTTP 503.
+2. Note the shapes. Each Liongard detection carries a very large ChangeDetection field (5KB-44KB); the routine reads only ID, SystemName, Name, Date, SystemType and never ChangeDetection. cipp_list_tenants returns roughly 34 tenants; the routine reads only customerId, displayName, defaultDomainName, GraphErrorCount and Excluded, and never echoes LastGraphError.
+3. Confirm a Slack connector is connected and note the destination channel name and ID (e.g. #sw-dev, C0931CKJ75X). If Slack does not show in the /schedule connector list, read its connector_uuid and url from an existing routine that already uses Slack (RemoteTrigger list -> get -> mcp_connections).
+4. Update the existing scheduled routine named "Compliance Drift Reporter" (trigger trig_01KdNPXeYMep1SFEDEzCrPQV):
+   - Keep the schedule: weekly, cron "0 12 * * 1" (Monday 08:00 America/New_York = 12:00 UTC).
+   - On the WYRE MCP Gateway connector set permitted_tools to: liongard_detections_list, cipp_list_tenants, cipp_list_standards.
+   - On the Slack connector set permitted_tools to: slack_create_canvas, slack_send_message.
+   - An empty permitted_tools list = the routine runs with no tools.
+   - Install the exact routine prompt below.
+5. Trigger a manual run and verify: a canvas titled "Compliance Drift - <date>" was created with a posture scorecard and two sections (Liongard, CIPP), a one-line summary landed in the destination channel, the Liongard count matches Data.Pagination.TotalRows, and the CIPP counts (tenants with a baseline + unmanaged) sum to the non-excluded tenant total.`;
 
-const routinePrompt = `You are the Compliance Drift Reporter, a weekly routine for WYRE. A Liongard detection is a configuration-change event, and that is the compliance-drift signal you report on. Baseline pass/fail evaluation is intentionally out of scope.
+const routinePrompt = `You are the Compliance Drift Reporter, a weekly routine for WYRE. You report two compliance signals in one digest: Liongard configuration-change detections, and CIPP baseline and posture state. Treat the two sources independently - a failure in one must not block the other.
 
-STEP 1 - Collect detections.
+PHASE 1 - Liongard detections.
 Compute a 7-day window: endDate = now (ISO-8601), startDate = 7 days before now. Call liongard_detections_list with that startDate and endDate, pageSize 5, page 1.
-- The response envelope is Data.Detections (array) and Data.Pagination ({ TotalRows, HasMoreRows, CurrentPage, TotalPages, PageSize }).
-- For EACH detection read ONLY these small fields: ID, SystemName, Name, Date, SystemType. IGNORE the ChangeDetection field entirely - it is very large (5KB-44KB each) and must never be read or echoed.
-- Paginate by incrementing page until you have collected 25 detections OR HasMoreRows is false - whichever comes first. CAP at 25 detections (5 pages). Do not request more than 5 pages.
+- The envelope is Data.Detections (array) and Data.Pagination ({ TotalRows, HasMoreRows, CurrentPage, TotalPages, PageSize }).
+- For EACH detection read ONLY: ID, SystemName, Name, Date, SystemType. NEVER read or echo ChangeDetection - it is 5KB-44KB each.
+- Paginate by incrementing page until you have collected 25 detections OR HasMoreRows is false. CAP at 25 (5 pages).
 - Record Data.Pagination.TotalRows as the true weekly total.
+- If liongard_detections_list errors, mark the Liongard source UNAVAILABLE and continue to Phase 2.
 
-STEP 2 - Handle failure.
-If liongard_detections_list errors or returns no usable envelope, do NOT fail silently. Call slack_send_message to channel C0931CKJ75X with: 'Compliance Drift Reporter needs a human: liongard_detections_list could not be read this week.' Then stop.
+PHASE 2 - CIPP baseline and access health.
+Call cipp_list_tenants with no arguments. It returns a flat array of tenant objects.
+- For each tenant read ONLY: customerId, displayName, defaultDomainName, GraphErrorCount, Excluded. Skip any tenant where Excluded is true.
+- Access health: a tenant with GraphErrorCount > 0 has BROKEN delegated access. Record its displayName. Do NOT echo LastGraphError.
+Call cipp_list_standards with tenantFilter "allTenants". It returns the assigned compliance baselines and their state, or an empty array.
+- A non-excluded tenant absent from the standards result has NO baseline assigned - classify it UNMANAGED.
+- A tenant present with a passing state is PASS; with a failing state is FAIL.
+- If the standards result is an empty array, EVERY non-excluded tenant is UNMANAGED. This is expected while baselines are still being rolled out - it is NOT an error, and you must NEVER invent per-tenant compliance findings that are not in the data.
+- If cipp_list_tenants errors, mark the CIPP source UNAVAILABLE.
+Never call cipp_list_bpa (deprecated, HTTP 503) or cipp_run_standards_check (a write operation).
 
-STEP 3 - No detections.
-If TotalRows is 0 (no detections in the window), call slack_send_message to channel C0931CKJ75X with the single line: 'Compliance drift: no configuration changes detected this week.' Then stop.
+PHASE 3 - Total failure check.
+If BOTH the Liongard source and the CIPP source are UNAVAILABLE, call slack_send_message to channel C0931CKJ75X with: 'Compliance Drift Reporter needs a human: neither Liongard nor CIPP could be read this week.' Then stop.
 
-STEP 4 - Build the report.
-Group the collected detections by SystemName. Within each group, sort by Date descending. For each detection write one line: the detection Name and its Date (human-readable). At the top put a total: 'TotalRows configuration-change detections this week across N systems.' If TotalRows is greater than the number you collected, add a note: 'Showing the 25 most recent detections of TotalRows total.'
+PHASE 4 - Zero findings check.
+If every available source succeeded AND there are zero Liongard detections AND zero baseline FAIL tenants AND zero broken-access tenants, call slack_send_message to channel C0931CKJ75X with the single line: 'Compliance drift: no configuration changes, no baseline failures, no access issues this week.' Then stop. Tenants being UNMANAGED is a reportable finding, not zero findings - if any tenant is unmanaged, continue to Phase 5.
 
-STEP 5 - Deliver.
-Call slack_create_canvas titled 'Compliance Drift - <today's date YYYY-MM-DD>' with the grouped report as markdown. Then call slack_send_message to channel C0931CKJ75X with a one-line summary that links the canvas, e.g. 'Compliance drift report ready: TotalRows configuration changes this week. See canvas: <link>.'
+PHASE 5 - Build the report.
+Compose a markdown report:
+- SCORECARD at the top: 'Configuration changes this week: <Liongard TotalRows>. Tenants with a baseline assigned: <X> of <N>. Tenants failing baseline: <F>. Tenants with broken delegated access: <B>.' If a source was UNAVAILABLE, say so on its scorecard line instead of a number.
+- SECTION 'Configuration changes (Liongard)': group the collected detections by SystemName, sort each group by Date descending, one line per detection (Name and human-readable Date). If TotalRows exceeds the number collected, note 'Showing the 25 most recent of <TotalRows>.' If the Liongard source was UNAVAILABLE, the section body is the single line 'Liongard data unavailable this run.'
+- SECTION 'Baseline compliance (CIPP)':
+   * Baseline coverage: if any tenant has a standard assigned, list PASS and FAIL tenants by displayName, then list UNMANAGED tenants. If no standards are assigned at all, write the single line 'No compliance baselines assigned in CIPP yet - <N> tenants unmanaged.'
+   * Tenant access health: list the displayName of every tenant with broken delegated access, or 'All tenants have healthy delegated access.' if none.
+   If the CIPP source was UNAVAILABLE, the section body is the single line 'CIPP data unavailable this run.'
 
-Use only these tools: liongard_detections_list, slack_create_canvas, slack_send_message. Keep every step light - never read or include the ChangeDetection field.`;
+PHASE 6 - Deliver.
+Call slack_create_canvas titled 'Compliance Drift - <today's date YYYY-MM-DD>' with the scorecard and both sections as markdown. Then call slack_send_message to channel C0931CKJ75X with a one-line summary linking the canvas, e.g. 'Compliance drift report ready: <TotalRows> config changes, <F> baseline failures, <B> tenants with access issues. See canvas: <link>.'
+
+Use only these tools: liongard_detections_list, cipp_list_tenants, cipp_list_standards, slack_create_canvas, slack_send_message. Keep every step light - never read Liongard's ChangeDetection field or CIPP's LastGraphError blobs.`;
 ---
-<DocsLayout title="Compliance Drift Reporter" description="Build a Claude-managed scheduled agent that surfaces the week's Liongard configuration-change detections, groups them by system, and posts a grouped drift report to Slack as a canvas — no servers, no code.">
+<DocsLayout title="Compliance Drift Reporter" description="Build a Claude-managed scheduled agent that reports two compliance signals in one weekly digest — Liongard configuration-change detections and CIPP baseline drift plus tenant access health — and posts it to Slack as a canvas. No servers, no code.">
   <h1>Compliance Drift Reporter</h1>
 
   <p class="lead text-lg text-[var(--muted)] mb-8">
     A worked example of an <a href={`${baseUrl}advanced-workflows/`}>advanced workflow</a>:
-    a Claude-managed scheduled agent that, once a week, pulls the last seven days of
-    Liongard detections — the configuration-change events that <em>are</em> the
-    compliance-drift signal — groups them by system, and publishes a digest to Slack as a
-    canvas with a one-line summary. There are no servers and no code to deploy: the agent
-    is a saved prompt plus a schedule plus two MCP connectors, running in Claude's cloud.
+    a Claude-managed scheduled agent that, once a week, pulls two independent
+    compliance signals — the last seven days of Liongard configuration-change
+    detections, and the CIPP picture of which tenants have a compliance baseline and
+    which tenants have healthy delegated access — and publishes a combined digest to
+    Slack as a canvas with a one-line summary. There are no servers and no code to
+    deploy: the agent is a saved prompt plus a schedule plus two MCP connectors,
+    running in Claude's cloud.
   </p>
 
   <h2 id="what-it-builds">What it builds</h2>
   <p>
-    The finished workflow runs unattended on a weekly cron. Each run it collects the
-    week's Liongard detections, reads only the small per-detection metadata, groups the
-    findings by system, and notifies your team, turning a stream of scattered
-    configuration changes into a single weekly drift digest with a Slack trail.
+    The finished workflow runs unattended on a weekly cron. Each run it works through
+    four phases: collect the week's Liongard detections, collect the CIPP tenant and
+    baseline picture, compute a short posture scorecard, and deliver a two-section
+    report to Slack. It turns a stream of scattered configuration changes and a
+    partially rolled-out compliance program into a single weekly drift digest with a
+    Slack trail.
   </p>
 
   <hr class="my-8" />
@@ -89,11 +98,15 @@ Use only these tools: liongard_detections_list, slack_create_canvas, slack_send_
     <tbody>
       <tr>
         <td><strong>WYRE MCP Gateway connector</strong></td>
-        <td>Connected in claude.ai (<code>https://mcp.wyre.ai/v1/mcp</code>). Provides the <code>liongard_*</code> tools. See the <a href={`${baseUrl}getting-started/gateway/`}>Gateway overview</a>.</td>
+        <td>Connected in claude.ai (<code>https://mcp.wyre.ai/v1/mcp</code>). Provides the <code>liongard_*</code> and <code>cipp_*</code> tools. See the <a href={`${baseUrl}getting-started/gateway/`}>Gateway overview</a>.</td>
       </tr>
       <tr>
         <td><strong>Liongard enabled in the gateway</strong></td>
         <td>The gateway's Liongard API credentials must be able to <strong>read</strong> detections via <code>liongard_detections_list</code>.</td>
+      </tr>
+      <tr>
+        <td><strong>CIPP enabled in the gateway</strong></td>
+        <td>The gateway's CIPP connection must be able to <strong>read</strong> tenants via <code>cipp_list_tenants</code> and assigned standards via <code>cipp_list_standards</code>.</td>
       </tr>
       <tr>
         <td><strong>Slack connector</strong></td>
@@ -129,18 +142,36 @@ Use only these tools: liongard_detections_list, slack_create_canvas, slack_send_
       total stays bounded.
     </li>
     <li>
-      <strong>A week yields hundreds of detections — paginate small and cap.</strong> A
-      typical 7-day window returns several hundred detections. The routine pages at
-      <code>pageSize</code> 5 and caps at the 25 most recent, reporting
+      <strong>A week yields hundreds of Liongard detections — paginate small and
+      cap.</strong> A typical 7-day window returns several hundred detections. The
+      routine pages at <code>pageSize</code> 5 and caps at the 25 most recent, reporting
       <code>Data.Pagination.TotalRows</code> as the true total and noting when it is
-      showing a capped subset. This keeps each tool result inside a safe size.
+      showing a capped subset.
     </li>
     <li>
-      <strong>Baseline pass/fail evaluation is intentionally out of scope — the routine
-      reports configuration-change detections, which are the drift signal.</strong>
-      Liongard's metric-evaluation endpoint is not used here; a detection is itself a
-      record of something that changed, so the digest of detections <em>is</em> the drift
-      report.
+      <strong>CIPP's Best Practice Analyzer is deprecated — never call
+      <code>cipp_list_bpa</code>.</strong> The endpoint returns HTTP 503: <em>"The Best
+      Practice Analyser has been deprecated and will be removed in a future
+      release."</em> The CIPP posture signal in this routine comes from assigned
+      Standards and from per-tenant delegated-access health, not from BPA.
+    </li>
+    <li>
+      <strong><code>cipp_list_standards</code> is empty until baselines are assigned in
+      CIPP — that empty state is reported truthfully, never fabricated over.</strong>
+      While a compliance-baseline rollout is in progress, <code>cipp_list_standards</code>
+      legitimately returns an empty array. The routine reports this as "<em>N tenants
+      unmanaged</em>" and is explicitly instructed never to invent per-tenant compliance
+      findings that are not in the data. As baselines get assigned in CIPP, the report
+      fills in on its own.
+    </li>
+    <li>
+      <strong><code>cipp_list_tenants</code> returns one flat array of ~34 tenants —
+      read only the small fields and never echo <code>LastGraphError</code>.</strong>
+      Each tenant object carries a <code>LastGraphError</code> blob that can be long. The
+      routine reads only <code>customerId</code>, <code>displayName</code>,
+      <code>defaultDomainName</code>, <code>GraphErrorCount</code>, and
+      <code>Excluded</code>, and reports broken delegated access as just a tenant name
+      plus the fact that <code>GraphErrorCount</code> is non-zero.
     </li>
     <li>
       <strong><code>permitted_tools</code> must be populated per connector.</strong> A
@@ -161,7 +192,7 @@ Use only these tools: liongard_detections_list, slack_create_canvas, slack_send_
   <h2 id="build-prompt">The one-shot build prompt</h2>
   <p>
     With the connectors above in place, paste this to Claude. It confirms the gateway,
-    creates the routine, and verifies it end to end.
+    updates the existing routine, and verifies it end to end.
   </p>
   <pre class="not-prose"><code>{buildPrompt}</code></pre>
 
@@ -177,39 +208,50 @@ Use only these tools: liongard_detections_list, slack_create_canvas, slack_send_
   <hr class="my-8" />
 
   <h2 id="how-it-works">How it works</h2>
+  <h3>Two sources, reported independently</h3>
+  <p>
+    The routine reads two unrelated systems — Liongard and CIPP — and they fail
+    independently. So it treats them as separate sources: if one is unreachable the
+    routine still delivers the other half and notes the gap in the report itself. Only
+    when <em>both</em> sources fail does it escalate to a human and stop. A vendor
+    outage never silently blanks the whole digest, and a partial report never hides
+    that it is partial.
+  </p>
   <h3>A weekly cadence, by design</h3>
   <p>
-    Compliance drift is a slow-moving signal — configurations change across days and
-    weeks. The routine runs every Monday morning so the digest is waiting before the
-    week's review work starts. A weekly cron is also kind to the API: one windowed
-    sweep per week, not one per hour.
+    Compliance drift is a slow-moving signal — configurations change and baselines roll
+    out across days and weeks. The routine runs every Monday morning so the digest is
+    waiting before the week's review work starts. A weekly cron is also kind to the
+    APIs: one windowed sweep per week, not one per hour.
   </p>
-  <h3>Detections are the drift signal</h3>
+  <h3>CIPP baseline drift and the empty-state rule</h3>
   <p>
-    A Liongard detection is a configuration-change event, a record that something on a
-    monitored system changed. The routine does not attempt a baseline pass/fail
-    evaluation; instead it treats the week's detections themselves as the drift report.
-    That keeps the routine built on a single, reliable endpoint
-    (<code>liongard_detections_list</code>) and the classification logic trivial.
+    A CIPP Standard is a compliance baseline assigned to a tenant; a tenant that fails
+    its assigned Standard has drifted from baseline. The routine reads the assigned
+    Standards via <code>cipp_list_standards</code> and classifies every tenant as
+    <em>pass</em>, <em>fail</em>, or <em>unmanaged</em> (no baseline assigned). While a
+    baseline rollout is still in progress that endpoint returns an empty array — so the
+    routine is built to report the empty state honestly as a count of unmanaged
+    tenants, and is explicitly told never to fabricate compliance findings over empty
+    data. The report doubles as a live rollout tracker: "<em>7 tenants unmanaged</em>"
+    is a standing nudge to finish assigning baselines.
   </p>
-  <h3>It windows to 7 days and caps the volume</h3>
+  <h3>Tenant access health is a day-one signal</h3>
   <p>
-    Each detection record carries a <code>ChangeDetection</code> field of 5KB–44KB, so a
-    single page of five detections is already a ~145KB response. The routine scopes every
-    call to a 7-day <code>startDate</code>/<code>endDate</code> window, pages at
-    <code>pageSize</code> 5, and stops once it has collected the 25 most recent
-    detections — reading only the small metadata (<code>ID</code>,
-    <code>SystemName</code>, <code>Name</code>, <code>Date</code>,
-    <code>SystemType</code>) and never the bloat field. <code>TotalRows</code> from the
-    pagination envelope is reported as the true weekly total even when the digest shows a
-    capped subset.
+    Each tenant in <code>cipp_list_tenants</code> carries a <code>GraphErrorCount</code>:
+    when it is non-zero, CIPP's delegated access into that customer's Microsoft tenant
+    is broken and CIPP can see nothing there. That is a real posture problem with data
+    available today, independent of the baseline rollout, so the routine surfaces the
+    list of tenants with broken delegated access every week alongside the baseline
+    picture.
   </p>
   <h3>Delivery is a Slack canvas plus a summary</h3>
   <p>
-    The grouped report can be long, so the routine publishes it as a Slack canvas, a
+    The combined report can be long, so the routine publishes it as a Slack canvas, a
     durable document teammates can scroll and reference, and posts only a one-line
-    summary to the channel linking it. When there are no detections at all, it posts a
-    single line and skips the canvas. See <a href={`${baseUrl}advanced-workflows/delivery-adapters/`}>delivery adapters</a>
+    summary to the channel linking it. When there are no detections, no baseline
+    failures, and no access issues at all, it posts a single line and skips the canvas.
+    See <a href={`${baseUrl}advanced-workflows/delivery-adapters/`}>delivery adapters</a>
     for other ways to surface a routine's output.
   </p>
 
@@ -217,13 +259,14 @@ Use only these tools: liongard_detections_list, slack_create_canvas, slack_send_
 
   <h2 id="extending">Extending it</h2>
   <p>
-    Once a working metric-evaluation endpoint is available in the gateway, the natural
-    next step is true baseline pass/fail: the routine could evaluate each system against
-    its compliance baseline and flag failures, not just report that something changed.
-    A second extension is escalation — for a system with repeated detections week over
-    week, open a PSA ticket (e.g. via the gateway's <code>autotask</code> or
+    The natural next step is escalation. For a system with repeated Liongard detections
+    week over week, or a tenant that fails its CIPP baseline run after run, the routine
+    could open a PSA ticket (via the gateway's <code>autotask</code> or
     <code>halopsa</code> tools) so the recurring drift becomes tracked remediation work
-    rather than a line in a digest.
+    rather than a line in a digest. A second extension targets the access-health
+    signal: a tenant whose delegated access stays broken for weeks is a candidate for an
+    automated GDAP-relationship repair workflow. The Best Practice Analyzer is
+    <em>not</em> an extension path — CIPP has deprecated it.
   </p>
   <p class="text-sm text-[var(--muted)]">
     Questions or a workflow you'd like documented?

--- a/msp-claude-plugins/docs/superpowers/plans/2026-05-19-compliance-drift-reporter-cipp.md
+++ b/msp-claude-plugins/docs/superpowers/plans/2026-05-19-compliance-drift-reporter-cipp.md
@@ -1,0 +1,193 @@
+# Compliance Drift Reporter — CIPP expansion: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expand the Compliance Drift Reporter Advanced Workflow docs page and live routine so its weekly report covers CIPP baseline/posture drift alongside Liongard config-change detections.
+
+**Architecture:** A docs-content change in `msp-claude-plugins` (two `.astro` pages + CHANGELOG) plus an operational update to the live Claude-managed routine `trig_01KdNPXeYMep1SFEDEzCrPQV`. The routine gains two CIPP gateway tools and a rewritten two-phase prompt. No application code.
+
+**Tech Stack:** Astro docs site (`msp-claude-plugins/docs`), WYRE MCP Gateway connectors, Claude-managed scheduled routines.
+
+**Reference:** Spec at `msp-claude-plugins/docs/superpowers/specs/2026-05-19-compliance-drift-reporter-cipp-design.md`.
+
+---
+
+### Task 1: Rewrite the build prompt and routine prompt consts
+
+**Files:**
+- Modify: `msp-claude-plugins/docs/src/pages/advanced-workflows/compliance-drift-reporter.astro` (frontmatter `const buildPrompt` and `const routinePrompt`)
+
+- [ ] **Step 1: Replace `buildPrompt`** with this exact string content:
+
+```
+Build me the expanded Compliance Drift Reporter — a scheduled agent that combines Liongard configuration-change detections with CIPP baseline and posture data. Do all of this end to end:
+
+1. Confirm the WYRE MCP Gateway works:
+   - Liongard: call liongard_detections_list with a recent 7-day startDate/endDate and pageSize 5; confirm a Data.Detections array plus a Data.Pagination envelope.
+   - CIPP tenants: call cipp_list_tenants; confirm a flat array of tenant objects, each with customerId, displayName, defaultDomainName, GraphErrorCount and Excluded.
+   - CIPP standards: call cipp_list_standards with tenantFilter "allTenants"; note whether it returns assigned baselines or an empty array. An empty array is expected until baselines are assigned in CIPP - it is not an error.
+   Do NOT call cipp_list_bpa: the Best Practice Analyser is deprecated and returns HTTP 503.
+2. Note the shapes. Each Liongard detection carries a very large ChangeDetection field (5KB-44KB); the routine reads only ID, SystemName, Name, Date, SystemType and never ChangeDetection. cipp_list_tenants returns roughly 34 tenants; the routine reads only customerId, displayName, defaultDomainName, GraphErrorCount and Excluded, and never echoes LastGraphError.
+3. Confirm a Slack connector is connected and note the destination channel name and ID (e.g. #sw-dev, C0931CKJ75X). If Slack does not show in the /schedule connector list, read its connector_uuid and url from an existing routine that already uses Slack.
+4. Update the existing scheduled routine named "Compliance Drift Reporter" (trigger trig_01KdNPXeYMep1SFEDEzCrPQV):
+   - Keep the schedule: weekly, cron "0 12 * * 1" (Monday 08:00 America/New_York = 12:00 UTC).
+   - On the WYRE MCP Gateway connector set permitted_tools to: liongard_detections_list, cipp_list_tenants, cipp_list_standards.
+   - On the Slack connector set permitted_tools to: slack_create_canvas, slack_send_message.
+   - An empty permitted_tools list = the routine runs with no tools.
+   - Install the exact routine prompt below.
+5. Trigger a manual run and verify: a canvas titled "Compliance Drift - <date>" was created with a posture scorecard and two sections (Liongard, CIPP), a one-line summary landed in the destination channel, the Liongard count matches Data.Pagination.TotalRows, and the CIPP counts (tenants with a baseline + unmanaged) sum to the non-excluded tenant total.
+```
+
+- [ ] **Step 2: Replace `routinePrompt`** with this exact string content:
+
+```
+You are the Compliance Drift Reporter, a weekly routine for WYRE. You report two compliance signals in one digest: Liongard configuration-change detections, and CIPP baseline and posture state. Treat the two sources independently - a failure in one must not block the other.
+
+PHASE 1 - Liongard detections.
+Compute a 7-day window: endDate = now (ISO-8601), startDate = 7 days before now. Call liongard_detections_list with that startDate and endDate, pageSize 5, page 1.
+- The envelope is Data.Detections (array) and Data.Pagination ({ TotalRows, HasMoreRows, CurrentPage, TotalPages, PageSize }).
+- For EACH detection read ONLY: ID, SystemName, Name, Date, SystemType. NEVER read or echo ChangeDetection - it is 5KB-44KB each.
+- Paginate by incrementing page until you have collected 25 detections OR HasMoreRows is false. CAP at 25 (5 pages).
+- Record Data.Pagination.TotalRows as the true weekly total.
+- If liongard_detections_list errors, mark the Liongard source UNAVAILABLE and continue to Phase 2.
+
+PHASE 2 - CIPP baseline and access health.
+Call cipp_list_tenants with no arguments. It returns a flat array of tenant objects.
+- For each tenant read ONLY: customerId, displayName, defaultDomainName, GraphErrorCount, Excluded. Skip any tenant where Excluded is true.
+- Access health: a tenant with GraphErrorCount > 0 has BROKEN delegated access. Record its displayName. Do NOT echo LastGraphError.
+Call cipp_list_standards with tenantFilter "allTenants". It returns the assigned compliance baselines and their state, or an empty array.
+- A non-excluded tenant absent from the standards result has NO baseline assigned - classify it UNMANAGED.
+- A tenant present with a passing state is PASS; with a failing state is FAIL.
+- If the standards result is an empty array, EVERY non-excluded tenant is UNMANAGED. This is expected while baselines are still being rolled out - it is NOT an error, and you must NEVER invent per-tenant compliance findings that are not in the data.
+- If cipp_list_tenants errors, mark the CIPP source UNAVAILABLE.
+Never call cipp_list_bpa (deprecated, HTTP 503) or cipp_run_standards_check (a write operation).
+
+PHASE 3 - Total failure check.
+If BOTH the Liongard source and the CIPP source are UNAVAILABLE, call slack_send_message to channel C0931CKJ75X with: 'Compliance Drift Reporter needs a human: neither Liongard nor CIPP could be read this week.' Then stop.
+
+PHASE 4 - Zero findings check.
+If every available source succeeded AND there are zero Liongard detections AND zero baseline FAIL tenants AND zero broken-access tenants, call slack_send_message to channel C0931CKJ75X with the single line: 'Compliance drift: no configuration changes, no baseline failures, no access issues this week.' Then stop. Tenants being UNMANAGED is a reportable finding, not zero findings - if any tenant is unmanaged, continue to Phase 5.
+
+PHASE 5 - Build the report.
+Compose a markdown report:
+- SCORECARD at the top: 'Configuration changes this week: <Liongard TotalRows>. Tenants with a baseline assigned: <X> of <N>. Tenants failing baseline: <F>. Tenants with broken delegated access: <B>.' If a source was UNAVAILABLE, say so on its scorecard line instead of a number.
+- SECTION 'Configuration changes (Liongard)': group the collected detections by SystemName, sort each group by Date descending, one line per detection (Name and human-readable Date). If TotalRows exceeds the number collected, note 'Showing the 25 most recent of <TotalRows>.' If the Liongard source was UNAVAILABLE, the section body is the single line 'Liongard data unavailable this run.'
+- SECTION 'Baseline compliance (CIPP)':
+   * Baseline coverage: if any tenant has a standard assigned, list PASS and FAIL tenants by displayName, then list UNMANAGED tenants. If no standards are assigned at all, write the single line 'No compliance baselines assigned in CIPP yet - <N> tenants unmanaged.'
+   * Tenant access health: list the displayName of every tenant with broken delegated access, or 'All tenants have healthy delegated access.' if none.
+   If the CIPP source was UNAVAILABLE, the section body is the single line 'CIPP data unavailable this run.'
+
+PHASE 6 - Deliver.
+Call slack_create_canvas titled 'Compliance Drift - <today's date YYYY-MM-DD>' with the scorecard and both sections as markdown. Then call slack_send_message to channel C0931CKJ75X with a one-line summary linking the canvas, e.g. 'Compliance drift report ready: <TotalRows> config changes, <F> baseline failures, <B> tenants with access issues. See canvas: <link>.'
+
+Use only these tools: liongard_detections_list, cipp_list_tenants, cipp_list_standards, slack_create_canvas, slack_send_message. Keep every step light - never read Liongard's ChangeDetection field or CIPP's LastGraphError blobs.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add msp-claude-plugins/docs/src/pages/advanced-workflows/compliance-drift-reporter.astro
+git commit -m "docs(advanced-workflows): rewrite Compliance Drift Reporter prompts for CIPP"
+```
+
+---
+
+### Task 2: Rewrite the page body prose
+
+**Files:**
+- Modify: `msp-claude-plugins/docs/src/pages/advanced-workflows/compliance-drift-reporter.astro` (the `<DocsLayout>` body)
+
+- [ ] **Step 1: Update each section** to cover both signals, keeping the existing page's tone and HTML structure:
+  - `title` / `description` / lead paragraph: a weekly agent covering Liongard config-change detections **and** CIPP baseline/posture drift.
+  - `what-it-builds`: four phases — Liongard collect, CIPP collect, scorecard, deliver.
+  - `prerequisites` table: add a **CIPP enabled in the gateway** row (`cipp_list_tenants`, `cipp_list_standards`). Keep the existing Liongard, Slack, routines, channel rows.
+  - `gotchas`: keep the Liongard `ChangeDetection` and pagination gotchas; add the three new CIPP gotchas from the spec ("Known gotchas" section) — BPA deprecated, `cipp_list_standards` empty until rollout (never fabricate), 34-tenant flat array / never echo `LastGraphError`.
+  - `how-it-works`: add subsections — "Two sources, reported independently", "CIPP baseline drift and the empty-state rule", "Tenant access health is a day-one signal".
+  - `extending`: replace the Liongard-metric-endpoint paragraph; new extensions = PSA ticket for repeat offenders, auto-remediation of broken delegated access. Note BPA is deprecated so is not an extension path.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add msp-claude-plugins/docs/src/pages/advanced-workflows/compliance-drift-reporter.astro
+git commit -m "docs(advanced-workflows): rewrite Compliance Drift Reporter body for CIPP"
+```
+
+---
+
+### Task 3: Update the agent-routine catalog
+
+**Files:**
+- Modify: `msp-claude-plugins/docs/src/pages/advanced-workflows/agent-routine-catalog.astro`
+
+- [ ] **Step 1: Update two table rows.**
+  - `compliance-drift-reporter` / `liongard` row: change `Connector(s)` to `liongard, cipp` and the note to `✅ built — batch 1, expanded to CIPP baseline + posture drift.`
+  - `security-posture-reviewer` / `cipp` row: append to its note `M365 posture is now partly covered by the Compliance Drift Reporter.`
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add msp-claude-plugins/docs/src/pages/advanced-workflows/agent-routine-catalog.astro
+git commit -m "docs(advanced-workflows): note CIPP coverage in agent-routine catalog"
+```
+
+---
+
+### Task 4: Update the changelog
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add an entry** under the `[Unreleased]` section (create the section/`### Changed` heading if absent), following Keep a Changelog 1.1.0:
+
+```markdown
+### Changed
+- Advanced Workflows: the Compliance Drift Reporter now also reports CIPP baseline
+  drift (assigned Standards) and tenant delegated-access health, alongside the
+  existing Liongard configuration-change detections.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): Compliance Drift Reporter CIPP expansion"
+```
+
+---
+
+### Task 5: Build the docs site and open the PR
+
+**Files:** none (verification + PR)
+
+- [ ] **Step 1: Build the docs site**
+
+Run: `cd msp-claude-plugins/docs && npm run build`
+Expected: build completes with no errors; `compliance-drift-reporter` and `agent-routine-catalog` pages render.
+
+- [ ] **Step 2: Push and open the PR**
+
+```bash
+git push -u origin advanced-workflows-cipp-compliance-drift
+gh pr create --title "Advanced Workflows: Compliance Drift Reporter CIPP expansion" \
+  --body "Expands the Compliance Drift Reporter to report CIPP baseline drift and tenant access health alongside Liongard detections. Spec: docs/superpowers/specs/2026-05-19-compliance-drift-reporter-cipp-design.md"
+```
+
+Expected: PR created against `main`.
+
+---
+
+### Task 6: Update the live routine (operational, after PR merges)
+
+**Files:** none (operational — performed in the WYRE Claude account, not git)
+
+- [ ] **Step 1:** Paste the Task 1 `buildPrompt` to Claude in the WYRE account with the WYRE MCP Gateway and Slack connectors attached.
+- [ ] **Step 2:** Confirm the routine `trig_01KdNPXeYMep1SFEDEzCrPQV` now has gateway `permitted_tools` = `liongard_detections_list, cipp_list_tenants, cipp_list_standards`.
+- [ ] **Step 3:** Trigger a manual run; verify the canvas has the scorecard + both sections and the summary line posts to `C0931CKJ75X`.
+
+---
+
+## Self-review
+
+- **Spec coverage:** Phases 1–6, per-source degradation, empty-state rule, scorecard, both sections, build prompt, catalog + changelog, routine update — all mapped to Tasks 1–6. ✓
+- **Placeholder scan:** prompt consts are verbatim; prose tasks reference the spec's enumerated sections rather than leaving "TODO". ✓
+- **Consistency:** tool list (`liongard_detections_list`, `cipp_list_tenants`, `cipp_list_standards`, `slack_create_canvas`, `slack_send_message`), channel `C0931CKJ75X`, trigger `trig_01KdNPXeYMep1SFEDEzCrPQV`, cron `0 12 * * 1` consistent across build prompt, routine prompt, and Task 6. ✓

--- a/msp-claude-plugins/docs/superpowers/specs/2026-05-19-compliance-drift-reporter-cipp-design.md
+++ b/msp-claude-plugins/docs/superpowers/specs/2026-05-19-compliance-drift-reporter-cipp-design.md
@@ -1,0 +1,166 @@
+# Compliance Drift Reporter — CIPP expansion
+
+**Date:** 2026-05-19
+**Status:** Approved design — ready for implementation plan
+**Affects:** `wyre-technology/msp-claude-plugins` (Advanced Workflows docs + live routine)
+
+## Summary
+
+The batch-1 **Compliance Drift Reporter** routine (`trig_01KdNPXeYMep1SFEDEzCrPQV`)
+currently reports only Liongard configuration-change detections. As WYRE rolls out
+compliance baselines in CIPP, the routine should also report **baseline drift from
+CIPP** — tenants failing their assigned CIPP Standards, plus a supporting Best
+Practice Analyzer score per tenant.
+
+This is an **expansion of the existing routine**, not a new one: one routine, one
+weekly cadence, one combined Slack report covering both signals.
+
+## Motivation
+
+Liongard and CIPP report drift in fundamentally different shapes:
+
+- **Liongard** — a stream of *change events* ("this config changed"). The current
+  routine treats the week's detections as the drift signal.
+- **CIPP Standards** — a point-in-time *pass/fail against a baseline* ("this tenant
+  fails its assigned standard"). This is true baseline drift, the missing half the
+  current doc's "Extending it" section already anticipates.
+
+The current routine's docs explicitly name this as the next step: *"true baseline
+pass/fail: the routine could evaluate each system against its compliance baseline
+and flag failures, not just report that something changed."* CIPP Standards is
+that baseline.
+
+## Decisions (resolved during brainstorming)
+
+| Question | Decision |
+|---|---|
+| New routine or expand existing? | **Expand the existing routine** — one combined report |
+| Which CIPP signal? | **Both** — CIPP Standards compliance (primary) + Best Practice Analyzer score (supporting) |
+| Tenant scope? | **All CIPP tenants** — tenants with no baseline assigned surface as an "unmanaged" finding |
+| Fresh data or cached? | **Read last computed results** — read-only, no `cipp_run_standards_check` trigger; the routine stays a pure reporter |
+| Report structure? | **Approach C** — two-section report (Liongard / CIPP) with a computed posture scorecard header |
+
+## Scope of changes
+
+Four artifacts change in `wyre-technology/msp-claude-plugins`:
+
+| Artifact | Change |
+|---|---|
+| Live routine `trig_01KdNPXeYMep1SFEDEzCrPQV` | Add `cipp_list_tenants`, `cipp_list_standards`, `cipp_list_bpa` to the WYRE MCP Gateway connector's `permitted_tools`; replace the routine prompt with the two-phase version |
+| `msp-claude-plugins/docs/src/pages/advanced-workflows/compliance-drift-reporter.astro` | Rewrite: cover both signals, new build prompt + routine prompt, new CIPP multi-tenant gotchas |
+| `msp-claude-plugins/docs/src/pages/advanced-workflows/agent-routine-catalog.astro` | Update the `compliance-drift-reporter`/liongard row note; note CIPP posture coverage is folded in (touches the `security-posture-reviewer`/cipp row) |
+| `CHANGELOG.md` | New `[Unreleased]` entry |
+
+**Unchanged:** weekly cron `0 12 * * 1` (Monday 08:00 America/New_York), Slack
+delivery (canvas + one-line summary to channel `C0931CKJ75X`), and the entire
+Liongard collection logic.
+
+## Run flow
+
+The routine runs four phases per invocation:
+
+### Phase 1 — Liongard collection (unchanged)
+
+Compute a 7-day window. Call `liongard_detections_list` at `pageSize` 5, paginating
+until 25 detections collected or `HasMoreRows` is false. Read only `ID`,
+`SystemName`, `Name`, `Date`, `SystemType` per detection — never `ChangeDetection`
+(5KB–44KB each). Record `Data.Pagination.TotalRows` as the true weekly total.
+
+### Phase 2 — CIPP collection
+
+1. `cipp_list_tenants` — the full tenant list. This is the denominator.
+2. `cipp_list_standards` — which tenants have a standard assigned and their
+   compliance state. A tenant present in the tenant list but absent here =
+   **unmanaged** (no baseline assigned).
+3. `cipp_list_bpa` — per-tenant Best Practice Analyzer score.
+4. Classify each tenant: **pass** / **fail** / **unmanaged**; capture its BPA score.
+
+Read only small per-tenant fields (tenant name/id, standard name, compliance
+status, BPA score). Never read per-tenant config payloads — the same "read the
+metadata, skip the bloat" discipline as Liongard's `ChangeDetection` rule.
+
+### Phase 3 — Posture scorecard
+
+Compute from numbers already collected:
+
+- Configuration changes this week (Liongard `TotalRows`)
+- Tenants failing CIPP Standards
+- Tenants with no baseline assigned ("unmanaged")
+- Average BPA score across tenants
+
+### Phase 4 — Deliver
+
+Publish a Slack canvas titled `Compliance Drift — <YYYY-MM-DD>` with the scorecard
+header followed by two sections:
+
+- **Configuration changes (Liongard)** — detections grouped by system, as today.
+- **Baseline compliance (CIPP)** — per-tenant pass/fail table, plus a list of
+  unmanaged tenants.
+
+Post one summary line to `C0931CKJ75X` linking the canvas.
+
+## Error handling — per-source degradation
+
+With two independent data sources, "if it fails, stop" is wrong: one vendor's
+outage should not blank a report the other half is fine to deliver. Silent partial
+data is equally wrong. The rule: **degrade per-source, and make the gap visible in
+the report itself.**
+
+| Condition | Behavior |
+|---|---|
+| Liongard fails, CIPP OK | Deliver CIPP section; canvas notes *"Liongard data unavailable this run."* |
+| CIPP fails, Liongard OK | Deliver Liongard section; canvas notes *"CIPP data unavailable this run."* |
+| Both fail | Post a "needs a human" line to `C0931CKJ75X`, then stop (batch-1 behavior preserved) |
+| Both OK, zero findings | Post a single summary line, skip the canvas (batch-1 behavior preserved) |
+
+## Build & verification
+
+The doc uses the established **one-shot build-prompt** pattern: a single prompt
+pasted to Claude that confirms connectors, updates the routine, and verifies it
+end to end.
+
+**Shape probing.** The Liongard envelope (`Data.Detections` + `Data.Pagination`)
+is known. The CIPP envelopes for `cipp_list_standards` and `cipp_list_bpa` are
+**not yet verified**. The build prompt's Step 1 probes all three `cipp_*` tools
+against a couple of real tenants and records the actual response shape; the
+routine prompt's field names are finalized against that probe. No unverified
+field names are baked into the live routine — the same approach the batch-1 doc
+uses for Liongard.
+
+**Build prompt steps:**
+
+1. Confirm the gateway is reachable. Probe `liongard_detections_list` (known
+   shape) plus `cipp_list_tenants`, `cipp_list_standards`, `cipp_list_bpa` —
+   record envelope shapes and the per-tenant fields that distinguish
+   pass / fail / unmanaged.
+2. Confirm the Slack connector and destination channel `C0931CKJ75X`.
+3. Update the existing routine `trig_01KdNPXeYMep1SFEDEzCrPQV`: add the three
+   `cipp_*` tools to the gateway connector's `permitted_tools`; install the
+   two-phase routine prompt.
+4. Manual run + verify: the canvas has the scorecard header and both sections;
+   the Liongard count reconciles with `TotalRows`; CIPP tenant counts
+   (pass + fail + unmanaged) sum to the `cipp_list_tenants` total.
+
+**Testing.** A scheduled routine has no unit-test harness — verification is the
+manual run in Step 4, plus a follow-up run a week later confirming the cron fired
+and the partial-degradation messaging renders correctly when a source is down.
+
+## Known gotchas (new, CIPP-specific)
+
+- **A 34+ tenant CIPP sweep can be large.** Read only the small per-tenant fields;
+  never read per-tenant config payloads. Cap detail rows if a response is
+  unexpectedly large, the same way the Liongard phase caps at 25 detections.
+- **`permitted_tools` must list every `cipp_*` tool the routine calls.** A
+  connector with an empty or incomplete `permitted_tools` list runs with no tools
+  and silently does nothing.
+- **The routine is read-only by design.** It must not call
+  `cipp_run_standards_check` — that is a write-capable, minutes-long operation.
+  The routine reads whatever CIPP last computed on its own schedule.
+
+## Out of scope
+
+- Triggering fresh CIPP standards checks.
+- Correlating Liongard systems to CIPP tenants into a unified per-entity table
+  (no shared key — fragile mapping; rejected as Approach B).
+- Any remediation action (opening PSA tickets for repeat offenders) — noted as a
+  possible future extension, not part of this work.

--- a/msp-claude-plugins/docs/superpowers/specs/2026-05-19-compliance-drift-reporter-cipp-design.md
+++ b/msp-claude-plugins/docs/superpowers/specs/2026-05-19-compliance-drift-reporter-cipp-design.md
@@ -1,7 +1,7 @@
 # Compliance Drift Reporter — CIPP expansion
 
 **Date:** 2026-05-19
-**Status:** Approved design — ready for implementation plan
+**Status:** Approved design (revised after gateway probe) — ready for implementation plan
 **Affects:** `wyre-technology/msp-claude-plugins` (Advanced Workflows docs + live routine)
 
 ## Summary
@@ -9,11 +9,29 @@
 The batch-1 **Compliance Drift Reporter** routine (`trig_01KdNPXeYMep1SFEDEzCrPQV`)
 currently reports only Liongard configuration-change detections. As WYRE rolls out
 compliance baselines in CIPP, the routine should also report **baseline drift from
-CIPP** — tenants failing their assigned CIPP Standards, plus a supporting Best
-Practice Analyzer score per tenant.
+CIPP** — tenants failing their assigned CIPP Standards — plus a **tenant access
+health** signal derived from CIPP's per-tenant Graph error count.
 
 This is an **expansion of the existing routine**, not a new one: one routine, one
 weekly cadence, one combined Slack report covering both signals.
+
+## Gateway probe — what is actually available (2026-05-19)
+
+Before designing against CIPP, the three candidate tools were probed against the
+live WYRE gateway. Findings, which shaped this design:
+
+- **`cipp_list_tenants`** — works. Returns a **flat JSON array** (no envelope) of
+  ~34 tenant objects. Useful fields per tenant: `customerId`, `displayName`,
+  `defaultDomainName`, `Excluded`, `GraphErrorCount`, `LastGraphError`,
+  `delegatedPrivilegeStatus`. At probe time, **10 of 34 tenants had
+  `GraphErrorCount > 0`** (broken delegated access — AADSTS errors).
+- **`cipp_list_standards`** — works but returns `[]` for both `allTenants` and a
+  specific tenant. No compliance baselines are assigned in CIPP yet; this is
+  expected — the baseline rollout is in progress. The design treats an empty
+  result as a truthful first-class state, never something to paper over.
+- **`cipp_list_bpa`** — **deprecated and disabled.** Returns HTTP 503: *"The Best
+  Practice Analyser has been deprecated and will be removed in a future release."*
+  BPA is therefore **excluded from this design entirely.**
 
 ## Motivation
 
@@ -25,17 +43,18 @@ Liongard and CIPP report drift in fundamentally different shapes:
   fails its assigned standard"). This is true baseline drift, the missing half the
   current doc's "Extending it" section already anticipates.
 
-The current routine's docs explicitly name this as the next step: *"true baseline
-pass/fail: the routine could evaluate each system against its compliance baseline
-and flag failures, not just report that something changed."* CIPP Standards is
-that baseline.
+Because Standards is empty until the rollout lands, the CIPP section also reports
+**tenant access health** — tenants whose CIPP-to-Microsoft delegated access is
+broken (`GraphErrorCount > 0`). That signal has real data today, so the CIPP
+section is useful from day one, and broken delegated access is itself a posture
+problem worth surfacing weekly.
 
 ## Decisions (resolved during brainstorming)
 
 | Question | Decision |
 |---|---|
 | New routine or expand existing? | **Expand the existing routine** — one combined report |
-| Which CIPP signal? | **Both** — CIPP Standards compliance (primary) + Best Practice Analyzer score (supporting) |
+| Which CIPP signal? | **CIPP Standards compliance** (primary baseline-drift signal) **+ tenant access health** from `GraphErrorCount` (day-one signal while Standards is empty). **BPA dropped** — deprecated. |
 | Tenant scope? | **All CIPP tenants** — tenants with no baseline assigned surface as an "unmanaged" finding |
 | Fresh data or cached? | **Read last computed results** — read-only, no `cipp_run_standards_check` trigger; the routine stays a pure reporter |
 | Report structure? | **Approach C** — two-section report (Liongard / CIPP) with a computed posture scorecard header |
@@ -46,7 +65,7 @@ Four artifacts change in `wyre-technology/msp-claude-plugins`:
 
 | Artifact | Change |
 |---|---|
-| Live routine `trig_01KdNPXeYMep1SFEDEzCrPQV` | Add `cipp_list_tenants`, `cipp_list_standards`, `cipp_list_bpa` to the WYRE MCP Gateway connector's `permitted_tools`; replace the routine prompt with the two-phase version |
+| Live routine `trig_01KdNPXeYMep1SFEDEzCrPQV` | Add `cipp_list_tenants`, `cipp_list_standards` to the WYRE MCP Gateway connector's `permitted_tools`; replace the routine prompt with the two-phase version |
 | `msp-claude-plugins/docs/src/pages/advanced-workflows/compliance-drift-reporter.astro` | Rewrite: cover both signals, new build prompt + routine prompt, new CIPP multi-tenant gotchas |
 | `msp-claude-plugins/docs/src/pages/advanced-workflows/agent-routine-catalog.astro` | Update the `compliance-drift-reporter`/liongard row note; note CIPP posture coverage is folded in (touches the `security-posture-reviewer`/cipp row) |
 | `CHANGELOG.md` | New `[Unreleased]` entry |
@@ -68,25 +87,32 @@ until 25 detections collected or `HasMoreRows` is false. Read only `ID`,
 
 ### Phase 2 — CIPP collection
 
-1. `cipp_list_tenants` — the full tenant list. This is the denominator.
-2. `cipp_list_standards` — which tenants have a standard assigned and their
-   compliance state. A tenant present in the tenant list but absent here =
-   **unmanaged** (no baseline assigned).
-3. `cipp_list_bpa` — per-tenant Best Practice Analyzer score.
-4. Classify each tenant: **pass** / **fail** / **unmanaged**; capture its BPA score.
+1. `cipp_list_tenants` — the full tenant list (flat array). This is the
+   denominator. For each tenant read only `customerId`, `displayName`,
+   `defaultDomainName`, `GraphErrorCount`, `Excluded`. Skip tenants where
+   `Excluded` is `true`.
+2. `cipp_list_standards` with `tenantFilter: "allTenants"` — the assigned
+   baselines and their compliance state. A tenant present in the tenant list but
+   absent from the standards result = **unmanaged** (no baseline assigned). When
+   the standards result is `[]`, every tenant is unmanaged — report that
+   truthfully.
+3. Classify each non-excluded tenant on two independent axes:
+   - **Baseline:** `pass` / `fail` / `unmanaged` (from `cipp_list_standards`).
+   - **Access:** `healthy` (`GraphErrorCount` == 0) / `broken`
+     (`GraphErrorCount` > 0).
 
-Read only small per-tenant fields (tenant name/id, standard name, compliance
-status, BPA score). Never read per-tenant config payloads — the same "read the
-metadata, skip the bloat" discipline as Liongard's `ChangeDetection` rule.
+Read only the small per-tenant fields named above — never per-tenant config
+payloads, and never echo `LastGraphError` blobs verbatim (they are long); report
+only that access is broken plus the tenant name.
 
 ### Phase 3 — Posture scorecard
 
 Compute from numbers already collected:
 
 - Configuration changes this week (Liongard `TotalRows`)
-- Tenants failing CIPP Standards
-- Tenants with no baseline assigned ("unmanaged")
-- Average BPA score across tenants
+- Tenants with a baseline assigned (`X of N`)
+- Tenants failing their baseline
+- Tenants with broken delegated access (`GraphErrorCount` > 0)
 
 ### Phase 4 — Deliver
 
@@ -94,8 +120,12 @@ Publish a Slack canvas titled `Compliance Drift — <YYYY-MM-DD>` with the score
 header followed by two sections:
 
 - **Configuration changes (Liongard)** — detections grouped by system, as today.
-- **Baseline compliance (CIPP)** — per-tenant pass/fail table, plus a list of
-  unmanaged tenants.
+- **Baseline compliance (CIPP)** — two sub-parts:
+  - *Baseline coverage* — per-tenant pass/fail for tenants with an assigned
+    standard; a list of unmanaged tenants. When no standards are assigned at all,
+    a single honest line: "No compliance baselines assigned in CIPP yet — N
+    tenants unmanaged."
+  - *Tenant access health* — the list of tenants with broken delegated access.
 
 Post one summary line to `C0931CKJ75X` linking the canvas.
 
@@ -113,33 +143,36 @@ the report itself.**
 | Both fail | Post a "needs a human" line to `C0931CKJ75X`, then stop (batch-1 behavior preserved) |
 | Both OK, zero findings | Post a single summary line, skip the canvas (batch-1 behavior preserved) |
 
+"Zero findings" means: no Liongard detections AND no baseline failures AND no
+broken-access tenants. An empty `cipp_list_standards` is **not** an error and not
+"zero findings" — it is the reportable "N tenants unmanaged" state.
+
 ## Build & verification
 
 The doc uses the established **one-shot build-prompt** pattern: a single prompt
 pasted to Claude that confirms connectors, updates the routine, and verifies it
 end to end.
 
-**Shape probing.** The Liongard envelope (`Data.Detections` + `Data.Pagination`)
-is known. The CIPP envelopes for `cipp_list_standards` and `cipp_list_bpa` are
-**not yet verified**. The build prompt's Step 1 probes all three `cipp_*` tools
-against a couple of real tenants and records the actual response shape; the
-routine prompt's field names are finalized against that probe. No unverified
-field names are baked into the live routine — the same approach the batch-1 doc
-uses for Liongard.
+**Shapes are now verified** (see "Gateway probe" above), so the routine prompt
+ships with concrete field names. The build prompt still re-confirms the gateway is
+reachable and that `cipp_list_standards` responds, so a future CIPP change is
+caught at build time.
 
 **Build prompt steps:**
 
-1. Confirm the gateway is reachable. Probe `liongard_detections_list` (known
-   shape) plus `cipp_list_tenants`, `cipp_list_standards`, `cipp_list_bpa` —
-   record envelope shapes and the per-tenant fields that distinguish
-   pass / fail / unmanaged.
+1. Confirm the gateway is reachable. Call `liongard_detections_list` (7-day
+   window, `pageSize` 5) and confirm the `Data.Detections` / `Data.Pagination`
+   envelope. Call `cipp_list_tenants` and confirm a flat array with
+   `customerId` / `displayName` / `GraphErrorCount`. Call `cipp_list_standards`
+   with `tenantFilter: "allTenants"` and note whether it is empty.
 2. Confirm the Slack connector and destination channel `C0931CKJ75X`.
-3. Update the existing routine `trig_01KdNPXeYMep1SFEDEzCrPQV`: add the three
-   `cipp_*` tools to the gateway connector's `permitted_tools`; install the
-   two-phase routine prompt.
-4. Manual run + verify: the canvas has the scorecard header and both sections;
-   the Liongard count reconciles with `TotalRows`; CIPP tenant counts
-   (pass + fail + unmanaged) sum to the `cipp_list_tenants` total.
+3. Update the existing routine `trig_01KdNPXeYMep1SFEDEzCrPQV`: add
+   `cipp_list_tenants` and `cipp_list_standards` to the gateway connector's
+   `permitted_tools`; install the two-phase routine prompt.
+4. Manual run + verify: the canvas has the scorecard header and both sections; the
+   Liongard count reconciles with `TotalRows`; the CIPP tenant counts (with a
+   baseline + unmanaged) sum to the non-excluded `cipp_list_tenants` total; the
+   broken-access count matches the tenants with `GraphErrorCount > 0`.
 
 **Testing.** A scheduled routine has no unit-test harness — verification is the
 manual run in Step 4, plus a follow-up run a week later confirming the cron fired
@@ -147,20 +180,28 @@ and the partial-degradation messaging renders correctly when a source is down.
 
 ## Known gotchas (new, CIPP-specific)
 
-- **A 34+ tenant CIPP sweep can be large.** Read only the small per-tenant fields;
-  never read per-tenant config payloads. Cap detail rows if a response is
-  unexpectedly large, the same way the Liongard phase caps at 25 detections.
+- **CIPP's Best Practice Analyzer is deprecated** — `cipp_list_bpa` returns HTTP
+  503. The routine must never call it.
+- **`cipp_list_standards` is empty until baselines are assigned in CIPP.** This is
+  not an error. The routine reports the empty state truthfully as "N tenants
+  unmanaged" and must never fabricate per-tenant compliance findings over an empty
+  array.
+- **A 34-tenant CIPP sweep is bounded but read carefully.** `cipp_list_tenants`
+  returns one flat array; read only the small per-tenant fields and never echo
+  `LastGraphError` strings verbatim.
 - **`permitted_tools` must list every `cipp_*` tool the routine calls.** A
   connector with an empty or incomplete `permitted_tools` list runs with no tools
   and silently does nothing.
 - **The routine is read-only by design.** It must not call
-  `cipp_run_standards_check` — that is a write-capable, minutes-long operation.
-  The routine reads whatever CIPP last computed on its own schedule.
+  `cipp_run_standards_check` — that is a write-capable operation. The routine
+  reads whatever CIPP last computed on its own schedule.
 
 ## Out of scope
 
+- Best Practice Analyzer — deprecated by CIPP.
 - Triggering fresh CIPP standards checks.
 - Correlating Liongard systems to CIPP tenants into a unified per-entity table
   (no shared key — fragile mapping; rejected as Approach B).
-- Any remediation action (opening PSA tickets for repeat offenders) — noted as a
-  possible future extension, not part of this work.
+- Any remediation action (opening PSA tickets for repeat offenders, or fixing
+  broken delegated access) — noted as possible future extensions, not part of
+  this work.


### PR DESCRIPTION
## Summary

Expands the batch-1 **Compliance Drift Reporter** so its weekly routine reports **CIPP baseline drift** (assigned Standards) and **tenant delegated-access health** alongside the existing Liongard configuration-change detections. One routine, one weekly report, two-section Slack canvas with a posture scorecard.

## What changed

- **`compliance-drift-reporter.astro`** — rewritten: new one-shot build prompt + two-phase routine prompt covering both sources; new CIPP prerequisites, gotchas, and how-it-works sections.
- **`agent-routine-catalog.astro`** — updated the `compliance-drift-reporter` and `security-posture-reviewer` row notes.
- **`CHANGELOG.md`** — `### Changed` entry.

## Design decisions

- **Expanded** the existing routine rather than adding a new one.
- **Per-source degradation** — a Liongard *or* CIPP outage no longer blanks the whole report; the gap is noted in the canvas. Only a dual failure escalates to a human.
- **Empty-state honesty** — `cipp_list_standards` is empty until the baseline rollout lands; the routine reports "N tenants unmanaged" truthfully and is told never to fabricate findings over an empty array.
- **BPA dropped** — `cipp_list_bpa` is deprecated by CIPP (HTTP 503). Tenant access health (`GraphErrorCount`) replaces it as the day-one CIPP signal.

Tool shapes were verified against the live gateway before writing the prompts.

## Docs

- Spec: `docs/superpowers/specs/2026-05-19-compliance-drift-reporter-cipp-design.md`
- Plan: `docs/superpowers/plans/2026-05-19-compliance-drift-reporter-cipp.md`

## Follow-up (operational, after merge)

Run the build prompt against the WYRE Claude account to update live routine `trig_01KdNPXeYMep1SFEDEzCrPQV` — add `cipp_list_tenants` / `cipp_list_standards` to its gateway `permitted_tools` and install the new prompt.

## Test plan

- [x] `astro build` passes; both pages render with CIPP content.