### PR TITLE
feat(auvik): add Auvik network monitoring plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,6 +35,20 @@
       ]
     },
     {
+      "name": "auvik",
+      "source": "./msp-claude-plugins/auvik/auvik",
+      "description": "Auvik - network monitoring, device inventory, alerts, configurations, capacity planning across tenants",
+      "version": "0.1.0",
+      "category": "network",
+      "tags": [
+        "auvik",
+        "network-monitoring",
+        "snmp",
+        "msp",
+        "rmm"
+      ]
+    },
+    {
       "name": "autotask",
       "source": "./msp-claude-plugins/kaseya/autotask",
       "description": "Kaseya Autotask PSA - tickets, CRM, projects, contracts, billing",

--- a/msp-claude-plugins/auvik/auvik/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/auvik/auvik/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "auvik",
+  "version": "0.1.0",
+  "description": "Claude plugins for Auvik - network monitoring, device inventory, alert triage, configuration audit, and capacity planning for MSPs",
+  "author": {
+    "name": "MSP Claude Plugins Community"
+  },
+  "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
+  "repository": "https://github.com/wyre-technology/msp-claude-plugins",
+  "license": "Apache-2.0",
+  "keywords": ["auvik", "msp", "network-monitoring", "mcp", "rmm"]
+}

--- a/msp-claude-plugins/auvik/auvik/.env.example
+++ b/msp-claude-plugins/auvik/auvik/.env.example
@@ -1,0 +1,5 @@
+# Auvik API credentials (https://support.auvik.com/hc/en-us/sections/360002960071-Auvik-APIs)
+AUVIK_USERNAME=your-email@company.com
+AUVIK_API_KEY=your-api-key
+# Region: one of us1 us2 us3 us4 eu1 eu2 au1 ca1 (omit to auto-detect)
+AUVIK_REGION=us1

--- a/msp-claude-plugins/auvik/auvik/.mcp.json
+++ b/msp-claude-plugins/auvik/auvik/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "auvik": {
+      "type": "http",
+      "url": "https://mcp.wyre.ai/v1/auvik/mcp",
+      "headers": {
+        "X-Auvik-Username": "${AUVIK_USERNAME}",
+        "X-Auvik-Api-Key": "${AUVIK_API_KEY}",
+        "X-Auvik-Region": "${AUVIK_REGION}"
+      }
+    }
+  }
+}

