### PR TITLE
docs(cipp): point CIPP_BASE_URL at the Azure Function App, not the SWA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `cipp` plugin docs pointed `CIPP_BASE_URL` at the Static Web App / custom-domain UI URL (`https://cipp.yourdomain.com`). The SWA redirects bearer-token requests to its interactive login page, so API calls fail. The README setup steps and `.env.example` now use the CIPP-API Azure Function App URL (`https://<function-app-name>.azurewebsites.net`) and explain the distinction
 - Gateway URL drift: flipped `blackpoint`, `crewhu`, `immybot`, `timezest`, `threatlocker` plugin READMEs and `.mcp.json` files from `mcp.wyretechnology.com` to canonical `mcp.wyre.ai` (closes #73)
 
 ### Added

--- a/msp-claude-plugins/cipp/cipp/.env.example
+++ b/msp-claude-plugins/cipp/cipp/.env.example
@@ -1,7 +1,11 @@
 # CIPP MCP Server Configuration
 # Server: https://github.com/wyre-technology/cipp-mcp
 
-CIPP_BASE_URL=https://cipp.yourdomain.com
+# Must be the CIPP-API Azure Function App URL
+# (https://<function-app-name>.azurewebsites.net), NOT the Static Web App /
+# custom-domain UI URL (e.g. https://cipp.yourdomain.com). The SWA redirects
+# bearer-token requests to its interactive login page, so API calls fail.
+CIPP_BASE_URL=https://cippXXXXX.azurewebsites.net
 
 # --- Authentication (choose ONE) -------------------------------------------
 #

--- a/msp-claude-plugins/cipp/cipp/README.md
+++ b/msp-claude-plugins/cipp/cipp/README.md
@@ -37,6 +37,7 @@ This plugin orients Claude around the [`cipp-mcp`](https://github.com/wyre-techn
 1. Stand up the [cipp-mcp](https://github.com/wyre-technology/cipp-mcp) server (Docker, npx, or Smithery).
 2. Issue API credentials in CIPP at **Settings → API Client Management**.
 3. Copy `.env.example` to `.env` and fill in `CIPP_BASE_URL` plus either a bearer token or OAuth client-credentials.
+   `CIPP_BASE_URL` must be the CIPP-API **Azure Function App** URL (`https://<function-app-name>.azurewebsites.net`, named like `cippXXXXX` in your CIPP resource group) — **not** the Static Web App / custom-domain UI URL. The SWA redirects bearer-token requests to its interactive login page, so API calls fail.
 4. Add the cipp-mcp server to your Claude config (Desktop, Code, or via the Wyre MCP Gateway).
 
 ## Authentication options


### PR DESCRIPTION
## Summary

The CIPP plugin's setup docs pointed `CIPP_BASE_URL` at the Static Web App / custom-domain UI URL (`https://cipp.yourdomain.com`). The SWA's built-in auth intercepts bearer-token requests and 302s them to `/.auth/login/aad`, so every API call fails.

External API clients must hit the CIPP-API **Azure Function App** URL directly (`https://<function-app-name>.azurewebsites.net`).

## Changes

- `cipp/cipp/README.md` — setup step 3 now spells out Function-App-vs-SWA and where to find the Function App URL
- `cipp/cipp/.env.example` — corrected example URL + explanatory comment
- `CHANGELOG.md` — entry under Unreleased → Fixed

Companion to wyre-technology/cipp-mcp#40; matches the guidance in `mcp-gateway/docs/vendors/cipp.md`.