### PR TITLE
feat(warmly): add Warmly visitor-intelligence plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "msp-claude-plugins",
   "description": "Community-driven Claude Code plugins for Managed Service Providers. Integrates with PSA, RMM, and documentation tools.",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "owner": {
     "name": "Aaron Sachs"
   },
@@ -326,6 +326,20 @@
         "documents",
         "proposals",
         "esign",
+        "msp"
+      ]
+    },
+    {
+      "name": "warmly",
+      "source": "./msp-claude-plugins/warmly/warmly",
+      "description": "Warmly visitor intelligence - identified website visitors, account-level engagement, and credit balance",
+      "version": "0.1.0",
+      "category": "sales",
+      "tags": [
+        "warmly",
+        "sales",
+        "visitor-intelligence",
+        "prospecting",
         "msp"
       ]
     },

--- a/msp-claude-plugins/docs/src/data/plugins.ts
+++ b/msp-claude-plugins/docs/src/data/plugins.ts
@@ -1038,6 +1038,31 @@ export const plugins: Plugin[] = [
     compatibility: { claudeCode: true, claudeDesktop: true, validated: false }
   },
   {
+    id: 'warmly',
+    name: 'Warmly',
+    vendor: 'Warmly',
+    description: 'Warmly visitor intelligence - identified website visitors, account-level engagement, and credit balance',
+    category: 'sales',
+    maturity: 'alpha',
+    features: [
+      'Visitor Intelligence'
+    ],
+    skills: [
+      { name: 'visitor-intelligence', description: 'Use this skill when triaging or acting on identified website visitors and account-level engagement from Warmly - prioritizing warm accounts for outreach, filtering visitors by ICP fit, scoring engagement depth, matching visitors to CRM records, or watching identification credit burn.' },
+      { name: 'api-patterns', description: 'Use this skill when working with the Warmly MCP tools - available tools, WorkOS AuthKit OAuth 2.0 + PKCE authentication, organization scoping, Streamable HTTP transport, credit usage, error handling, and best practices.' }
+    ],
+    agents: [],
+    commands: [],
+    apiInfo: {
+      baseUrl: '',
+      auth: '',
+      rateLimit: '',
+      docsUrl: ''
+    },
+    path: 'warmly/warmly',
+    compatibility: { claudeCode: true, claudeDesktop: true, validated: false }
+  },
+  {
     id: 'pax8',
     name: 'Pax8',
     vendor: 'Pax8',

--- a/msp-claude-plugins/warmly/warmly/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/warmly/warmly/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "warmly",
+  "version": "0.1.0",
+  "description": "Warmly visitor intelligence - identified website visitors, account-level engagement, and credit balance",
+  "author": {
+    "name": "MSP Claude Plugins Community"
+  },
+  "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
+  "repository": "https://github.com/wyre-technology/msp-claude-plugins",
+  "license": "Apache-2.0"
+}

--- a/msp-claude-plugins/warmly/warmly/.env.example
+++ b/msp-claude-plugins/warmly/warmly/.env.example
@@ -1,0 +1,9 @@
+# Warmly MCP OAuth credentials (BYOC)
+# Warmly delegates auth to a WorkOS AuthKit tenant. Register an OAuth client
+# and copy the values here. Public PKCE clients are supported, so the secret
+# may be empty.
+WARMLY_CLIENT_ID=your-client-id
+WARMLY_CLIENT_SECRET=
+# Optional. Required only for multi-organization Warmly accounts — pins API
+# calls to a specific org. Single-org accounts can leave this blank.
+WARMLY_ORGANIZATION_ID=

