### PR TITLE
docs(mcp-servers): full category list + remove AFKBot + h1/h2 anchor IDs

### DIFF
--- a/msp-claude-plugins/docs/src/data/mcp-servers.ts
+++ b/msp-claude-plugins/docs/src/data/mcp-servers.ts
@@ -1349,35 +1349,6 @@ export const mcpServers: McpServer[] = [
     mcpbAvailable: true,
   },
   {
-    id: 'afkbot',
-    name: 'AFKBot MCP',
-    npmPackage: '@wyre-technology/afkbot-mcp',
-    description: 'MCP server for AFKBot PTO management — file time-off requests and query PTO history from any MCP client.',
-    category: 'psa',
-    repoUrl: 'https://github.com/wyre-technology/afkbot-mcp',
-    envVars: [
-      { name: 'AZURE_TENANT_ID', required: true, description: 'Azure AD tenant ID for AFKBot Easy Auth' },
-      { name: 'AZURE_CLIENT_ID', required: true, description: 'MCP server app registration client ID' },
-      { name: 'AZURE_CLIENT_SECRET', required: true, description: 'MCP server app registration client secret' },
-      { name: 'AFKBOT_API_URL', required: false, description: 'AFKBot API URL (defaults to production)' },
-      { name: 'AFKBOT_APP_CLIENT_ID', required: false, description: 'AFKBot Easy Auth client ID (defaults to production)' }
-    ],
-    domains: [
-      {
-        name: 'PTO Requests',
-        description: 'File and query time-off requests.',
-        tools: [
-          { name: 'create_pto_request', description: 'File a new PTO request (full-day or partial-day) for an employee' },
-          { name: 'list_pto_requests', description: 'List PTO requests with optional status / employee / limit filters' }
-        ]
-      }
-    ],
-    architecture: 'Single TypeScript MCP server using Azure AD client-credentials flow to authenticate against AFKBot Easy Auth.',
-    installCommand: 'npx @wyre-technology/afkbot-mcp',
-    dockerAvailable: true,
-    mcpbAvailable: true,
-  },
-  {
     id: 'avanan',
     name: 'Avanan MCP',
     npmPackage: '@wyre-technology/avanan-mcp',

--- a/msp-claude-plugins/docs/src/pages/mcp-servers/index.astro
+++ b/msp-claude-plugins/docs/src/pages/mcp-servers/index.astro
@@ -5,18 +5,22 @@ import { mcpServers, getMcpServersByCategory } from '@/data/mcp-servers';
 
 const psaServers = getMcpServersByCategory('psa');
 const rmmServers = getMcpServersByCategory('rmm');
+const securityServers = getMcpServersByCategory('security');
 const docServers = getMcpServersByCategory('documentation');
+const accountingServers = getMcpServersByCategory('accounting');
+const networkServers = getMcpServersByCategory('network');
+const salesServers = getMcpServersByCategory('sales');
 ---
 
 <DocsLayout title="MCP Servers">
-  <h1>MCP Servers</h1>
+  <h1 id="mcp-servers">MCP Servers</h1>
 
   <p class="lead text-lg text-[var(--muted)] mb-8">
     Browse all {mcpServers.length} MCP servers for MSP platforms. Each server gives Claude
     direct API access to your tools via the Model Context Protocol.
   </p>
 
-  <h2>PSA Platforms ({psaServers.length})</h2>
+  <h2 id="psa">PSA Platforms ({psaServers.length})</h2>
 
   <p>Professional Services Automation servers for ticket management, CRM, and billing.</p>
 
@@ -26,7 +30,7 @@ const docServers = getMcpServersByCategory('documentation');
     ))}
   </div>
 
-  <h2>RMM Platforms ({rmmServers.length})</h2>
+  <h2 id="rmm">RMM Platforms ({rmmServers.length})</h2>
 
   <p>Remote Monitoring and Management servers for device management and automation.</p>
 
