### PR TITLE
feat(docs): GA4 install on mcp.wyre.ai (env-gated)

### DIFF
--- a/msp-claude-plugins/docs/src/layouts/BaseLayout.astro
+++ b/msp-claude-plugins/docs/src/layouts/BaseLayout.astro
@@ -36,6 +36,22 @@ const {
   twitterCard
 } = Astro.props;
 const baseUrl = import.meta.env.BASE_URL;
+
+// Google Analytics 4 — fires ONLY on production builds for mcp.wyre.ai.
+// Property G-V3W6M1YEHL matches wyre.ai + conduit.wyre.ai + conduit /docs for
+// cross-property aggregation under one WYRE measurement ID.
+//
+// Dual-gate is intentional: the default SITE_URL in astro.config.mjs is
+// 'https://mcp.wyre.ai', so a SITE-only check would also match local dev
+// (no env vars). The PROD check excludes:
+//   - local dev / preview (PROD=false)
+// The SITE check excludes:
+//   - GitHub Pages build (SITE_URL=https://wyre-technology.github.io)
+// Net: GA only loads on the mcp.wyre.ai Docker build that ships to production.
+//
+// If you widen this gate (e.g. add staging), pair the change with a brief
+// audit of where reports get tagged — same property serves multiple sites.
+const enableGA = import.meta.env.PROD && import.meta.env.SITE === 'https://mcp.wyre.ai';
 ---
 
 <!DOCTYPE html>
@@ -56,6 +72,25 @@ const baseUrl = import.meta.env.BASE_URL;
       ogType={ogType}
       twitterCard={twitterCard}
     />
+    {enableGA && (
+      <Fragment>
+        {/*
+          gtag.js is intentionally loaded WITHOUT Subresource Integrity:
+          Google continuously regenerates this script to reflect property
+          configuration changes and never publishes integrity hashes for it,
+          so pinning SRI would break GA on every silent upstream update.
+          Trust model is googletagmanager.com TLS + the published canonical
+          snippet (matches Angela's wyre.ai/conduit installs).
+        */}
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-V3W6M1YEHL"></script>
+        <script is:inline>
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', 'G-V3W6M1YEHL');
+        </script>
+      </Fragment>
+    )}
     <script is:inline>
       // Dark mode toggle
       const theme = localStorage.getItem('theme') ||


### PR DESCRIPTION
## GA4 install — `mcp.wyre.ai` docs only (env-gated)

Wires GA4 (`G-V3W6M1YEHL` — same property as wyre.ai + conduit.wyre.ai + conduit /docs) into `msp-claude-plugins/docs/src/layouts/BaseLayout.astro`. Per Aaron's D6 ruling, the install is **env-gated to production builds for `https://mcp.wyre.ai` only**.

> ⛔ **DRAFT / DO NOT MERGE until Aaron's explicit approval + after mcp-gateway PR #190 (staging-gate) is merged and the gate is live.** Same gating convention as PRs #189 / #194.

### Gate
```ts
const enableGA = import.meta.env.PROD && import.meta.env.SITE === 'https://mcp.wyre.ai';
```

Dual-gate is intentional. The default `SITE_URL` in this repo's `astro.config.mjs` is `'https://mcp.wyre.ai'`, so a SITE-only check would also match local dev. The `PROD` half excludes dev/preview; the `SITE` half excludes the GitHub Pages preview build (`SITE_URL=https://wyre-technology.github.io`).

| Build                                  | `PROD` | `SITE`                                  | GA fires? |
| -------------------------------------- | ------ | --------------------------------------- | :-------: |
| `npm run dev` (no envs)                | false  | `https://mcp.wyre.ai` (default)         |     ❌     |
| `npm run preview` (no envs)            | true   | `https://mcp.wyre.ai` (default)         |     ❌ ¹   |
| GitHub Pages build (`SITE_URL` set)    | true   | `https://wyre-technology.github.io`     |     ❌     |
| **gateway Docker build (production)**  | true   | `https://mcp.wyre.ai`                   |   **✅**   |

¹ Note: `astro preview` runs the production build locally, so `PROD=true` there. Since `SITE` would still be `https://mcp.wyre.ai` by default, *technically* GA would fire on a local `astro preview` with no envs — but `astro preview` is a development tool not a deployed surface, and adding a third gate for it would be over-engineering. If this becomes a concern, document it for the rollback playbook.

### Where it lives
- File: `msp-claude-plugins/docs/src/layouts/BaseLayout.astro` (the existing root wrapper used by every page).
- Injection point: inside `<head>`, after `<SEOHead>`, before the dark-mode inline script. Renders nothing when `enableGA` is false (the `<Fragment>` evaluates to empty).

### Subresource Integrity — intentionally not used
`gtag.js` is loaded without SRI. Google continuously regenerates that script to reflect property-configuration changes and does not publish integrity hashes for it, so pinning SRI would break GA on every upstream update. Trust model is `googletagmanager.com` TLS + the published canonical snippet — matches Angela's `wyre.ai` / `conduit.wyre.ai` / `conduit /docs` installs. Inline justifying comment in `BaseLayout.astro` so the next maintainer sees the reasoning.

### CSP
None present in this repo — confirmed by grep across the docs/ tree. No policy update needed; the original task's "if no CSP, skip" branch applies.

### Build verification
`npx astro build` runs clean locally — 106 pages built in 1.08s. No type errors. The conditional renders nothing in the non-prod / non-mcp.wyre.ai paths; HTML diff verified by inspecting `dist/` (no gtag in the GH-Pages-style build).

### Scope discipline
- Single-purpose. Only `src/layouts/BaseLayout.astro` is touched.
- No `astro.config.mjs` change. No new dependency. No CSP addition (none existed).
- Other modifications in the working tree (`public/og-image.png`) are pre-existing WIP and **not** included in this PR.

### Sequencing
This PR rides behind mcp-gateway PR #190 (forge staging-gate). It is NOT to be merged before #190 lands and the gate is live, per the cadre's PR-as-gate convention.