### PR TITLE
docs(wyre-site-editor): sync README with pricing.json unlock

### DIFF
--- a/msp-claude-plugins/wyre-site-editor/wyre-site-editor/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/wyre-site-editor/wyre-site-editor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wyre-site-editor",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Edit wyre.ai site content conversationally — change copy, preview it on a live URL, and publish safely, without touching git or a CMS",
   "author": {
     "name": "WYRE Technology"

--- a/msp-claude-plugins/wyre-site-editor/wyre-site-editor/README.md
+++ b/msp-claude-plugins/wyre-site-editor/wyre-site-editor/README.md
@@ -8,16 +8,18 @@ publishes only when you say so. No git, no CMS login, no code.
 
 - "Change the homepage headline to *AI that ships*"
 - "Update the second service card's blurb"
+- "Update the pricing page FAQ answer about usage caps"
 - "Show me a preview" → clickable link to a live draft of the site
 - "Publish it" → the change goes live (after you've seen the preview)
 
 ## What's editable
 
-Homepage copy (hero + contact) and the five service cards, per the site's
-content contract (`docs/decap-content-contract.md` in
+Homepage copy (hero + contact), the five service cards, and pricing page
+copy (hero + FAQ), per the site's content contract
+(`docs/decap-content-contract.md` in
 [`wyre-technology/wyre-ai`](https://github.com/wyre-technology/wyre-ai)).
-Pricing copy/FAQ and features cards are planned next. Pricing **dollar
-amounts** are never editable here — they sync from the billing system.
+Features cards are planned next. Pricing **dollar amounts** are never
+editable here — they sync from the billing system.
 
 ## Safety model
 


### PR DESCRIPTION
## Summary
- #146 unlocked `src/data/pricing.json` (pricing hero + FAQ) in the `site-editing` skill but didn't touch README.md — it still said "Pricing copy/FAQ ... planned next", which would contradict Aaron's planned Angela-plugin Slack announcement.
- Updates the "what's editable" line and adds a pricing example to "what you can do".
- Bumps plugin.json 1.0.1 -> 1.0.2 for the bump gate.

## Test plan
- [x] `node scripts/check-marketplace-drift.mjs --base origin/main` — pass (71 entries)
- [x] `claude plugin validate .` + per-plugin validate — pass
- [ ] gh pr checks (confirming on the live PR before reporting green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)