### PR TITLE
ci: hard-fail per-plugin validation now that #137 landed

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,12 +37,10 @@ jobs:
           fi
 
       # Per-plugin validation checks skill/agent/command frontmatter, which
-      # root validation does not. Advisory until the repo-wide frontmatter
-      # cleanup lands (45/63 plugins currently fail on pre-existing agent
-      # frontmatter YAML). TODO: drop continue-on-error once that cleanup
-      # merges, then add --strict once warnings hit zero.
-      - name: Validate each plugin (advisory)
-        continue-on-error: true
+      # root validation does not. Hard-failing since #137 landed the repo-wide
+      # frontmatter cleanup (63/63 plugins pass). TODO: add --strict once
+      # warnings hit zero.
+      - name: Validate each plugin
         run: |
           fail=0
           for dir in $(node -e "require('./.claude-plugin/marketplace.json').plugins.forEach(p=>console.log(p.source.replace('./','')))"); do


### PR DESCRIPTION
Promised follow-up from #136/#137: the per-plugin `claude plugin validate` loop goes from advisory (`continue-on-error`) to hard-fail — #137 fixed the 45/63 pre-existing agent-YAML failures and the full loop now passes 63/63. `--strict` remains a TODO for when warnings hit zero.