### PR TITLE
feat(kaseya-quote-manager): add read-only sales plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "msp-claude-plugins",
   "description": "Community-driven Claude Code plugins for Managed Service Providers. Integrates with PSA, RMM, and documentation tools.",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "owner": {
     "name": "Aaron Sachs"
   },
@@ -45,6 +45,21 @@
         "autotask",
         "psa",
         "tickets",
+        "msp"
+      ]
+    },
+    {
+      "name": "kaseya-quote-manager",
+      "source": "./msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager",
+      "description": "Kaseya Quote Manager (Datto Commerce) - read-only quotes, sales orders, purchasing, catalog, CRM, org",
+      "version": "1.0.0",
+      "category": "sales",
+      "tags": [
+        "kaseya",
+        "kaseya-quote-manager",
+        "datto-commerce",
+        "sales",
+        "quotes",
         "msp"
       ]
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Kaseya Quote Manager plugin (sales): read-only access to Kaseya Quote Manager (Datto Commerce). 3 skills (api-patterns, quotes, purchasing) + 3 commands (list-quotes, get-quote, get-sales-order). Tools follow `kqm_<entity>_list` / `kqm_<entity>_get` across sales, procurement, catalog, CRM, and org domains. Marketplace version bumped to 1.7.0
 - Docs: new **Advanced Workflows** section in the gateway docs, with its first guide — the Autotask Ticket Triage Agent (a Claude-managed scheduled agent that classifies new Autotask tickets by priority, advances them to In Progress, and notifies Slack)
 - Docs: **Advanced Workflows batch 1** — six new workflow guides, each a Claude-managed scheduled routine built and verified against WYRE's MCP Gateway: Patch Drift Reporter (Datto RMM), Device Health Auditor (Datto RMM), M365 License Auditor (CIPP), Compliance Drift Reporter (Liongard), Billing Reconciler (QuickBooks Online), and QBR Prep (Autotask + Datto RMM + CIPP + Liongard + IT Glue). Plus a **Delivery Adapters** reference (how a routine delivers its report — Slack, IT Glue — and the adapter contract for new targets) and an **Agent → Routine Catalog** classifying every marketplace subagent by routine-fitness archetype
 - Subagent coverage for four previously thin plugins, bringing them to parity with the strongest sibling plugins. All content grounded in the real MCP server tool surface:

--- a/msp-claude-plugins/docs/scripts/generate-plugins.ts
+++ b/msp-claude-plugins/docs/scripts/generate-plugins.ts
@@ -38,6 +38,7 @@ function deriveVendor(sourcePath: string): string {
 
   const vendorMap: Record<string, string> = {
     kaseya: 'Kaseya',
+    'kaseya-quote-manager': 'Kaseya',
     connectwise: 'ConnectWise',
     ninjaone: 'NinjaOne',
     syncro: 'Syncro',

--- a/msp-claude-plugins/docs/src/data/plugins.ts
+++ b/msp-claude-plugins/docs/src/data/plugins.ts
@@ -203,6 +203,37 @@ export const plugins: Plugin[] = [
     compatibility: { claudeCode: true, claudeDesktop: true, validated: false }
   },
   {
+    id: 'kaseya-quote-manager',
+    name: 'Kaseya Quote Manager',
+    vendor: 'Kaseya',
+    description: 'Kaseya Quote Manager (Datto Commerce) - read-only quotes, sales orders, purchasing, catalog, CRM, org',
+    category: 'sales',
+    maturity: 'beta',
+    features: [
+      'Purchasing',
+      'Quote Generation'
+    ],
+    skills: [
+      { name: 'purchasing', description: 'Use this skill when navigating Kaseya Quote Manager procurement data — purchase orders, their lines and costs, suppliers, and product-supplier relationships.' },
+      { name: 'quotes', description: 'Use this skill when navigating Kaseya Quote Manager quotes — drilling from a quote into its sections and line items, and following quotes through to sales orders, order lines, and payments.' },
+      { name: 'api-patterns', description: 'Use this skill when working with the Kaseya Quote Manager (Datto Commerce) MCP tools — API-key authentication, the read-only tool surface, page/pageSize pagination with modifiedAfter, rate limits, and error handling.' }
+    ],
+    agents: [],
+    commands: [
+      { name: '/get-quote', description: 'Get a Kaseya Quote Manager quote with its sections and line items' },
+      { name: '/get-sales-order', description: 'Get a Kaseya Quote Manager sales order with its lines and payments' },
+      { name: '/list-quotes', description: 'List Kaseya Quote Manager quotes, optionally scoped to a recent window' }
+    ],
+    apiInfo: {
+      baseUrl: '',
+      auth: '',
+      rateLimit: '',
+      docsUrl: ''
+    },
+    path: 'kaseya-quote-manager/kaseya-quote-manager',
+    compatibility: { claudeCode: true, claudeDesktop: true, validated: false }
+  },
+  {
     id: 'betterstack',
     name: 'BetterStack',
     vendor: 'BetterStack',

--- a/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "kaseya-quote-manager",
+  "version": "1.0.0",
+  "description": "Kaseya Quote Manager (Datto Commerce) - read-only access to quotes, sales orders, purchasing, catalog, CRM, and org data",
+  "author": "WYRE Technology"
+}

--- a/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/README.md
+++ b/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/README.md
@@ -1,0 +1,68 @@
+# Kaseya Quote Manager Plugin
+
+Read-only plugin for Kaseya Quote Manager (formerly Datto Commerce) - navigate
+quotes, sales orders, purchasing, catalog, CRM, and org data for MSP sales and
+distribution workflows.
+
+## Installation
+
+```
+/plugin marketplace add wyre-technology/msp-claude-plugins --plugin kaseya-quote-manager
+```
+
+## Configuration
+
+This plugin is served through the WYRE MCP gateway. Provide your Kaseya Quote
+Manager API key as the gateway credential.
+
+### Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `X_KQM_APIKEY` | Yes | API key from Quote Manager (Settings > API). The gateway maps it to the upstream `apiKey` header. |
+
+### Obtaining Credentials
+
+1. Log in to Kaseya Quote Manager
+2. Navigate to **Settings > API**
+3. Generate a new API key
+4. Provide the key as the `X_KQM_APIKEY` gateway credential
+
+## Read-Only
+
+The entire tool surface is read-only. Every tool is a `kqm_<entity>_list` or
+`kqm_<entity>_get` - there are no write tools.
+
+## Available Skills
+
+| Skill | Description |
+|-------|-------------|
+| [api-patterns](skills/api-patterns/) | Authentication (apiKey header), pagination, rate limits, read-only tool surface |
+| [quotes](skills/quotes/) | Quotes -> sections -> lines, and sales orders/lines/payments |
+| [purchasing](skills/purchasing/) | Purchase orders, costs, suppliers, product-supplier pricing |
+
+## Available Commands
+
+| Command | Description |
+|---------|-------------|
+| `/list-quotes` | List quotes, optionally scoped with modifiedAfter |
+| `/get-quote` | Get a quote with sections and line items |
+| `/get-sales-order` | Get a sales order with lines and payments |
+
+## Tool Domains
+
+- **sales**: quote, quote_section, quote_line, sales_order, sales_order_line, sales_order_payment
+- **procurement**: purchase_order, purchase_order_line, purchase_order_cost, supplier, product_supplier
+- **catalog**: product, product_image (list only), category, brand
+- **crm**: customer, customer_address, contact
+- **org**: employee, warehouse
+
+## API Documentation
+
+- [Kaseya Quote Manager API](https://help.quotemanager.kaseya.com/help/Content/2-integrate/api.htm)
+- Base URL: `https://api.kaseyaquotemanager.com/v1/`
+
+## Rate Limits
+
+- 60 requests per minute
+- 20,000 requests per day

--- a/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/commands/get-quote.md
+++ b/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/commands/get-quote.md
@@ -1,0 +1,32 @@
+---
+name: get-quote
+description: Get a Kaseya Quote Manager quote with its sections and line items
+arguments:
+  - name: id
+    description: Quote ID
+    required: true
+---
+
+# Get Kaseya Quote Manager Quote
+
+## Prerequisites
+- Kaseya Quote Manager API key configured (read-only)
+
+## Steps
+1. Retrieve the quote: `kqm_quote_get` with `id=$id`
+2. List its sections: `kqm_quote_section_list` for the quote
+3. For each section, list lines: `kqm_quote_line_list`
+4. Display the quote with sections, line items, quantities, and pricing
+
+## Examples
+
+### Get quote by ID
+```
+/get-quote id=12345
+```
+
+## Error Handling
+| Error | Resolution |
+|-------|------------|
+| 404 Not Found | Verify the quote ID exists |
+| 401 Unauthorized | Verify the API key |

--- a/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/commands/get-sales-order.md
+++ b/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/commands/get-sales-order.md
@@ -1,0 +1,32 @@
+---
+name: get-sales-order
+description: Get a Kaseya Quote Manager sales order with its lines and payments
+arguments:
+  - name: id
+    description: Sales order ID
+    required: true
+---
+
+# Get Kaseya Quote Manager Sales Order
+
+## Prerequisites
+- Kaseya Quote Manager API key configured (read-only)
+
+## Steps
+1. Retrieve the sales order: `kqm_sales_order_get` with `id=$id`
+2. List its lines: `kqm_sales_order_line_list`
+3. List payments: `kqm_sales_order_payment_list`
+4. Display the order with lines, totals, and payment status
+
+## Examples
+
+### Get sales order by ID
+```
+/get-sales-order id=67890
+```
+
+## Error Handling
+| Error | Resolution |
+|-------|------------|
+| 404 Not Found | Verify the sales order ID exists |
+| 401 Unauthorized | Verify the API key |

--- a/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/commands/list-quotes.md
+++ b/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/commands/list-quotes.md
@@ -1,0 +1,34 @@
+---
+name: list-quotes
+description: List Kaseya Quote Manager quotes, optionally scoped to a recent window
+arguments:
+  - name: modifiedAfter
+    description: ISO timestamp - only return quotes changed after this time
+    required: false
+  - name: pageSize
+    description: Results per page (max 100)
+    required: false
+---
+
+# List Kaseya Quote Manager Quotes
+
+## Prerequisites
+- Kaseya Quote Manager API key configured (read-only)
+
+## Steps
+1. Call `kqm_quote_list` with `page=1`, `pageSize=$pageSize` (default 100), and `modifiedAfter=$modifiedAfter` if provided
+2. Page through results until a partial page is returned
+3. Display quotes with id, customer, status, and total
+
+## Examples
+
+### List quotes changed this month
+```
+/list-quotes modifiedAfter=2026-05-01T00:00:00Z
+```
+
+## Error Handling
+| Error | Resolution |
+|-------|------------|
+| 429 Rate Limited | Wait and retry with backoff (60 req/min, 20k/day) |
+| 401 Unauthorized | Verify the API key |

--- a/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/skills/api-patterns/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: "Kaseya Quote Manager API Patterns"
+when_to_use: "When working with Kaseya Quote Manager authentication, pagination, rate limits, or error handling for the Kaseya Quote Manager MCP server"
+description: >
+  Use this skill when working with the Kaseya Quote Manager (Datto Commerce)
+  MCP tools — API-key authentication, the read-only tool surface, page/pageSize
+  pagination with modifiedAfter, rate limits, and error handling.
+triggers:
+  - kaseya quote manager api
+  - kqm authentication
+  - kqm pagination
+  - kqm rate limit
+  - quote manager api
+  - datto commerce api
+---
+
+# Kaseya Quote Manager MCP Tools & API Patterns
+
+## Overview
+
+The Kaseya Quote Manager MCP server exposes quoting, sales-order,
+procurement, catalog, CRM, and org data from Kaseya Quote Manager
+(formerly Datto Commerce). The entire tool surface is **READ-ONLY** —
+every tool is a `_list` or `_get`; there are no write tools.
+
+Tool names follow `kqm_<entity>_list` and `kqm_<entity>_get` across
+five domains:
+
+- **sales**: `quote`, `quote_section`, `quote_line`, `sales_order`, `sales_order_line`, `sales_order_payment`
+- **procurement**: `purchase_order`, `purchase_order_line`, `purchase_order_cost`, `supplier`, `product_supplier`
+- **catalog**: `product`, `product_image` (list only), `category`, `brand`
+- **crm**: `customer`, `customer_address`, `contact`
+- **org**: `employee`, `warehouse`
+
+## Connection & Authentication
+
+Kaseya Quote Manager uses a single API key. Against the upstream API the
+key is sent in the `apiKey` HTTP header:
+
+| Header | Value |
+|--------|-------|
+| `apiKey` | The raw Quote Manager API key |
+
+Generate the key in Quote Manager under **Settings → API**.
+
+When used through the WYRE MCP gateway, the gateway maps the environment
+variable `X_KQM_APIKEY` onto an `X-Kqm-Api-Key` header, and the MCP server
+translates that into the upstream `apiKey` header automatically. You do not
+need to construct headers by hand — set the credential and the server
+handles upstream auth translation.
+
+```bash
+export X_KQM_APIKEY="your-quote-manager-api-key"
+```
+
+## Base URL
+
+```
+https://api.kaseyaquotemanager.com/v1/
+```
+
+## Pagination
+
+List endpoints use page-based pagination:
+
+| Parameter | Type | Default | Max | Description |
+|-----------|------|---------|-----|-------------|
+| page | number | 1 | - | 1-based page number |
+| pageSize | number | - | 100 | Results per page |
+| modifiedAfter | datetime | - | - | Only return records changed after this timestamp |
+
+Use `modifiedAfter` for incremental syncs rather than re-walking the full
+collection. Always check whether more pages exist (a full page of `pageSize`
+results usually means there is another page) before claiming a result set is
+complete.
+
+## Rate Limiting
+
+- **60 requests per minute**
+- **20,000 requests per day**
+- **Strategy:** batch with the largest `pageSize` (100) to minimize calls;
+  use `modifiedAfter` for incremental pulls.
+- **Backoff:** on `429`, wait and retry with exponential backoff.
+
+## Error Handling
+
+| Status Code | Meaning | Resolution |
+|-------------|---------|------------|
+| 400 | Bad Request | Check query parameters |
+| 401 | Unauthorized | Verify the API key is correct |
+| 403 | Forbidden | Check API key permissions |
+| 404 | Not Found | Resource doesn't exist |
+| 429 | Rate Limited | Wait and retry with backoff |
+| 500 | Server Error | Retry after a delay |
+
+## API Documentation
+
+- [Kaseya Quote Manager API](https://help.quotemanager.kaseya.com/help/Content/2-integrate/api.htm)

--- a/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/skills/purchasing/SKILL.md
+++ b/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/skills/purchasing/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: "Kaseya Quote Manager Purchasing"
+when_to_use: "When viewing or analyzing purchase orders, suppliers, or product-supplier pricing in Kaseya Quote Manager"
+description: >
+  Use this skill when navigating Kaseya Quote Manager procurement data —
+  purchase orders, their lines and costs, suppliers, and product-supplier
+  relationships. The tool surface is read-only.
+triggers:
+  - kaseya quote manager purchasing
+  - kqm purchase order
+  - kqm supplier
+  - quote manager procurement
+  - kqm product supplier
+  - kqm purchasing
+---
+
+# Kaseya Quote Manager — Purchasing
+
+## Overview
+
+The procurement domain covers what an MSP buys to fulfill quotes and sales
+orders: **purchase orders** (with lines and costs), the **suppliers** they
+are placed with, and **product-supplier** records that map catalog products
+to supplier SKUs and pricing.
+
+All access here is **read-only**.
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| `kqm_purchase_order_list` | List purchase orders |
+| `kqm_purchase_order_get` | Retrieve a single purchase order |
+| `kqm_purchase_order_line_list` | List PO line items |
+| `kqm_purchase_order_line_get` | Retrieve a single PO line |
+| `kqm_purchase_order_cost_list` | List costs against purchase orders |
+| `kqm_purchase_order_cost_get` | Retrieve a single PO cost |
+| `kqm_supplier_list` | List suppliers/distributors |
+| `kqm_supplier_get` | Retrieve a single supplier |
+| `kqm_product_supplier_list` | List product-supplier mappings (supplier SKU + cost) |
+| `kqm_product_supplier_get` | Retrieve a single product-supplier mapping |
+
+## Common Workflows
+
+### Review a purchase order
+
+1. Find the PO: `kqm_purchase_order_list`
+2. Get the PO: `kqm_purchase_order_get`
+3. List its lines: `kqm_purchase_order_line_list`
+4. Review costs: `kqm_purchase_order_cost_list`
+
+### Compare supplier pricing for a product
+
+1. List product-supplier records: `kqm_product_supplier_list`
+2. Resolve supplier details: `kqm_supplier_get`
+3. Compare cost across suppliers for the same product
+
+## Notes
+
+- Paginate with `pageSize=100`; use `modifiedAfter` for incremental pulls.
+- Procurement data pairs naturally with the catalog domain (`kqm_product_*`)
+  and the quotes domain for margin analysis.

--- a/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/skills/quotes/SKILL.md
+++ b/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/skills/quotes/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: "Kaseya Quote Manager Quotes & Sales Orders"
+when_to_use: "When viewing or analyzing quotes, quote sections/lines, or sales orders in Kaseya Quote Manager"
+description: >
+  Use this skill when navigating Kaseya Quote Manager quotes — drilling from
+  a quote into its sections and line items, and following quotes through to
+  sales orders, order lines, and payments. The tool surface is read-only.
+triggers:
+  - kaseya quote manager quote
+  - kqm quote
+  - kqm quote lines
+  - kqm sales order
+  - quote manager sales order
+  - quote sections lines
+---
+
+# Kaseya Quote Manager — Quotes & Sales Orders
+
+## Overview
+
+Quotes are the primary domain of Kaseya Quote Manager. A quote is composed of
+one or more **sections**, and each section holds **line items** (products with
+quantity and pricing). When a quote is accepted it becomes a **sales order**,
+which has its own **order lines** and **payments**.
+
+All access here is **read-only** — these tools list and retrieve data; they
+never create or modify records.
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| `kqm_quote_list` | List quotes (paginate with page/pageSize, filter with modifiedAfter) |
+| `kqm_quote_get` | Retrieve a single quote by id |
+| `kqm_quote_section_list` | List sections, typically for a given quote |
+| `kqm_quote_section_get` | Retrieve a single quote section |
+| `kqm_quote_line_list` | List line items, typically for a given section/quote |
+| `kqm_quote_line_get` | Retrieve a single quote line |
+| `kqm_sales_order_list` | List sales orders |
+| `kqm_sales_order_get` | Retrieve a single sales order |
+| `kqm_sales_order_line_list` | List sales-order line items |
+| `kqm_sales_order_line_get` | Retrieve a single sales-order line |
+| `kqm_sales_order_payment_list` | List payments against sales orders |
+| `kqm_sales_order_payment_get` | Retrieve a single payment |
+
+## Quote Hierarchy
+
+```
+Quote
+└── Quote Section
+    └── Quote Line (product, qty, price)
+
+Sales Order (created when a quote is accepted)
+├── Sales Order Line
+└── Sales Order Payment
+```
+
+## Common Workflows
+
+### Inspect a quote and its line items
+
+1. Find the quote: `kqm_quote_list` (filter by customer / modifiedAfter)
+2. Get the quote: `kqm_quote_get` with the quote id
+3. List its sections: `kqm_quote_section_list`
+4. For each section, list lines: `kqm_quote_line_list`
+
+### Trace a quote to revenue
+
+1. Locate the sales order: `kqm_sales_order_list`
+2. Pull its lines: `kqm_sales_order_line_list`
+3. Review payments: `kqm_sales_order_payment_list`
+
+### Summarize quoting activity
+
+1. List recent quotes with `modifiedAfter` to bound the window
+2. Page through with `pageSize=100` until a partial page is returned
+3. Aggregate totals from quote lines / sales-order lines
+
+## Notes
+
+- Always paginate fully before reporting totals — a full page of 100 results
+  usually means more pages remain.
+- Use `modifiedAfter` to scope large pulls to a recent window.


### PR DESCRIPTION
## Summary

Adds a new vendor plugin for **Kaseya Quote Manager** (formerly Datto Commerce) to the marketplace.

- Category: `sales`
- Read-only tool surface: tools follow `kqm_<entity>_list` / `kqm_<entity>_get` across sales, procurement, catalog, CRM, and org domains.
- No per-vendor `.mcp.json` (gateway-served; avoids 'Tool already registered' collisions).

## Files

- `.claude-plugin/plugin.json` (v1.0.0)
- `skills/api-patterns/SKILL.md` — apiKey header auth, page/pageSize + modifiedAfter pagination, rate limits (60/min, 20k/day), read-only surface
- `skills/quotes/SKILL.md` — quote → section → line, sales orders/lines/payments
- `skills/purchasing/SKILL.md` — purchase orders/costs, suppliers, product-supplier pricing
- `commands/list-quotes.md`, `commands/get-quote.md`, `commands/get-sales-order.md`
- `README.md`

## Marketplace / data

- Registered in `marketplace.json`; marketplace version bumped 1.6.0 → 1.7.0
- Added generator vendor mapping for clean display name
- Regenerated `docs/src/data/plugins.ts` — now **52 plugins**; new plugin shows 3 skills / 0 agents / 3 commands

Note: local `astro build` could not run (npm install fails on the `sharp` native dep in this environment); the prebuild generator (`generate-plugins.ts`) ran cleanly and validated categories. CI will run the full build.