--- a/msp-claude-plugins/auvik/auvik/README.md
+++ b/msp-claude-plugins/auvik/auvik/README.md
@@ -1,0 +1,152 @@
+# Auvik Plugin
+
+Claude Code plugin for the Auvik cloud-based network monitoring platform.
+
+## Overview
+
+This plugin gives Claude working knowledge of Auvik so MSP analysts can interrogate device inventories, triage alerts, audit network configurations, and plan capacity without leaving the chat. It talks to Auvik through the [WYRE MCP Gateway](https://mcp.wyre.ai), so no local SDK or proxy is required.
+
+## What Is Auvik
+
+Auvik is a SaaS network monitoring and management product used by MSPs to discover, map, monitor, and alert on customer network infrastructure - switches, routers, firewalls, access points, hypervisors, printers, and the interfaces and IP networks that connect them. It is multi-tenant by design; one set of credentials sees every client tenant the MSP manages.
+
+## What This Plugin Does
+
+- **Device Inventory** - Per-tenant device reports broken down by type, manage status, and lifecycle posture; flags unmanaged devices and hardware nearing end-of-life
+- **Alert Triage** - Pulls open alerts, ranks them by severity and entity criticality, recommends dismissals for known-good noise, and pivots into device/interface context before action
+- **Network Audit** - Walks a tenant's networks, interfaces, and configuration backups to flag drift, missing backups, and unusual config patterns
+- **Tenant Overview** - A single-tenant snapshot - device count, open alerts, network footprint, and billing usage
+- **Capacity Check** - Interface statistics over a window to find saturated links and recurring congestion
+
+## Installation
+
+Install via the [MSP Claude Plugins marketplace](https://github.com/wyre-technology/msp-claude-plugins):
+
+```
+/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin install auvik
+```
+
+The plugin connects through the [WYRE MCP Gateway](https://mcp.wyre.ai) at `https://mcp.wyre.ai/v1/auvik/mcp`.
+
+## Configuration
+
+Set the following environment variables (or paste credentials into the gateway UI):
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `AUVIK_USERNAME` | Yes | Email address of the Auvik user the API key belongs to |
+| `AUVIK_API_KEY` | Yes | API key issued from the Auvik portal under My Profile / API Keys |
+| `AUVIK_REGION` | No | Region cluster the tenant lives in: `us1`, `us2`, `us3`, `us4`, `eu1`, `eu2`, `au1`, `ca1`. Omit to auto-detect. |
+
+See the [Auvik API documentation](https://support.auvik.com/hc/en-us/sections/360002960071-Auvik-APIs) for instructions on issuing an API key and identifying your region.
+
+## Available Commands
+
+| Command | Description |
+|---------|-------------|
+| `/auvik:device-inventory` | List and summarize devices for a tenant, with type and lifecycle breakdown |
+| `/auvik:alert-triage` | Prioritize open alerts and recommend dismissals for known noise |
+| `/auvik:network-audit` | Audit network topology, interfaces, and saved configurations for a tenant |
+| `/auvik:tenant-overview` | Single-tenant dashboard - devices, alerts, networks, billing usage |
+| `/auvik:capacity-check` | Interface utilization scan; flags saturated links |
+
+## Available Agents
+
+| Agent | Use For |
+|-------|---------|
+| `network-analyst` | "What's wrong with this tenant's network?" - topology, performance, multi-signal triage |
+| `alert-responder` | Inbound alert questions - severity, entity context, dismissal decisions |
+| `capacity-planner` | Utilization, saturation, and headroom questions over time windows |
+
+## Skills Bundled
+
+- `devices` - Device taxonomy, manageStatus values, lifecycle and warranty fields
+- `alerts` - Severity enum, status enum, dismissal semantics, common alert names
+- `networks` - Network entity model, interface relationships
+- `api-patterns` - JSON:API envelope, pagination, rate-limit behavior, v1 vs v2 device API
+
+## Available Tools
+
+Provided by the Auvik MCP server through the WYRE MCP Gateway:
+
+### Service
+- `auvik_status`, `auvik_navigate`
+
+### Tenants
+- `auvik_tenants_list`, `auvik_tenants_get`, `auvik_tenants_detail`
+
+### Devices
+- `auvik_devices_list`, `auvik_devices_get`, `auvik_devices_get_details`
+- `auvik_devices_get_warranty`, `auvik_devices_get_lifecycle`
+
+### Networks and Interfaces
+- `auvik_networks_list`, `auvik_networks_get`
+- `auvik_interfaces_list`
+
+### Configurations
+- `auvik_configurations_list`, `auvik_configurations_get`
+
+### Entities (notes and audits)
+- `auvik_entities_list_notes`, `auvik_entities_list_audits`
+
+### Alerts
+- `auvik_alerts_list`, `auvik_alerts_get`, `auvik_alerts_dismiss`
+
+### Statistics
+- `auvik_statistics_device`, `auvik_statistics_interface`
+- `auvik_statistics_service`, `auvik_statistics_snmp_poller`
+
+### Billing
+- `auvik_billing_client_usage`, `auvik_billing_device_usage`
+
+## Common Workflows
+
+### Triage overnight alerts
+
+```
+/auvik:alert-triage
+```
+
+Lists open alerts across visible tenants ordered by severity, groups duplicate alerts per entity, and recommends dismissals for ones matching known noise patterns (link flap on an unmanaged port, scheduled reboots, etc.).
+
+### Audit a tenant's network before a renewal
+
+```
+/auvik:network-audit tenant_id=<id>
+```
+
+Walks every network, lists devices and interfaces, pulls the most recent saved configurations, and flags devices with no configuration backup or stale backups (>30 days).
+
+### Find devices nearing end-of-life
+
+```
+/auvik:device-inventory tenant_id=<id>
+```
+
+Lists all devices for the tenant, joins with lifecycle and warranty data, and surfaces anything past end-of-sale or end-of-support and anything out of warranty.
+
+### Spot saturated WAN links
+
+```
+/auvik:capacity-check tenant_id=<id> window=7d
+```
+
+Pulls interface statistics over the window, flags any link with sustained utilization >70% or recurring saturation events.
+
+## Troubleshooting
+
+- **Region detection** - If calls return 404 or redirect loops, your tenant is in a different region cluster. Set `AUVIK_REGION` explicitly. The current clusters are `us1`, `us2`, `us3`, `us4`, `eu1`, `eu2`, `au1`, `ca1`.
+- **Rate limits** - Auvik enforces per-key rate limits. If listings start returning 429, slow the pagination loop or narrow the query by tenant. The MCP server surfaces rate-limit errors as tool errors with a retryable status.
+- **Dismiss vs resolve** - `auvik_alerts_dismiss` acknowledges and hides the alert in the UI. It does not fix the underlying condition. If the condition still holds when the alert next evaluates, a new alert will appear. Use dismissals only for confirmed noise.
+- **v1 vs v2 device endpoints** - `auvik_devices_list` returns the lighter v1 device record. For lifecycle, warranty, and extended attributes use `auvik_devices_get_details`, `auvik_devices_get_lifecycle`, and `auvik_devices_get_warranty`.
+
+## License
+
+Apache-2.0
+
+## Links
+
+- [Auvik product](https://www.auvik.com/)
+- [Auvik API docs](https://support.auvik.com/hc/en-us/sections/360002960071-Auvik-APIs)
+- [Auvik support](https://support.auvik.com/)

--- a/msp-claude-plugins/auvik/auvik/agents/alert-responder.md
+++ b/msp-claude-plugins/auvik/auvik/agents/alert-responder.md
@@ -1,0 +1,52 @@
+---
+name: alert-responder
+description: Use this agent for Auvik alert-related questions - what's open, what matters, what to dismiss, what to escalate. Trigger for: triage alerts, what's alerting, open alerts, critical alerts Auvik, dismiss noise, alert storm, NOC queue Auvik, what's wrong right now. Examples: "Triage the overnight Auvik queue", "What's critical across all tenants right now?", "ACME has 40 open alerts - tell me which to actually look at", "Can I dismiss these flap alerts safely?"
+tools: ["Bash", "Read", "Write", "Glob", "Grep"]
+model: inherit
+---
+
+You are a NOC analyst expert at working an Auvik alert queue for an MSP. The Auvik alert engine generates a continuous stream of conditions across every managed entity in every managed tenant - device down, interface flap, configuration changed, backup failed, utilization high. Your job is to convert that stream into a ranked, actionable list and to tell the human user which alerts deserve a ticket, which deserve investigation, and which are confirmed noise that should be dismissed.
+
+You start every triage by establishing scope. Single tenant or all visible tenants? Default severity floor of `warning` (info-level alerts are almost never actionable and they drown the queue). You call `auvik_alerts_list status=open` with those filters and read the count before deciding how to present the queue. A queue of 12 is read alert-by-alert; a queue of 400 is read by alertName + entityType + severity grouping first.
+
+For the top of the queue - all `emergency` and `critical` alerts, plus the most-frequent grouped patterns - you call `auvik_alerts_get` for the full record. The list response is truncated; the detail call is where the dispatch reason, the description, and the entity reference all become legible. Then you resolve the entity - `auvik_devices_get` for device or interface alerts (interfaces via their parent device), `auvik_networks_get` for network alerts. The entity context is what tells you whether the alert is real.
+
+You internalize one rule above all others: **a critical alert on an unmanaged device is almost always discovery noise, not an incident**. Auvik can fire alerts against devices it sees on a scan but is not actively monitoring; those alerts have low signal because Auvik does not have the polling depth to know if the condition is real. You separate these out and recommend dismissal-or-suppression as a category.
+
+When the alert is on a managed device, you read the alertName for the standard patterns: `Device unreachable` on a managed device is real until proven otherwise (could also be credentials). `Interface down` on an uplink is real; on a user-facing access port it is usually a workstation that went home. `Configuration changed` is informational - someone or something modified the device; cross-check the audit log. `Backup failed` is operational debt rather than incident. `Interface utilization high` you cross-reference to `auvik_statistics_interface` to see if it was a momentary spike or sustained pressure.
+
+You never dismiss alerts unilaterally. You surface the dismissal candidates as a numbered list with one-line justifications and the exact `auvik_alerts_dismiss` calls you would make, and you wait for the user to confirm. You explain - exactly once per session - that dismissing an alert does not fix the underlying condition; if the condition still holds when Auvik next evaluates it, a new alert will appear.
+
+You report `alertId` references on every finding so the user can reproduce your reasoning.
+
+## Capabilities
+
+- Pull and rank the open alert queue by severity, recency, and entity criticality
+- Group duplicate alerts by alertName + entityType for batch triage decisions
+- Resolve every triaged alert to its referenced entity for real context
+- Distinguish unmanaged-device discovery noise from real managed-device incidents
+- Classify by standard alertName patterns (device down, interface down, config changed, backup failed, utilization high, SNMP poller failure)
+- Recommend dismissals with one-line justifications, never dismiss without explicit user confirmation
+- Hand off saturation alerts to capacity-planner; hand off topology questions to network-analyst
+
+## Approach
+
+Establish scope first. Tenant + severity floor.
+
+Read the queue size before deciding presentation format - alert-by-alert under 20, grouped over 50.
+
+Pull `auvik_alerts_get` and the referenced entity for everything you plan to recommend an action on. Truncated list rows are not enough to make a defensible decision.
+
+Apply the unmanaged-device filter early - it removes a huge fraction of low-signal alerts in noisy tenants.
+
+When in doubt between dismiss and investigate, choose investigate and explain why - dismissing a real alert is worse than holding a noise alert in the queue for a few minutes longer.
+
+Cross-reference with statistics for utilization alerts before deciding if the condition is sustained or transient.
+
+## Output Format
+
+For a triage report: a ranked list grouped by severity. Within each severity, alerts grouped by alertName + entityType. Each group shows: alert count, top entity (with manageStatus), alertId references, classification (action / investigate / dismiss-noise), and the recommended next step.
+
+A separate "Dismissal candidates" block at the end - numbered, with the exact `auvik_alerts_dismiss` call and the one-line justification per item. Wait for the user to confirm.
+
+A "What I did not look at" footer if the queue was large and you sampled - explicit about scope so the user knows what's still unread.

--- a/msp-claude-plugins/auvik/auvik/agents/capacity-planner.md
+++ b/msp-claude-plugins/auvik/auvik/agents/capacity-planner.md
@@ -1,0 +1,57 @@
+---
+name: capacity-planner
+description: Use this agent for Auvik utilization, saturation, and headroom questions - "is this link maxed out?", "what links need an upgrade?", "where is the bottleneck?". Trigger for: capacity planning, link utilization, saturated link, bandwidth headroom, network upgrade Auvik, p95 utilization, hotspot interfaces, bottleneck Auvik, WAN saturation, uplink utilization. Examples: "Which links at ACME are running hot?", "Capacity plan for the next quarter at tenant 12345", "Is the WAN saturated?", "Find me every interface above 70% p95 in the last 7 days"
+tools: ["Bash", "Read", "Write", "Glob", "Grep"]
+model: inherit
+---
+
+You are a capacity planner for MSP-managed networks using Auvik as the data source. The Auvik statistics endpoints expose per-interface utilization, error, and discard counters over a time window, plus per-device CPU and memory. Your job is to take those time-series signals and produce two artifacts: an incident-grade answer to "what is saturated right now?" and a planning-grade answer to "what needs an upgrade this quarter?".
+
+You start by pinning the tenant and the window. Capacity questions without a window are ill-defined. Default to 24h for incident-grade questions ("the network is slow right now") and 7d or 30d for planning-grade questions ("what should we upgrade"). Never run a 30d statistics scan against a large tenant without warning the user that it will take meaningful time and burn rate-limit budget.
+
+Your standard approach: enumerate interfaces with `auvik_interfaces_list`, filter to `adminStatus = up` and `operStatus = up` (down interfaces produce no useful utilization signal), and prioritize uplinks, WAN interfaces, and trunks before user-facing access ports. You exclude `interfaceType in {loopback, tunnel, virtual}` unless the user specifically asks about them. For the resulting candidate set you call `auvik_statistics_interface` over the window.
+
+Your utilization metric is `max(bandwidthIn, bandwidthOut) / linkSpeed` per sample. You report two numbers per interface: peak in the window and p95. P95 is the MSP standard - it discounts the occasional spike while catching sustained pressure. You classify:
+
+- Saturated: p95 > 70%, or peak > 90% with > 5% of intervals above 70%. These need a real conversation about upgrade or QoS.
+- Warm: p95 between 40% and 70%. Watchlist; check the growth trend.
+- Cool: p95 < 40%. Healthy.
+
+You handle errors and discards as a separate axis. An interface that is not saturated but is dropping packets has a layer-1 or layer-2 problem (cable, optic, duplex mismatch) - it goes in its own report section, not in the saturation list.
+
+For every saturated interface you cross-reference the owning device's CPU and memory in the same window via `auvik_statistics_device`. A saturated link on a CPU-bound device is a device problem, not a link problem.
+
+You guard the math. `linkSpeed = 0` happens on some platforms for interfaces with no negotiated speed - skip those, don't divide. Some Auvik statistics responses have gaps in the time series; treat gaps as missing rather than as zero utilization.
+
+You report every recommendation with the supporting numbers. "Recommend upgrade for sw-edge-01 Gi0/24 (p95 78%, peak 96%, 11% of intervals above 70% over 7d)" is the standard.
+
+## Capabilities
+
+- Pull per-interface statistics over a configurable window and compute peak and p95 utilization
+- Filter interfaces to the candidate set that actually matters (up/up, exclude loopbacks/tunnels/virtuals)
+- Classify interfaces as saturated / warm / cool against industry-standard thresholds
+- Separate utilization problems from error/discard problems
+- Cross-reference saturated interfaces to the owning device's CPU and memory
+- Produce incident-grade ("what is hot now") and planning-grade ("what to upgrade") deliverables from the same data sweep
+
+## Approach
+
+Pin tenant and window before the first statistics call.
+
+For large tenants, narrow the candidate set before running statistics - statistics calls are the heaviest tool in this MCP. Filter to infrastructure devices and uplink interfaces first; expand only if the question demands it.
+
+P95 is the headline metric. Peak alone overstates the problem; mean alone understates it.
+
+For planning deliverables, always include the growth trend - same query over the previous equivalent window, if available - so the user can see whether an interface is heading toward saturation or stable.
+
+Errors and discards are categorically different from saturation. Report them separately and name the likely L1/L2 cause categories rather than recommending bandwidth upgrades.
+
+For device-bound bottlenecks (CPU > 70% sustained on the device owning a saturated link), recommend the device upgrade, not the link upgrade.
+
+## Output Format
+
+For an incident-grade question: a single table - device, interface, link speed, current utilization, peak in window, p95, classification. Ordered by impact, saturated first. Below the table, the top 1-3 immediate actions with the supporting numbers inline.
+
+For a planning-grade deliverable: a structured report - Executive Summary (one paragraph, plain English), Saturated Interfaces, Warm Interfaces (watchlist), Error/Discard Hotspots, Device Bottlenecks, Recommendations. Recommendations should be sized and specific - "Upgrade WAN at SITE-LAX from 100M to 500M; current p95 86%, peak 98%, sustained above 70% for 22% of the 7d window" rather than "WAN needs upgrade".
+
+For both: include the tenant_id, window, and the exact `auvik_statistics_interface` call shape used, so the analysis can be reproduced.

--- a/msp-claude-plugins/auvik/auvik/agents/network-analyst.md
+++ b/msp-claude-plugins/auvik/auvik/agents/network-analyst.md
@@ -1,0 +1,49 @@
+---
+name: network-analyst
+description: Use this agent when the user is asking what's wrong with a tenant's network, investigating broad performance complaints, mapping topology, or doing multi-signal triage across devices, interfaces, alerts, and statistics in Auvik. Trigger for: investigate the network, what's wrong with <tenant>, the network is slow, find the bottleneck, topology audit, multi-signal triage, network health check, network performance Auvik. Examples: "Investigate ACME's network - they say it's slow", "Audit the topology for tenant 12345", "Something is off with the LA office network", "Pull a network health snapshot for ACME and tell me what to fix first"
+tools: ["Bash", "Read", "Write", "Glob", "Grep"]
+model: inherit
+---
+
+You are an expert network analyst for MSP environments using Auvik. The Auvik API gives you tenants, devices, networks, interfaces, alerts, configurations, and per-entity statistics over time. Your job is to take a thin user signal - "the network is slow", "something is off at the LA office", "audit ACME for us" - and turn it into a defensible picture of what is actually happening and what to fix first.
+
+You begin by pinning down scope. "The network is slow" is not a question you can answer without a tenant, a location or subset of the network, and a rough time window. If any of those is missing, you decide whether to ask the user or to constrain by the others - never make the first API call without knowing which tenant you are working on.
+
+Your standard sweep when given a tenant is: enumerate the network footprint with `auvik_networks_list`, enumerate devices with `auvik_devices_list`, pull open alerts with `auvik_alerts_list`, and inspect interface health with `auvik_interfaces_list`. From those four signals you can already say a lot - device count vs unmanaged count, network count vs scan-error count, alert pressure by severity, and oper-down interfaces on managed devices. You produce the headline numbers from this sweep before diving deeper.
+
+Then you go after the inflection. If alert pressure is the loud signal, you hand off to the alert-responder pattern - pull `auvik_alerts_get` on the top critical/emergency items and resolve their entities. If the network feels slow, you pivot to the capacity-planner pattern - pull `auvik_statistics_interface` on the uplinks and any interface flagged by an alert. If the question is "what is the network even shaped like", you walk `auvik_networks_get` on each network and `auvik_devices_get_details` on each managed infrastructure device.
+
+You separate signal from noise carefully. A `manageStatus = unmanaged` device with a critical alert is almost always discovery noise rather than a real incident. A flapping interface (`adminStatus = up`, `operStatus` toggling) on a user access port is rarely the cause of "the network is slow" - users do not feel link-flap noise the way they feel WAN saturation or DNS latency. You weight your conclusions accordingly.
+
+When you find a real condition, you do not act on it - you surface it with a clear recommended next step and the tool call you would make. Dismissals, configuration changes, and ticket creation are all decisions the user makes, not you.
+
+You always report numbers with their source tool call so a reviewer can reproduce your conclusion. "27 open alerts (auvik_alerts_list status=open tenant_id=12345)" is the standard.
+
+## Capabilities
+
+- Build a per-tenant network snapshot from devices, networks, alerts, and interfaces in a single sweep
+- Identify visibility gaps (unmanaged infrastructure devices, networks with scan errors)
+- Correlate alerts to their referenced entities for context-aware triage
+- Pivot from headline counts into per-device or per-interface detail when the inflection is clear
+- Cross-reference configuration backup health with device criticality
+- Produce reproducible findings with explicit tool calls and tenant scoping
+
+## Approach
+
+Always pin the tenant first. Never run the sweep across all visible tenants implicitly - that produces output that looks fine and is wrong.
+
+Run the four-call sweep before diving deeper. The headline numbers are usually enough to direct the rest of the investigation.
+
+Distinguish managed from unmanaged before drawing any conclusion about device health - an unmanaged device's "online" status is a single discovery scan, not continuous polling.
+
+When statistics are involved, default to a 24h window for interactive triage and 7d / 30d for capacity questions.
+
+For configuration audits, prioritize devices with no saved configuration over devices with stale saved configurations - "no backup" is a worse posture than "old backup".
+
+## Output Format
+
+For an initial sweep: a headline block with network count, device count by type, alert count by severity, and unmanaged-infrastructure count. Below the block, a 3-5 bullet list of "what to look at first" with the specific tool call for each.
+
+For a deeper investigation: a per-finding section with the evidence (tool calls + key field values) and a recommended next action. Findings ordered by impact - service-affecting before posture-degrading before informational.
+
+For a network audit deliverable: a structured report - Tenant Summary, Coverage Gaps, Configuration Posture, Active Issues, Capacity Concerns, Recommendations. Recommendations should be specific and assigned ("Add SNMP credentials to switch sw-edge-02 to bring it from unmanaged to managed" rather than "review unmanaged devices").

--- a/msp-claude-plugins/auvik/auvik/commands/alert-triage.md
+++ b/msp-claude-plugins/auvik/auvik/commands/alert-triage.md
@@ -1,0 +1,72 @@
+---
+name: alert-triage
+description: Triage open Auvik alerts, rank by severity, and recommend dismissals for known noise
+argument-hint: "[tenant_id] [severity]"
+arguments:
+  - name: tenant_id
+    description: Scope to a single tenant. Omit to triage across all visible tenants.
+    required: false
+  - name: severity
+    description: Minimum severity to include (info, warning, critical, emergency)
+    required: false
+    default: "warning"
+---
+
+# Auvik Alert Triage
+
+Run the daily Auvik alert queue: pull what's open, rank it, recommend dismissals for confirmed noise, and surface the alerts that need human action. Designed for MSP NOC analysts working a multi-tenant queue.
+
+## Prerequisites
+
+- Tools: `auvik_alerts_list`, `auvik_alerts_get`, `auvik_alerts_dismiss`, `auvik_devices_get`, `auvik_tenants_list`
+
+## Steps
+
+1. **List open alerts**
+
+   Call `auvik_alerts_list` with `status=open` (and `tenant_id` if scoped). Filter to severity >= the requested minimum (default `warning`). Paginate to completion.
+
+2. **Bucket by severity**
+
+   Order: `emergency`, `critical`, `warning`, `info`. Within each bucket, group by `alertName` and `entityType` - duplicate alerts on the same device usually collapse to a single decision.
+
+3. **Pull full details for the top of the queue**
+
+   For each of the top 20 alerts (or all emergency/critical alerts, whichever is larger), call `auvik_alerts_get` to retrieve the full record - description, detected time, dispatch reason, and the referenced entity ID.
+
+4. **Resolve the entity for context**
+
+   For alerts referencing a device, call `auvik_devices_get` on the entity to retrieve `deviceName`, `deviceType`, and `manageStatus`. Unmanaged devices with critical alerts are usually false-positives from Auvik discovery, not real incidents.
+
+5. **Classify each alert**
+
+   Into one of:
+   - **Action required** - confirmed real condition on a managed device (down switch, saturated interface, failed config backup, etc.)
+   - **Investigate** - the entity context is ambiguous - device recently changed, alert is new pattern, signal quality unclear
+   - **Dismiss (noise)** - known false-positive pattern: link flap on user-port access switches, scheduled reboot windows, transient SNMP timeouts, alerts on `manageStatus = unmanaged` devices
+
+6. **Recommend dismissals - do not dismiss automatically**
+
+   Surface the dismiss candidates as a list with one-line justifications and the `auvik_alerts_dismiss` call you would make. Wait for the user to confirm before dismissing. Dismissal acknowledges and hides - it does not fix - so a real condition that's still active will re-alert anyway.
+
+## Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| tenant_id | string | No | all | Scope to a single tenant |
+| severity | string | No | warning | Minimum severity filter |
+
+## Examples
+
+```
+/auvik:alert-triage
+```
+
+```
+/auvik:alert-triage tenant_id=12345 severity=critical
+```
+
+## Related Commands
+
+- `/auvik:tenant-overview` - To see alert counts per tenant before drilling in
+- `/auvik:capacity-check` - When a wave of saturation alerts comes in

--- a/msp-claude-plugins/auvik/auvik/commands/capacity-check.md
+++ b/msp-claude-plugins/auvik/auvik/commands/capacity-check.md
@@ -1,0 +1,82 @@
+---
+name: capacity-check
+description: Scan Auvik interface statistics for saturated links and recurring congestion
+argument-hint: "<tenant_id> [window]"
+arguments:
+  - name: tenant_id
+    description: Tenant (client) ID to scan
+    required: true
+  - name: window
+    description: Time window for the statistics query (e.g. 24h, 7d, 30d)
+    required: false
+    default: "7d"
+---
+
+# Auvik Capacity Check
+
+Pull interface statistics for a tenant and flag any link running hot. The output supports both incident response ("why is the network slow right now?") and capacity planning ("which links will we need to upgrade in the next quarter?").
+
+## Prerequisites
+
+- Tools: `auvik_interfaces_list`, `auvik_statistics_interface`, `auvik_devices_get`, `auvik_statistics_device`
+
+## Steps
+
+1. **Enumerate interfaces**
+
+   Call `auvik_interfaces_list` for the tenant. Filter to interfaces that are admin-up and oper-up - down links produce no utilization signal. Prioritize uplinks, WAN interfaces, and trunks; deprioritize user-facing access ports unless the user specifically asked.
+
+2. **Pull statistics**
+
+   For each candidate interface call `auvik_statistics_interface` over `window`. Pull at minimum `bandwidthInRate` and `bandwidthOutRate` (or the equivalent fields the response exposes), plus error/discard counters if available.
+
+3. **Compute utilization**
+
+   For each sample, utilization = max(in, out) / linkSpeed. Track:
+   - Peak utilization in the window
+   - Sustained utilization at the 95th percentile (the standard MSP framing)
+   - Count of intervals above 70%
+
+4. **Classify each interface**
+
+   - **Saturated** - p95 > 70%, or peak > 90% with > 5% of intervals above 70%. Flag for upgrade.
+   - **Warm** - p95 between 40% and 70%. Monitor; consider for upgrade if growth trend is upward.
+   - **Cool** - p95 < 40%. Healthy.
+
+5. **Surface error and discard hotspots separately**
+
+   An interface that is not saturated but is dropping packets or seeing CRC errors is a different problem (cable, optic, duplex mismatch) - flag it in its own section.
+
+6. **Cross-reference device health**
+
+   For each device owning a saturated interface, call `auvik_statistics_device` to check CPU and memory in the same window. A saturated link on a CPU-bound device is a different conversation than a saturated link on a healthy device.
+
+7. **Output**
+
+   Sections:
+   - Saturated interfaces - table with device, interface, link speed, p95, peak, % time above 70%
+   - Warm interfaces - same table, watchlist
+   - Error/discard hotspots - device, interface, error count, error rate
+   - Devices with elevated CPU/memory that own saturated interfaces
+
+## Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| tenant_id | string | Yes | - | Tenant to scan |
+| window | string | No | 7d | Time window for statistics |
+
+## Examples
+
+```
+/auvik:capacity-check tenant_id=12345
+```
+
+```
+/auvik:capacity-check tenant_id=12345 window=30d
+```
+
+## Related Commands
+
+- `/auvik:alert-triage` - When saturation has already triggered alerts
+- `/auvik:network-audit` - For the configuration/topology side of the same network

--- a/msp-claude-plugins/auvik/auvik/commands/device-inventory.md
+++ b/msp-claude-plugins/auvik/auvik/commands/device-inventory.md
@@ -1,0 +1,74 @@
+---
+name: device-inventory
+description: Inventory devices for an Auvik tenant with type, manage status, and lifecycle breakdown
+argument-hint: "[tenant_id] [limit]"
+arguments:
+  - name: tenant_id
+    description: Tenant (client) ID to scope the inventory to. Omit to prompt for selection.
+    required: false
+  - name: limit
+    description: Maximum devices to fetch
+    required: false
+    default: "500"
+---
+
+# Auvik Device Inventory
+
+Produce a clean device inventory for a single Auvik tenant, broken down by device type and manage status, with lifecycle and warranty risk called out at the top. This is the workflow MSP analysts run before a QBR, a renewal, or any conversation about hardware refresh.
+
+## Prerequisites
+
+- Auvik MCP server connected with a valid `AUVIK_USERNAME` and `AUVIK_API_KEY`
+- Tools: `auvik_tenants_list`, `auvik_devices_list`, `auvik_devices_get_details`, `auvik_devices_get_lifecycle`, `auvik_devices_get_warranty`
+
+## Steps
+
+1. **Resolve the tenant**
+
+   If `tenant_id` was not provided, call `auvik_tenants_list` and present the user the list of tenants to pick from. Do not proceed without an explicit tenant.
+
+2. **Pull the device list**
+
+   Call `auvik_devices_list` scoped to the tenant, paginating up to `limit`. The v1 list response gives you `deviceType`, `deviceName`, `manageStatus`, `onlineStatus`, `make`, and `model` for each device - enough for the headline breakdown.
+
+3. **Group and count**
+
+   Bucket devices by `deviceType` (router, switch, firewall, accessPoint, server, workstation, printer, hypervisor, etc.) and by `manageStatus` (`managed`, `unmanaged`, `unknown`). Surface the breakdown as a single compact table at the top of the report.
+
+4. **Pull lifecycle and warranty for the long-lived gear**
+
+   For devices in the infrastructure tiers (router, switch, firewall, accessPoint, server, hypervisor), call `auvik_devices_get_lifecycle` and `auvik_devices_get_warranty`. Skip workstations and printers for this pass; their lifecycle data is rarely populated.
+
+5. **Flag the risk items**
+
+   Surface separately:
+   - Devices past end-of-sale or end-of-support per the lifecycle response
+   - Devices out of warranty or with warranty expiring within 90 days
+   - Devices with `manageStatus = unmanaged` in the infrastructure tier (these are gaps - Auvik sees them but is not managing them)
+   - Devices with `onlineStatus = offline` or `unreachable`
+
+6. **Produce the output**
+
+   Order: tenant header, headline counts table, risk callouts, full device list (compact - one row per device with name, type, make/model, manageStatus, onlineStatus). Keep the full list under 500 rows; if the tenant is larger, truncate and note the count.
+
+## Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| tenant_id | string | No | prompt | Tenant to inventory |
+| limit | integer | No | 500 | Max devices to fetch |
+
+## Examples
+
+```
+/auvik:device-inventory
+```
+
+```
+/auvik:device-inventory tenant_id=12345 limit=1000
+```
+
+## Related Commands
+
+- `/auvik:tenant-overview` - For a higher-level snapshot before drilling in
+- `/auvik:network-audit` - For the configuration/topology side of the inventory

--- a/msp-claude-plugins/auvik/auvik/commands/network-audit.md
+++ b/msp-claude-plugins/auvik/auvik/commands/network-audit.md
@@ -1,0 +1,68 @@
+---
+name: network-audit
+description: Audit a tenant's networks, interfaces, and saved configurations; flag drift and missing backups
+argument-hint: "<tenant_id>"
+arguments:
+  - name: tenant_id
+    description: Tenant (client) ID to audit
+    required: true
+---
+
+# Auvik Network Audit
+
+Walk a tenant's networks, interfaces, and configuration backups end-to-end. The output is meant to support a renewal conversation or a quarterly health check - what does the network look like, are configurations being backed up, and is anything drifting from a known-good state.
+
+## Prerequisites
+
+- Tools: `auvik_networks_list`, `auvik_networks_get`, `auvik_interfaces_list`, `auvik_configurations_list`, `auvik_configurations_get`, `auvik_devices_list`, `auvik_entities_list_audits`
+
+## Steps
+
+1. **Enumerate networks**
+
+   Call `auvik_networks_list` for the tenant. Note the count, the IP ranges in use, and any networks marked private vs internet. Call `auvik_networks_get` on the largest few for detail (gateway, DHCP, scan status).
+
+2. **List interfaces**
+
+   Call `auvik_interfaces_list` for the tenant. Bucket by interface type (ethernet, wireless, virtual, etc.) and by `adminStatus` / `operStatus`. Flag any interface that is admin-up but oper-down for more than a transient period.
+
+3. **Audit saved configurations**
+
+   Call `auvik_configurations_list` for the tenant. For each managed network device (router, switch, firewall, accessPoint), check:
+   - Is there at least one saved configuration? Devices with zero saved configs are a backup gap - call them out.
+   - When was the most recent configuration saved? Anything > 30 days old on a device that should be actively managed is stale.
+
+4. **Spot configuration drift**
+
+   For devices with multiple saved configurations, call `auvik_configurations_get` on the two most recent for any device that has changed in the last 7 days. Surface a one-line summary of what changed. Frequent unexpected changes on infrastructure devices warrant a conversation with the customer.
+
+5. **Cross-reference with audit history**
+
+   Call `auvik_entities_list_audits` on the tenant or on suspect devices to surface who or what triggered recent changes - human edits, automation, or Auvik-driven actions.
+
+6. **Produce the audit report**
+
+   Sections in order:
+   - Tenant summary - network count, device count, interface count
+   - Configuration backup coverage - devices with backups vs without, list the gaps
+   - Stale backups - devices with most-recent-config older than 30 days
+   - Recent configuration changes - last 7 days, who changed what
+   - Flapping / down interfaces - with the owning device and last change time
+   - Recommendations - explicit next actions, assigned to the customer or to the MSP
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| tenant_id | string | Yes | Tenant to audit |
+
+## Examples
+
+```
+/auvik:network-audit tenant_id=12345
+```
+
+## Related Commands
+
+- `/auvik:device-inventory` - For the hardware side of the audit
+- `/auvik:capacity-check` - For the performance side of the audit

--- a/msp-claude-plugins/auvik/auvik/commands/tenant-overview.md
+++ b/msp-claude-plugins/auvik/auvik/commands/tenant-overview.md
@@ -1,0 +1,71 @@
+---
+name: tenant-overview
+description: Single-tenant Auvik snapshot - devices, alerts, networks, billing usage
+argument-hint: "<tenant_id>"
+arguments:
+  - name: tenant_id
+    description: Tenant (client) ID to summarize
+    required: true
+---
+
+# Auvik Tenant Overview
+
+Produce a one-page snapshot for a single Auvik-monitored client. Designed as the first command an analyst runs when picking up a ticket for an unfamiliar tenant - establishes scale, health, and current pain in under a screen of output.
+
+## Prerequisites
+
+- Tools: `auvik_tenants_get`, `auvik_tenants_detail`, `auvik_devices_list`, `auvik_alerts_list`, `auvik_networks_list`, `auvik_billing_client_usage`, `auvik_billing_device_usage`
+
+## Steps
+
+1. **Tenant header**
+
+   Call `auvik_tenants_get` and `auvik_tenants_detail` for descriptive metadata - name, status, region, contact, contract type if exposed.
+
+2. **Device count and breakdown**
+
+   Call `auvik_devices_list` with a high page size and accumulate. Report total device count and the top device-type buckets (router, switch, firewall, accessPoint, server, workstation, printer, other).
+
+3. **Open alert count**
+
+   Call `auvik_alerts_list` with `status=open`. Report counts per severity (emergency / critical / warning / info). Highlight if any emergency or critical alerts are open.
+
+4. **Network footprint**
+
+   Call `auvik_networks_list`. Report network count and whether scans are healthy (any networks in error or unscanned state).
+
+5. **Billing usage**
+
+   Call `auvik_billing_client_usage` for the tenant for the current billing period and `auvik_billing_device_usage` for the breakdown. Report the billable device count and any growth vs the previous period if available.
+
+6. **Output format**
+
+   A compact card-style report:
+
+   ```
+   Tenant: <name>           Region: <region>     Status: <status>
+   Devices: <N>  (routers <a>, switches <b>, firewalls <c>, APs <d>, servers <e>, ...)
+   Networks: <N>            Open alerts: emergency <e> / critical <c> / warning <w> / info <i>
+   Billable devices: <N>    Period: <YYYY-MM>
+   ```
+
+   Below the card, a 3-5 bullet "what to look at next" list referencing the relevant deeper commands (`/auvik:alert-triage`, `/auvik:device-inventory`, `/auvik:network-audit`, `/auvik:capacity-check`).
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| tenant_id | string | Yes | Tenant to summarize |
+
+## Examples
+
+```
+/auvik:tenant-overview tenant_id=12345
+```
+
+## Related Commands
+
+- `/auvik:alert-triage` - Drill into open alerts
+- `/auvik:device-inventory` - Drill into the device list
+- `/auvik:network-audit` - Drill into configurations and topology
+- `/auvik:capacity-check` - Drill into interface utilization

--- a/msp-claude-plugins/auvik/auvik/skills/alerts/SKILL.md
+++ b/msp-claude-plugins/auvik/auvik/skills/alerts/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: "Auvik Alerts"
+description: >
+  Use this skill when working with Auvik alerts - severity tiers,
+  status lifecycle, dismissal semantics, and the common alertName
+  patterns that show up in MSP NOC queues.
+when_to_use: "When listing, triaging, dismissing, or investigating Auvik alerts"
+triggers:
+  - auvik alert
+  - auvik triage
+  - auvik dismiss
+  - auvik severity
+  - auvik noc
+  - auvik down
+  - auvik flap
+---
+
+# Auvik Alerts
+
+Auvik alerts are condition-based notifications generated when a monitored entity (device, interface, network, service) crosses a threshold or changes state. This skill covers the severity model, the status lifecycle, and the dismissal semantics that confuse new users.
+
+## Tools
+
+| Tool | Use For |
+|------|---------|
+| `auvik_alerts_list` | List alerts, filterable by status / severity / tenant |
+| `auvik_alerts_get` | Full record for one alert |
+| `auvik_alerts_dismiss` | Acknowledge and hide an alert |
+
+## Severity
+
+Severity values, in increasing order:
+
+| Severity | Meaning |
+|----------|---------|
+| `info` | Informational - state change, no impact |
+| `warning` | Worth attention but not service-affecting |
+| `critical` | Service affecting; respond now |
+| `emergency` | Highest tier; usually a managed infrastructure device down |
+
+Default triage filter is `severity >= warning` - `info` alerts drown the queue and are rarely actionable.
+
+## Status
+
+| Status | Meaning |
+|--------|---------|
+| `open` | Currently active |
+| `dismissed` | Acknowledged by a user; hidden from the default UI view |
+| `closed` | Condition cleared on its own |
+
+`closed` is the only "the problem is fixed" state. `dismissed` is "a human decided not to look at this" - the underlying condition may or may not still hold.
+
+## Dismissal Semantics
+
+**Dismissing an alert does not fix the underlying condition.**
+
+Auvik's alert engine evaluates conditions on a recurring schedule. If you dismiss an alert and the condition still holds when the engine next evaluates, a new alert (with a new ID) will appear. This is the source of the "we keep dismissing the same alert" pattern in noisy tenants.
+
+Three appropriate uses of dismissal:
+
+1. **Known noise** - the condition is a confirmed false-positive for this tenant (e.g. link flap on a known-flaky access port on an unmanaged switch).
+2. **Already-acknowledged** - someone has already opened a ticket and is working it; dismissal removes it from the queue.
+3. **Transient that cleared** - the condition cleared between alert fire and triage; dismissing closes the loop.
+
+Two inappropriate uses:
+
+1. **Suppressing a real condition** - if the device is genuinely down, dismissing buys you 15 minutes of silence before the next alert. Fix the device.
+2. **Bulk-clearing the queue** - if the queue is too noisy, the alert rules need tuning, not dismissal.
+
+## Common alertName Patterns
+
+The exact set varies, but in practice these dominate MSP NOC queues:
+
+| alertName pattern | Typical real cause |
+|-------------------|--------------------|
+| `Device unreachable` / `Device down` | Real outage OR credentials problem |
+| `Interface down` | Link flap, cable, or upstream issue |
+| `Configuration changed` | Saved config differs from baseline |
+| `New device discovered` | Discovery picked up an unmanaged device |
+| `Backup failed` | Config backup attempt did not complete |
+| `High CPU` / `High memory` | Device under load |
+| `Interface utilization high` | Link saturation - cross-check via statistics |
+| `SNMP poller failure` | Credentials or ACL problem |
+
+## Entity Resolution
+
+Every alert references an `entityId` and `entityType`. To make a good triage decision, you almost always need to pull the entity:
+
+- `entityType = device` -> `auvik_devices_get`
+- `entityType = network` -> `auvik_networks_get`
+- `entityType = interface` -> the parent device via `auvik_devices_get`
+
+Critical alerts on `manageStatus = unmanaged` devices are almost always discovery noise, not real incidents.
+
+## Workflow
+
+1. `auvik_alerts_list status=open` (scope by tenant if needed).
+2. Order by severity desc, then detectedTime asc.
+3. For top-of-queue items, `auvik_alerts_get` for the full record.
+4. Resolve the entity for context.
+5. Decide: action, investigate, or dismiss-with-justification.
+6. Dismiss only after the user confirms.
+
+## Edge Cases
+
+- Some alerts have empty `description` fields - the alertName plus the entity is the whole signal.
+- `detectedTime` is UTC.
+- An alert can reference an entity that has since been deleted in Auvik - the entity fetch will 404. Treat this as evidence the alert is stale and a candidate for dismissal.
+
+## Related Skills
+
+- [devices](../devices/SKILL.md)
+- [networks](../networks/SKILL.md)
+- [api-patterns](../api-patterns/SKILL.md)

--- a/msp-claude-plugins/auvik/auvik/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/auvik/auvik/skills/api-patterns/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: "Auvik API Patterns"
+description: >
+  Use this skill when working with the Auvik MCP tools - JSON:API
+  envelope shape, basic-auth credential model, region routing,
+  cursor-based pagination, rate-limit handling, and the v1 vs v2
+  device API distinction.
+when_to_use: "When working with Auvik authentication, region selection, pagination, rate limits, or interpreting the JSON:API response shape"
+triggers:
+  - auvik api
+  - auvik authentication
+  - auvik pagination
+  - auvik region
+  - auvik rate limit
+  - auvik v1 v2
+  - auvik jsonapi
+---
+
+# Auvik MCP Tools and API Patterns
+
+## Overview
+
+The Auvik MCP server wraps the Auvik REST API (`https://auvikapi.{region}.my.auvik.com/v1` and `/v2`) and exposes tools across tenants, devices, networks, interfaces, configurations, alerts, statistics, and billing. Two quirks to know up front: Auvik uses HTTP Basic auth with `username:apiKey` (not a bearer token), and the API base URL is region-pinned - your credentials only work against the cluster your tenant lives in.
+
+## Authentication
+
+Auvik authenticates with HTTP Basic - the username is the Auvik user's email and the password is the API key.
+
+| Field | Value |
+|-------|-------|
+| Auth scheme | HTTP Basic |
+| Username | `AUVIK_USERNAME` (your Auvik login email) |
+| Password | `AUVIK_API_KEY` |
+
+The MCP server handles the basic-auth encoding. Set the env vars; do not pre-encode.
+
+## Region Routing
+
+Auvik tenants live in one of several regional clusters:
+
+| Region | Base host |
+|--------|-----------|
+| `us1` | `auvikapi.us1.my.auvik.com` |
+| `us2` | `auvikapi.us2.my.auvik.com` |
+| `us3` | `auvikapi.us3.my.auvik.com` |
+| `us4` | `auvikapi.us4.my.auvik.com` |
+| `eu1` | `auvikapi.eu1.my.auvik.com` |
+| `eu2` | `auvikapi.eu2.my.auvik.com` |
+| `au1` | `auvikapi.au1.my.auvik.com` |
+| `ca1` | `auvikapi.ca1.my.auvik.com` |
+
+Set `AUVIK_REGION` to pin the region. If omitted, the server attempts to detect the region from the credentials. Misroutes typically surface as 404 or redirect loops on calls that should obviously succeed.
+
+## JSON:API Envelope
+
+Auvik returns JSON:API-shaped responses. The tools surface this through to users, so know the shape:
+
+```json
+{
+  "data": [
+    {
+      "id": "...",
+      "type": "device",
+      "attributes": { ... },
+      "relationships": { ... }
+    }
+  ],
+  "links": { "next": "...", "prev": "...", "first": "...", "last": "..." },
+  "meta": { "totalRecords": 1284, "totalPages": 26 },
+  "included": [ ... ]
+}
+```
+
+Key points:
+
+- The record's real fields live under `attributes`, not the top level.
+- Relationships to other entities are referenced under `relationships`, not embedded - use `included` (when present) for sideloads.
+- Use `links.next` for the next page rather than constructing the URL yourself.
+
+Singletons (`*_get` style tools) return `data` as an object, not an array.
+
+## Pagination
+
+Auvik uses cursor-style pagination via `links.next`. Pattern:
+
+1. Call the list tool. Read `data` and `links.next`.
+2. If `links.next` is non-null, the tool exposes a way to fetch the next page (usually a `page_first` / `page_after` argument that the MCP server populates from the cursor).
+3. Continue until `links.next` is null or your accumulated count reaches a sane cap.
+
+Use page sizes of 100-500. Larger pages can time out on big tenants.
+
+`meta.totalRecords` is the authoritative count - prefer it over counting accumulated rows when reporting size.
+
+## Rate Limits
+
+Auvik enforces per-API-key rate limits. Behavior at limit:
+
+- 429 status with a `Retry-After` header.
+- The MCP server surfaces this as a tool error. Back off, then retry.
+- If you're hitting limits routinely, narrow the query (one tenant at a time, smaller windows) rather than tightening the retry loop.
+
+Statistics endpoints (`auvik_statistics_*`) are noticeably heavier than entity listings - rate-limit pressure usually shows up there first when scanning a large tenant.
+
+## v1 vs v2 Device API
+
+Auvik exposes two generations of device endpoints. The MCP tools split them:
+
+| Tool | API |
+|------|-----|
+| `auvik_devices_list`, `auvik_devices_get` | v1 - light record, fast |
+| `auvik_devices_get_details` | v2 - extended attributes |
+| `auvik_devices_get_lifecycle` | v2 - lifecycle fields |
+| `auvik_devices_get_warranty` | v2 - warranty fields |
+
+Default to v1 for bulk listings; reach for v2 only when you need the extended fields. Calling v2 tools in a tight loop over a large device set is the single most common cause of rate-limit problems.
+
+## Multi-Tenant Routing
+
+Auvik is multi-tenant by design - a single MSP credential sees every client tenant the MSP manages. Pattern:
+
+1. `auvik_tenants_list` to enumerate visible tenants.
+2. Filter and pass the chosen `tenant_id` (or `tenantId`, depending on the tool) on subsequent calls.
+3. For fleet-wide reports, fan out across tenants client-side rather than expecting a single call to roll them up.
+
+## Error Handling
+
+| Code | Meaning | Fix |
+|------|---------|-----|
+| 401 | Bad credentials | Check `AUVIK_USERNAME` + `AUVIK_API_KEY` |
+| 403 | Credentials valid, no access to the resource | Wrong tenant, or key lacks scope |
+| 404 | Unknown ID, or wrong region | Verify region; verify ID |
+| 429 | Rate limit | Back off; narrow the query |
+| 500 | Auvik-side hiccup | Retry, then escalate |
+
+## Best Practices
+
+- Always pass `tenant_id` explicitly on per-tenant reports - implicit scoping is a source of cross-tenant data leaks in human-facing output.
+- Default to v1 device endpoints; promote to v2 only for the device subset that needs it.
+- For statistics queries, prefer short windows (24h) for interactive use and reserve longer windows (7d / 30d) for batch capacity reports.
+- Cache `auvik_tenants_list` results within a session - the tenant list rarely changes.
+
+## Related Skills
+
+- [devices](../devices/SKILL.md)
+- [alerts](../alerts/SKILL.md)
+- [networks](../networks/SKILL.md)

--- a/msp-claude-plugins/auvik/auvik/skills/devices/SKILL.md
+++ b/msp-claude-plugins/auvik/auvik/skills/devices/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: "Auvik Devices"
+description: >
+  Use this skill when working with Auvik device records - identifying
+  device types, interpreting manageStatus, reading lifecycle and warranty
+  fields, and choosing between the v1 list endpoint and the detailed
+  device endpoints.
+when_to_use: "When listing, inspecting, or auditing Auvik devices, including lifecycle and warranty checks and managed vs unmanaged classification"
+triggers:
+  - auvik device
+  - auvik inventory
+  - auvik endpoint
+  - auvik switch
+  - auvik router
+  - auvik firewall
+  - auvik unmanaged
+  - auvik lifecycle
+  - auvik warranty
+  - auvik end of life
+---
+
+# Auvik Devices
+
+Devices are the unit of inventory in Auvik. Every discovered piece of network gear or endpoint - whether actively monitored or just seen on a discovery scan - has a device record. This skill covers the device type taxonomy, the manage-status model, lifecycle fields, and which tool to call for which question.
+
+## Tools
+
+| Tool | Use For |
+|------|---------|
+| `auvik_devices_list` | Bulk listing (v1 record - light) |
+| `auvik_devices_get` | Single device, v1 fields |
+| `auvik_devices_get_details` | Extended attributes (interfaces, IPs, SNMP) |
+| `auvik_devices_get_lifecycle` | End-of-sale, end-of-support dates |
+| `auvik_devices_get_warranty` | Warranty start / end / status |
+
+## Device Types
+
+Auvik classifies every device with a `deviceType` value. The set you'll see in practice:
+
+| Type | Notes |
+|------|-------|
+| `router` | L3 routing device |
+| `switch` | L2 switch |
+| `firewall` | Dedicated firewall (Fortinet, Palo, Meraki MX, etc.) |
+| `accessPoint` | Wireless AP |
+| `controller` | Wireless or SD-WAN controller |
+| `server` | Physical or virtual server with SNMP / WMI |
+| `hypervisor` | VMware, Hyper-V, etc. |
+| `workstation` | End-user PC / Mac |
+| `printer` | Network printer / MFD |
+| `voipPhone` | IP phone |
+| `storage` | NAS / SAN |
+| `ups` | UPS via SNMP |
+| `camera` | IP camera |
+| `unknown` | Discovered but not classified |
+
+For infrastructure reports, focus on `router`, `switch`, `firewall`, `accessPoint`, `controller`, `server`, `hypervisor`. For lifecycle reports, those plus `ups` and `storage`.
+
+## manageStatus
+
+Every device has a `manageStatus` value:
+
+| Value | Meaning |
+|-------|---------|
+| `managed` | Auvik is actively monitoring (SNMP / API credentials configured) |
+| `unmanaged` | Discovered but not actively polled (no credentials, or marked unmanaged) |
+| `unknown` | Status not yet determined |
+
+`unmanaged` infrastructure devices are visibility gaps - Auvik sees them on a scan but is not polling them for health. In an audit, these are the most important things to surface to the customer.
+
+## onlineStatus
+
+Separate from manageStatus:
+
+| Value | Meaning |
+|-------|---------|
+| `online` | Reachable on last scan/poll |
+| `offline` | Not reachable |
+| `unreachable` | SNMP / API call failed last attempt |
+
+A `managed` + `offline` device is a real alert. A `managed` + `unreachable` device is usually a credentials problem on the Auvik side.
+
+## Lifecycle Fields
+
+`auvik_devices_get_lifecycle` returns:
+
+- `endOfSale` - vendor stopped selling new units
+- `endOfSoftwareMaintenance` - last software / security update date
+- `endOfSupport` (or `endOfLife`) - vendor stopped supporting
+- `currentPhase` - vendor-derived lifecycle phase
+
+For risk reports, flag anything past `endOfSoftwareMaintenance` first - that is the operational risk threshold. Past `endOfSupport` is the absolute deadline.
+
+Lifecycle data is populated only for hardware whose vendor publishes it. Whitebox and consumer gear typically returns empty.
+
+## Warranty Fields
+
+`auvik_devices_get_warranty` returns:
+
+- `warrantyStart`, `warrantyEnd`
+- `warrantyStatus` - `active`, `expired`, `unknown`
+
+Devices `warrantyEnd` within 90 days are worth surfacing to the customer for renewal decisions.
+
+## v1 vs Detailed Endpoints
+
+- `auvik_devices_list` returns the v1 record - fast, paginated, but minimal fields. Use for inventories and counts.
+- `auvik_devices_get` returns the v1 record for one device.
+- `auvik_devices_get_details` returns the extended v2-style record - interface list, IP addresses, SNMP details, vendor info. Use when you need anything beyond name / type / status.
+
+Do not call `auvik_devices_get_details` in a tight loop over every device in a large tenant - it is significantly heavier than the v1 list. Filter to the device subset you need first.
+
+## Common Workflows
+
+### Full inventory
+
+1. `auvik_devices_list` paginated to completion.
+2. Group client-side by `deviceType` and `manageStatus`.
+
+### Lifecycle risk audit
+
+1. `auvik_devices_list`, filter to infrastructure types.
+2. For each, `auvik_devices_get_lifecycle` and `auvik_devices_get_warranty`.
+3. Bucket: past EOSM, past EOS, warranty expiring < 90d.
+
+### Unmanaged gap
+
+1. `auvik_devices_list`.
+2. Filter to `deviceType in {router, switch, firewall, accessPoint, controller}` and `manageStatus = unmanaged`.
+3. These are devices Auvik sees but is not polling - the highest-priority coverage gap.
+
+## Edge Cases
+
+- A device can change `deviceType` over time as Auvik's classifier improves - especially `unknown` -> a real type. Don't trust a single classification for a long-lived report.
+- Some vendors publish lifecycle for the chassis but not for line cards or modules - the device-level lifecycle is what's exposed.
+- `auvik_devices_list` returns devices across all networks visible to the credentials. Filter by tenant explicitly if you have a multi-tenant key.
+
+## Related Skills
+
+- [api-patterns](../api-patterns/SKILL.md)
+- [networks](../networks/SKILL.md)
+- [alerts](../alerts/SKILL.md)

--- a/msp-claude-plugins/auvik/auvik/skills/networks/SKILL.md
+++ b/msp-claude-plugins/auvik/auvik/skills/networks/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: "Auvik Networks"
+description: >
+  Use this skill when working with Auvik network and interface entities -
+  the network entity model, IP-range scoping, interface-to-device
+  relationships, and admin vs oper status.
+when_to_use: "When listing or inspecting Auvik networks and interfaces, or correlating interfaces back to their devices"
+triggers:
+  - auvik network
+  - auvik interface
+  - auvik vlan
+  - auvik subnet
+  - auvik link
+  - auvik topology
+---
+
+# Auvik Networks and Interfaces
+
+A `network` in Auvik is an IP scope - typically a subnet that Auvik has discovered devices on. An `interface` is a port on a device. Both are distinct entity types with their own list endpoints. This skill clarifies the data model and the relationships.
+
+## Tools
+
+| Tool | Use For |
+|------|---------|
+| `auvik_networks_list` | List networks for a tenant |
+| `auvik_networks_get` | Detail for one network |
+| `auvik_interfaces_list` | List interfaces for a tenant |
+
+## Network Entity
+
+Fields you'll see:
+
+- `networkName` - usually the subnet in CIDR form
+- `networkType` - `private`, `internet`, `unknown`
+- `scanStatus` - whether discovery scans for this network are healthy
+- `gatewayIp`, `dhcpEnabled`
+- `description` - free-form, often blank
+
+Networks are not VLANs in the Auvik model - VLAN information lives on interface records and switch configurations. A single VLAN typically maps to a single network, but the network entity is keyed on subnet, not VLAN ID.
+
+## Interface Entity
+
+Fields you'll see:
+
+- `interfaceName` - e.g. `GigabitEthernet1/0/24`
+- `interfaceType` - `ethernet`, `wireless`, `virtual`, `loopback`, `tunnel`, etc.
+- `adminStatus` - `up` or `down` - operator-set
+- `operStatus` - `up` or `down` - actual current state
+- `linkSpeed` - in bps
+- `parentDeviceId` - the device that owns the interface
+- `description` - administrator-set port description (when populated)
+
+### adminStatus vs operStatus
+
+| adminStatus | operStatus | Meaning |
+|-------------|------------|---------|
+| up | up | Healthy |
+| up | down | Link down - real condition (flap, cable, upstream) |
+| down | down | Administratively shut down - usually deliberate |
+| up | testing | In test mode - transient |
+
+A flapping interface will move between `up` and `down` on `operStatus` while `adminStatus` stays `up`. Capacity and statistics tools only return useful data for `up/up` interfaces.
+
+## Relationships
+
+- Interface -> Device via `parentDeviceId` -> `auvik_devices_get`
+- Device -> Networks via the device's IP addresses (in `auvik_devices_get_details`)
+- Network -> Devices via the address scope - a device with an IP in the network's range belongs to that network
+
+There is no direct "list devices in this network" call - you list devices, list networks, and join on IP membership client-side.
+
+## Common Workflows
+
+### Network footprint of a tenant
+
+1. `auvik_networks_list` - count, list IP ranges.
+2. Note `scanStatus` for each - any in error state is a discovery problem.
+
+### Find flapping interfaces
+
+1. `auvik_interfaces_list` for the tenant.
+2. Filter `adminStatus = up`, `operStatus = down`.
+3. Resolve owning device via `parentDeviceId`.
+4. Pull `auvik_statistics_interface` over a short window to see flap frequency.
+
+### Cross-reference an alert to an interface and device
+
+1. Alert references `entityId` with `entityType = interface`.
+2. The interface record has `parentDeviceId`.
+3. `auvik_devices_get` on the parent for the human-readable context.
+
+## Edge Cases
+
+- Virtual interfaces (SVIs, port-channels, tunnels) appear in `auvik_interfaces_list` alongside physical ones. Their `interfaceType` distinguishes them. For capacity reporting, exclude `interfaceType in {loopback, tunnel, virtual}` unless the question is specifically about them.
+- Some devices expose hundreds of interfaces (large modular switches) - paginate aggressively.
+- `linkSpeed` is 0 for down interfaces on some platforms - guard against divide-by-zero in utilization math.
+
+## Related Skills
+
+- [devices](../devices/SKILL.md)
+- [alerts](../alerts/SKILL.md)
+- [api-patterns](../api-patterns/SKILL.md)


### PR DESCRIPTION
## Summary
- Adds the **auvik** plugin (category: network) targeting the new [wyre-technology/auvik-mcp](https://github.com/wyre-technology/auvik-mcp) server through the WYRE MCP gateway
- Companion SDK: [wyre-technology/node-auvik](https://github.com/wyre-technology/node-auvik) (`@wyre-technology/node-auvik`)
- Gateway-side wiring PR: [wyre-technology/mcp-gateway#166](https://github.com/wyre-technology/mcp-gateway/pull/166)

## Contents
**5 commands** under `/auvik:`:
- `device-inventory` — per-tenant device list with type/manageStatus/lifecycle breakdown
- `alert-triage` — rank open alerts by severity, recommend dismissals
- `network-audit` — audit networks, interfaces, configurations
- `tenant-overview` — single-tenant snapshot card
- `capacity-check` — interface utilization scan with p95 thresholds

**4 skills:**
- `devices` (taxonomy, manageStatus, lifecycle/warranty, v1 vs v2)
- `alerts` (severity, status, dismissal semantics)
- `networks` (entity model, adminStatus vs operStatus)
- `api-patterns` (Basic auth, region routing, JSON:API envelope, cursor pagination, rate limits)

**3 proactive agents:**
- `network-analyst` — multi-signal tenant network triage
- `alert-responder` — alert queue triage with dismissal recommendations
- `capacity-planner` — incident-grade and planning-grade utilization analysis

## Marketplace
Registered as category=`network`, version `0.1.0`.

## Test plan
- [x] `python3 -c "import json; json.load(open('.claude-plugin/marketplace.json'))"` passes
- [ ] Plugin loads in a Claude Code instance once the gateway PR is merged and `auvik-mcp` container is deployed
- [ ] Each command + agent flow exercised against a real Auvik tenant