@@ -36,7 +40,17 @@ const docServers = getMcpServersByCategory('documentation');
     ))}
   </div>
 
-  <h2>Documentation Platforms ({docServers.length})</h2>
+  <h2 id="security">Security Platforms ({securityServers.length})</h2>
+
+  <p>Email security, EDR, threat intelligence, incident management, and phishing-defense servers for protecting customer environments.</p>
+
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-6 not-prose my-6">
+    {securityServers.map(server => (
+      <McpServerCard server={server} />
+    ))}
+  </div>
+
+  <h2 id="documentation">Documentation Platforms ({docServers.length})</h2>
 
   <p>Documentation and knowledge base servers for asset tracking and password management.</p>
 
@@ -46,7 +60,37 @@ const docServers = getMcpServersByCategory('documentation');
     ))}
   </div>
 
-  <h2>All MCP Servers at a Glance</h2>
+  <h2 id="accounting">Accounting Platforms ({accountingServers.length})</h2>
+
+  <p>Accounting and financial-operations servers for invoicing, reporting, and revenue reconciliation.</p>
+
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-6 not-prose my-6">
+    {accountingServers.map(server => (
+      <McpServerCard server={server} />
+    ))}
+  </div>
+
+  <h2 id="network">Network Platforms ({networkServers.length})</h2>
+
+  <p>Network monitoring and management servers for device visibility, topology, and uptime.</p>
+
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-6 not-prose my-6">
+    {networkServers.map(server => (
+      <McpServerCard server={server} />
+    ))}
+  </div>
+
+  <h2 id="sales">Sales Platforms ({salesServers.length})</h2>
+
+  <p>Sales pipeline, quoting, and partner-management servers for revenue operations.</p>
+
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-6 not-prose my-6">
+    {salesServers.map(server => (
+      <McpServerCard server={server} />
+    ))}
+  </div>
+
+  <h2 id="all-servers-at-a-glance">All MCP Servers at a Glance</h2>
 
   <table>
     <thead>


### PR DESCRIPTION
## Summary

Aaron-urgent customer-facing page fix for `mcp.wyre.ai/mcp-servers/`.

**3 changes:**

1. **ADD detailed sections for Security (11) / Accounting (2) / Network (1) / Sales (2)** — mirrors existing PSA/RMM/Documentation block pattern. Order: PSA → RMM → Security → Documentation → Accounting → Network → Sales. All 7 categories now browsable; previously 16 servers across 4 categories appeared only in the glance table.

2. **REMOVE AFKBot** from `docs/src/data/mcp-servers.ts`. Drops it from the PSA section + glance table + detail page. Server count goes **29 → 28**.

3. **ANCHOR IDs** on h1 + every category h2 + glance h2:
   - `id="mcp-servers"` (h1)
   - `id="psa" / "rmm" / "security" / "documentation" / "accounting" / "network" / "sales"` (each category h2)
   - `id="all-servers-at-a-glance"` (glance h2)

   Enables deep-linking per Aaron's explicit ask.

## Test plan

- [x] npm install + astro build clean locally (132 pages, 6s)
- [x] Rendered `dist/mcp-servers/index.html` verified:
  - 9 anchor IDs present
  - Zero AFKBot mentions
  - All 7 category h2s rendered with correct counts: security=11, accounting=2, network=1, sales=2
- [ ] CI build green
- [ ] Post-merge: trigger gateway `release.yml` (workflow_dispatch) to bake docs into new gateway image
- [ ] Aaron decides on prod-promote (HELD per boss's coordination — second promote of day after auth-fix caca015)

## Context

- Deploy path verified: docs are baked into the gateway Docker image at build time (`Dockerfile` Stage 1). Updating the live page therefore requires gateway image rebuild + prod promote.
- Risk frame confirmed: gateway main since caca015 = single commit (`1c1532d` docs/vendors/cipp.md hostname fix, +1/-1 line, pure docs change). Auth-fix preserved; docs-only delta.