### PR TITLE
chore(brand): product-brand "WYRE Technology" → "WYRE AI" (WYREAI-196)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for our tiered contribution guide.
 
 ## Community
 
-This project is maintained by [WYRE Technology](https://wyretechnology.com), a Chattanooga-based
+This project is maintained by [WYRE AI](https://wyretechnology.com), a Chattanooga-based
 MSP focused on AI enablement.
 
 - **Questions or feedback?** Open a [Discussion](https://github.com/wyre-technology/msp-claude-plugins/discussions)

--- a/msp-claude-plugins/alternative-payments/alternative-payments/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/alternative-payments/alternative-payments/.claude-plugin/plugin.json
@@ -1,9 +1,9 @@
 {
   "name": "alternative-payments",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Claude plugins for Alternative Payments - customers, invoices, payment requests, transactions, payouts, and webhooks",
   "author": {
-    "name": "WYRE Technology"
+    "name": "WYRE AI"
   },
   "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
   "repository": "https://github.com/wyre-technology/msp-claude-plugins",

--- a/msp-claude-plugins/blackpoint/blackpoint/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/blackpoint/blackpoint/.claude-plugin/plugin.json
@@ -1,9 +1,9 @@
 {
   "name": "blackpoint",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Blackpoint Cyber / CompassOne MDR - tenant, asset, detection, and vulnerability data for MSP incident response",
   "author": {
-    "name": "WYRE Technology"
+    "name": "WYRE AI"
   },
   "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
   "repository": "https://github.com/wyre-technology/msp-claude-plugins",

--- a/msp-claude-plugins/crewhu/crewhu/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/crewhu/crewhu/.claude-plugin/plugin.json
@@ -1,9 +1,9 @@
 {
   "name": "crewhu",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Crewhu - CSAT/NPS surveys, employee recognition, badges, and prize/redemption gamification for MSPs",
   "author": {
-    "name": "WYRE Technology"
+    "name": "WYRE AI"
   },
   "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
   "repository": "https://github.com/wyre-technology/msp-claude-plugins",

--- a/msp-claude-plugins/docs/public/llms.txt
+++ b/msp-claude-plugins/docs/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Connect your MSP tools to Claude AI via the Model Context Protocol (MCP). 24 plugins covering Autotask, ConnectWise, Datto RMM, NinjaOne, IT Glue, and more.
 
-MSP Claude Plugins is a free, open-source collection of integrations that connect Managed Service Provider (MSP) platforms to Claude via the Model Context Protocol (MCP). It is built and maintained by WYRE Technology.
+MSP Claude Plugins is a free, open-source collection of integrations that connect Managed Service Provider (MSP) platforms to Claude via the Model Context Protocol (MCP). It is built and maintained by WYRE AI.
 
 ## What it does
 

--- a/msp-claude-plugins/freshdesk/freshdesk/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/freshdesk/freshdesk/.claude-plugin/plugin.json
@@ -1,9 +1,9 @@
 {
   "name": "freshdesk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Freshdesk - cloud helpdesk/PSA ticketing for MSPs: tickets, conversations, contacts, companies, knowledge base, SLA policies, and business hours",
   "author": {
-    "name": "WYRE Technology"
+    "name": "WYRE AI"
   },
   "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
   "repository": "https://github.com/wyre-technology/msp-claude-plugins",

--- a/msp-claude-plugins/immybot/immybot/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/immybot/immybot/.claude-plugin/plugin.json
@@ -1,9 +1,9 @@
 {
   "name": "immybot",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "ImmyBot - desired-state Windows software deployment, maintenance sessions, and script execution for MSPs (Entra ID OAuth)",
   "author": {
-    "name": "WYRE Technology"
+    "name": "WYRE AI"
   },
   "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
   "repository": "https://github.com/wyre-technology/msp-claude-plugins",

--- a/msp-claude-plugins/inforcer/inforcer/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/inforcer/inforcer/.claude-plugin/plugin.json
@@ -1,9 +1,9 @@
 {
   "name": "inforcer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Inforcer - read-only Microsoft 365 security baseline governance for MSPs: tenants, baselines, alignment/drift, secure scores, identity inventory, audit events, and assessments",
   "author": {
-    "name": "WYRE Technology"
+    "name": "WYRE AI"
   },
   "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
   "repository": "https://github.com/wyre-technology/msp-claude-plugins",

--- a/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "kaseya-quote-manager",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Kaseya Quote Manager (Datto Commerce) - read-only access to quotes, sales orders, purchasing, catalog, CRM, and org data",
   "author": {
-    "name": "WYRE Technology"
+    "name": "WYRE AI"
   }
 }

--- a/msp-claude-plugins/saas-alerts/saas-alerts/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/saas-alerts/saas-alerts/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "saas-alerts",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "SaaS Alerts - SaaS security monitoring and alerting for M365 / Google Workspace: alerts, events, anomaly detection, and multi-tenant response",
-  "author": { "name": "WYRE Technology" },
+  "author": { "name": "WYRE AI" },
   "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
   "repository": "https://github.com/wyre-technology/msp-claude-plugins",
   "license": "Apache-2.0"

--- a/msp-claude-plugins/timezest/timezest/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/timezest/timezest/.claude-plugin/plugin.json
@@ -1,9 +1,9 @@
 {
   "name": "timezest",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "TimeZest - tech scheduling and appointment booking against ConnectWise / Autotask / Halo PSA tickets for MSPs",
   "author": {
-    "name": "WYRE Technology"
+    "name": "WYRE AI"
   },
   "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
   "repository": "https://github.com/wyre-technology/msp-claude-plugins",


### PR DESCRIPTION
Agents-ops lane of **WYREAI-196** (product-brand rebrand). Product-brand-only swap per Aaron's 2026-06-30 ruling — *"WYRE.AI isn't a legal entity...yet"*, so legal-entity strings stay. Sibling conduit `src/` lane = wh-gateway PR #583. **Branch-only; Aaron merges.**

### Swapped → "WYRE AI" (11 refs / 11 files — product-brand / maintainer / marketplace display)
- `README.md:211` maintainer credit (kept `wyretechnology.com` URL — no confirmed domain migration, matches gateway)
- `docs/public/llms.txt:5` "built and maintained by" line
- 9 `plugin.json` author fields: alternative-payments, blackpoint, crewhu, freshdesk, immybot, inforcer, kaseya-quote-manager, saas-alerts, timezest

### Held as "WYRE Technology" — flagged for Aaron's keep/flip call
Legal/policy + copyright surfaces, held to mirror wh-gateway's conduit `legal.ts` hold:
- `docs/src/pages/terms.astro:8` + `privacy.astro:8` page titles; `privacy.astro:47` body ("WYRE Technology staff")
- `docs/src/components/Footer.astro:70` `©` copyright line

### Out of scope (internal, non-distribution)
- 13 PRD `**Author:** Aaron / WYRE Technology` bylines
- 2 `.taskmaster/tasks.json` codegen templates (unrelated npm libs)

### Gates
- No `WYRE Technology, LLC` string exists anywhere in this repo (nothing at legal-entity risk)
- All 9 `plugin.json` re-validated as parseable JSON
- Zero `.astro` files changed → docs build unaffected; no brand-test suite in this repo
- `marketplace.json` carries no author names → no plugin↔marketplace drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)