--- a/msp-claude-plugins/warmly/warmly/README.md
+++ b/msp-claude-plugins/warmly/warmly/README.md
@@ -1,0 +1,52 @@
+# Warmly Plugin
+
+Claude Code plugin for [Warmly](https://www.warmly.ai) — visitor intelligence and account-level engagement for B2B sales teams.
+
+## Overview
+
+This plugin gives Claude access to Warmly's hosted MCP server, which exposes three read-only tools backed by Warmly's visitor identification platform:
+
+- **Identified site visitors** — pulled together with company and contact profiles, session data, and CRM overlap
+- **Account-level rollups** — visitor data aggregated by company with engagement metrics
+- **Credit balance** — current month's identification credit remaining
+
+These are most useful inside an MSP/B2B sales workflow: triaging warm accounts before outreach, prioritizing follow-ups by engagement depth, or watching credit burn against pipeline value.
+
+## Prerequisites
+
+### OAuth Setup (BYOC)
+
+Warmly's MCP server delegates authentication to a WorkOS AuthKit tenant. Each customer brings their own OAuth client.
+
+1. Read the Warmly MCP docs: [docs.getwarmly.com/mcp](https://docs.getwarmly.com/mcp)
+2. Obtain a `client_id` (and optionally `client_secret`) for your Warmly workspace's AuthKit tenant. AuthKit supports public PKCE clients, so `client_secret` may be empty.
+3. Note your `organization_id` if your Warmly account contains multiple organizations; single-org accounts can skip this.
+
+### Environment Variables
+
+```bash
+WARMLY_CLIENT_ID=your-client-id
+WARMLY_CLIENT_SECRET=            # may be empty for public PKCE clients
+WARMLY_ORGANIZATION_ID=          # optional; multi-org accounts only
+```
+
+## Connecting via the WYRE MCP Gateway
+
+The WYRE MCP Gateway (`mcp.wyre.ai`) hosts Warmly as a first-party connector. Connect Warmly in the gateway UI — the gateway proxies tool calls to `https://opps-api.getwarmly.com/api/mcp`, handles the AuthKit OAuth dance per tenant, and injects `X-Warmly-Organization-Id` automatically when the field is set.
+
+## Skills
+
+| Skill | When it surfaces |
+|---|---|
+| `api-patterns` | OAuth flow, transport (Streamable HTTP), available tools, rate limits, error handling |
+| `visitor-intelligence` | Triaging warm accounts, exporting visitor lists, scoring engagement, credit-burn checks |
+
+## Tool Reference
+
+| Tool | Returns |
+|---|---|
+| `list_warm_visitors` | Identified visitors with company + contact profiles, session details, and CRM intersection |
+| `list_warm_accounts` | Visitor data grouped by company with aggregated engagement metrics |
+| `get_credits_remaining` | Monthly credit balance |
+
+All three are read-only and free to call. See `skills/api-patterns/SKILL.md` for full schemas and usage patterns.

--- a/msp-claude-plugins/warmly/warmly/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/warmly/warmly/skills/api-patterns/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: "Warmly API Patterns"
+description: >
+  Use this skill when working with the Warmly MCP tools - available tools,
+  WorkOS AuthKit OAuth 2.0 + PKCE authentication, organization scoping,
+  Streamable HTTP transport, credit usage, error handling, and best practices.
+  Covers the official remote MCP server connection and all Warmly visitor
+  intelligence tools.
+when_to_use: "When working with available tools, authentication, organization scoping, transport, credits, error handling, and best practices in the Warmly MCP tools"
+triggers:
+  - warmly api
+  - warmly mcp
+  - warmly oauth
+  - warmly authkit
+  - warmly authentication
+  - warmly request
+  - warmly tools
+  - warmly connection
+  - warmly organization
+  - warmly credits
+  - warmly rate limit
+  - warmly error
+---
+
+# Warmly MCP Tools & API Patterns
+
+## Overview
+
+Warmly hosts a remote MCP server at `https://opps-api.getwarmly.com/api/mcp` that exposes three read-only tools backed by Warmly's visitor identification platform. Authentication is OAuth 2.0 with PKCE, delegated to a WorkOS AuthKit tenant. Transport is MCP Streamable HTTP and the server is stateful — it issues an `Mcp-Session-Id` on `initialize` that must accompany subsequent requests.
+
+Official docs: [docs.getwarmly.com/mcp](https://docs.getwarmly.com/mcp)
+
+## Connection & Authentication
+
+### MCP Server Endpoint
+
+```
+POST https://opps-api.getwarmly.com/api/mcp
+Accept: application/json, text/event-stream
+```
+
+### OAuth 2.0 via WorkOS AuthKit
+
+Warmly publishes RFC 9728 protected-resource metadata; the authorization server is a WorkOS AuthKit tenant:
+
+```
+GET https://opps-api.getwarmly.com/.well-known/oauth-protected-resource
+→ authorization_servers: ["https://vigorous-paper-03.authkit.app"]
+```
+
+AuthKit's `.well-known/oauth-authorization-server` exposes:
+
+- `authorization_endpoint`: `https://vigorous-paper-03.authkit.app/oauth2/authorize`
+- `token_endpoint`: `https://vigorous-paper-03.authkit.app/oauth2/token`
+- `registration_endpoint`: `https://vigorous-paper-03.authkit.app/oauth2/register` (Dynamic Client Registration supported)
+- `code_challenge_methods_supported`: `["S256"]`
+- `grant_types_supported`: `["authorization_code", "refresh_token"]`
+- `token_endpoint_auth_methods_supported`: `["none", "client_secret_post", "client_secret_basic"]` — **public PKCE clients are supported**, so `client_secret` may be empty
+
+Scopes used at the IdP: `openid profile email offline_access`. The MCP resource itself has `scopes_supported: []` — no resource-specific scopes are required, only a valid bearer token.
+
+### Multi-Organization Scoping
+
+For accounts with multiple Warmly organizations, every call must pin org context. Two equivalent transports:
+
+- Header (preferred): `X-Warmly-Organization-Id: <uuid>`
+- Query: `?organization_id=<uuid>` appended to the MCP URL
+
+The WYRE MCP Gateway uses the header form so the org never leaks into proxy access logs. Single-organization tokens resolve their org server-side; the header is optional.
+
+## Available Tools
+
+All three tools are read-only synchronous calls and do not consume identification credits (a list call returns the same visitors that have already been identified — Warmly bills on identification, not retrieval).
+
+### `list_warm_visitors`
+
+Returns identified site visitors with full enrichment.
+
+Per-visitor fields include:
+- Visitor identifier and session(s)
+- Company profile (name, domain, industry, employee count)
+- Contact profile when available (name, title, email, LinkedIn)
+- Pageviews and session timing
+- CRM intersection (whether the visitor matches a CRM contact or account)
+
+### `list_warm_accounts`
+
+Visitor activity rolled up to the account/company level.
+
+Per-account fields include:
+- Company profile
+- Aggregate visit/visitor counts
+- First-seen / last-seen timestamps
+- Engagement summary (page categories, depth)
+- Top contacts identified at that account
+
+### `get_credits_remaining`
+
+Current month's identification credit balance. Useful for catching credit exhaustion before scaling outreach off Warmly data.
+
+## Best Practices
+
+- **Filter before iterating.** Both `list_warm_*` tools return all currently identified visitors/accounts for the period. For large workspaces, narrow by company domain, date window, or engagement threshold in your downstream code rather than asking the model to scan the full payload.
+- **Pair with CRM tools.** Warmly's intersection signals tell you whether a visitor is already a known contact/account in your CRM. Combine with the HubSpot or PSA plugins to enrich identified accounts in-place rather than maintaining a separate Warmly list.
+- **Watch credits before bulk workflows.** Call `get_credits_remaining` first if a workflow plans to drive prospecting volume off Warmly identifications — credit exhaustion silently stops new visitor enrichment but leaves previously identified visitors visible.
+- **Treat as warm, not closed.** Visitor identification is probabilistic at the contact level. Treat `list_warm_visitors` contact data as the *highest-likelihood* identification for an account, not as a confirmed individual buyer signal.
+
+## Error Handling
+
+| Status | Meaning | Likely cause |
+|---|---|---|
+| 401 `invalid_token` | Missing or expired bearer token | Refresh the OAuth token; check `WWW-Authenticate: Bearer resource_metadata=...` for the auth server |
+| 403 | Token valid, organization context wrong | Pass `X-Warmly-Organization-Id` for multi-org accounts, or verify the token's authorized org |
+| 400 missing session | `Mcp-Session-Id` not sent | The server is stateful — every tool call must carry the session id issued on `initialize` |
+| 5xx | Warmly platform error | Retry with backoff; persistent 5xx → contact Warmly support |
+
+The WYRE MCP Gateway handles the initialize handshake, session id, and token refresh automatically — these are concerns only when connecting to Warmly's MCP directly.
+
+## Rate Limits
+
+Warmly has not published explicit MCP rate limits. The three tools are list reads, not write operations; sustained polling is unnecessary because identifications are batched server-side. A safe pattern is to call `list_warm_visitors` / `list_warm_accounts` no more than once per minute per workspace.

--- a/msp-claude-plugins/warmly/warmly/skills/visitor-intelligence/SKILL.md
+++ b/msp-claude-plugins/warmly/warmly/skills/visitor-intelligence/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: "Warmly Visitor Intelligence"
+description: >
+  Use this skill when triaging or acting on identified website visitors and
+  account-level engagement from Warmly - prioritizing warm accounts for
+  outreach, filtering visitors by ICP fit, scoring engagement depth,
+  matching visitors to CRM records, or watching identification credit burn.
+  Covers list_warm_visitors, list_warm_accounts, and get_credits_remaining.
+when_to_use: "When triaging warm accounts, exporting visitor lists, scoring engagement, matching visitors to CRM records, or checking credit balance with Warmly"
+triggers:
+  - warmly visitors
+  - warmly accounts
+  - warmly warm leads
+  - warmly identified
+  - warmly site visitors
+  - warmly company visits
+  - warmly icp
+  - warmly outreach
+  - warmly engagement
+  - warmly prospecting
+  - warmly credits remaining
+  - who visited our site
+  - identified visitors
+---
+
+# Warmly Visitor Intelligence
+
+## What Warmly tells you
+
+Warmly identifies anonymous website visitors by IP-to-company reverse lookup, third-party data overlays, and (where consented) contact-level deanonymization. For an MSP or B2B sales team, the practical outputs are:
+
+- **Which companies are on the site right now** (or were in the recent window)
+- **Which identified people from those companies** showed up, with title and contact info when available
+- **How deeply they engaged** — pages viewed, time on page, return visits
+
+That is the raw material for prioritizing outreach: warm > cold, deep engagement > a single bounce, target ICP > unrelated traffic.
+
+## Tool selection
+
+| Task | Tool |
+|---|---|
+| "Who visited the site today?" | `list_warm_visitors` |
+| "Which companies are showing pipeline-grade engagement this week?" | `list_warm_accounts` |
+| "Are we about to run out of identifications?" | `get_credits_remaining` |
+
+`list_warm_visitors` is the right starting point when you want contact-level signal (a named person you can email/call). `list_warm_accounts` is right when you want to triage at the account level (which companies are worth a salesperson's time at all).
+
+## Common workflows
+
+### Triage warm accounts for the morning outreach list
+
+1. `list_warm_accounts` to pull current account-level engagement.
+2. Filter by ICP fit (industry, employee count, geography — fields are on every account).
+3. Sort by an engagement signal that matches your sales motion: returning visitors, pricing-page hits, or session duration depending on what you're optimizing for.
+4. For the top N accounts, `list_warm_visitors` filtered to those companies to pull individual contact-level signal.
+
+### Cross-reference with CRM before reaching out
+
+Each visitor/account in Warmly's response includes intersection flags indicating whether the company or contact already exists in your CRM. Use this to route:
+
+- **Known contact, recent activity** → hand to the AE who owns it; don't re-outreach
+- **Known account, new contact** → enrich the existing account; queue the new contact for AE review
+- **Net-new account, ICP-matched** → SDR outbound, with the visit as the warming signal
+
+Pair the Warmly tools with the HubSpot, ConnectWise, or Autotask plugins to do the lookups in-place.
+
+### Engagement-depth scoring
+
+The raw payload exposes pageviews and session timing — derive a simple score (`pageviews * recency_weight + session_minutes`) rather than asking Claude to eyeball "high engagement." Surface only the top decile to outreach queues so SDR attention isn't diluted.
+
+### Credit-burn check before a campaign
+
+Before launching a workflow that depends on Warmly identifications scaling up (e.g. "enrich every visitor for the next 30 days"), call `get_credits_remaining` and confirm the balance covers expected volume. Identifications silently stop when the credit budget is exhausted — already-identified visitors stay visible, but new ones don't appear.
+
+## What Warmly does NOT tell you
+
+- **Confirmed buyer intent.** A page visit, even from a named contact, is not a qualified opportunity. Warmly is a top-of-funnel signal, not a closing one.
+- **Intent across other channels.** Warmly only sees your site. Cross-reference with intent platforms (G2, 6sense, Bombora) for a fuller picture.
+- **Outbound delivery.** Warmly identifies; sending is your CRM/sequencer's job. Use the HubSpot or sequencing tools to actually contact the people Warmly surfaces.
+
+## Tying it to MSP sales motions
+
+For an MSP-specific motion, the practical combinations are:
+
+- **Audit-page interest** → `list_warm_accounts` filtered to visits on the security/M365/Azure audit pages → SDR sequence offering a free audit assessment.
+- **Pricing-page visits without an active deal** → cross-reference HubSpot deals; if no open opportunity, route to the AE for outbound.
+- **Returning visitor from a closed-lost account** → re-engagement play; the AE who lost the deal originally is best-placed to re-open.
+
+Run these as repeatable workflows rather than one-off lookups — the value of visitor identification compounds when it consistently feeds the outreach engine.


### PR DESCRIPTION
## What

Adds a Claude Code plugin for [Warmly](https://www.warmly.ai)'s hosted MCP server — companion to the gateway-side change in [wyre-technology/mcp-gateway#191](https://github.com/wyre-technology/mcp-gateway/pull/191), which adds the Warmly vendor connection (and restores the HubSpot + Xero connections deleted in April).

## Plugin contents

| Path | Purpose |
|---|---|
| `.claude-plugin/plugin.json` | Plugin metadata (v0.1.0) |
| `.env.example` | BYOC AuthKit credentials + optional org id |
| `README.md` | Setup, gateway connection, tool reference |
| `skills/api-patterns/SKILL.md` | OAuth via WorkOS AuthKit (public PKCE supported), Streamable HTTP transport with `Mcp-Session-Id`, organization scoping, error/rate-limit guidance |
| `skills/visitor-intelligence/SKILL.md` | Triaging warm accounts, ICP filtering, engagement scoring, CRM cross-reference, credit-burn checks, MSP-specific sales motions |

Tools (read-only): `list_warm_visitors`, `list_warm_accounts`, `get_credits_remaining`.

## Marketplace

- Bumped `version`: `1.8.0` → `1.9.0`.
- Added `warmly` entry under category `sales` (alongside `pandadoc`, `salesbuildr`).
- Regenerated `docs/src/data/plugins.ts` via `npm run generate`. Reports 54 plugins (`shared-skills` is rendered separately through `sharedSkills.ts`); 55 marketplace entries total.

## HubSpot + Xero

These plugins were **already intact** in this repo with full skill sets (6 each, including `api-patterns`) and existing marketplace entries — the April removal only touched the gateway-side `vendor-config.ts`. No changes needed here for them.

## Verification

- Generator script ran cleanly; Warmly present in `plugins.ts` with both skills, category `sales`, maturity `alpha`.
- Local full build (`npm run build`) **skipped** because `sharp` failed to install on my Mac (native build issue unrelated to this change); CI will run the full prebuild + Astro build.

## Companion PR

- Gateway: https://github.com/wyre-technology/mcp-gateway/pull/191