### PR TITLE
docs(troubleshooting): publish the gateway's egress IP for vendor firewall allowlists

### DIFF
--- a/msp-claude-plugins/docs/src/pages/getting-started/troubleshooting.astro
+++ b/msp-claude-plugins/docs/src/pages/getting-started/troubleshooting.astro
@@ -145,6 +145,57 @@ const baseUrl = import.meta.env.BASE_URL;
 
   <hr class="my-8" />
 
+  <h2 id="egress-ip">Vendor tool calls time out after enabling IP restrictions</h2>
+  <p>
+    If your vendor restricts API access to an allowlist of source IP addresses — IT Glue, Autotask,
+    Kaseya VSA, and CIPP all support this — you need to allow the address WYRE's traffic arrives from.
+  </p>
+
+  <p>
+    Every request the WYRE Hosted Gateway makes to a vendor API leaves from a single static IP:
+  </p>
+
+  <pre><code>52.252.116.6</code></pre>
+
+  <p>
+    Add it as <code>52.252.116.6/32</code>. That's the only address you need — there's no range and no
+    secondary IP, and it covers every vendor integration, so you allowlist it once rather than per-vendor.
+    The address is static and doesn't rotate; if we ever need to change it, we'll contact you first.
+  </p>
+
+  <h3>Symptoms</h3>
+  <ul>
+    <li>
+      <strong>Connecting works, but every tool call hangs for ~30 seconds and times out.</strong> This is the
+      signature symptom. Autotask and Kaseya VSA <em>silently drop</em> requests from unapproved IPs — no
+      <code>403</code>, no error message, just a timeout.
+    </li>
+    <li>
+      Tool discovery succeeds but tool calls fail — discovery often doesn't touch the vendor API, so it can
+      pass while every real call is blocked.
+    </li>
+    <li>A flat <code>403</code> on every call, from the more polite vendors.</li>
+  </ul>
+
+  <h3>Fix</h3>
+  <ol>
+    <li>Add <code>52.252.116.6/32</code> to the vendor's API IP allowlist (in Autotask and Kaseya VSA, this is set on the API <em>user</em>, not the account).</li>
+    <li>Retry a tool call — the change usually takes effect immediately.</li>
+    <li>
+      To confirm it's correct, open a recent gateway-originated request in your vendor's audit log and check
+      the source IP reads <code>52.252.116.6</code>. That's the same address the vendor's firewall evaluates.
+    </li>
+  </ol>
+
+  <p class="text-sm text-[var(--muted)]">
+    Note: don't allowlist the gateway's <em>inbound</em> address (<code>132.196.176.48</code>). That's for traffic
+    <em>to</em> the gateway and is never what a vendor's firewall sees. Mixing these up is the most common
+    mistake here, and it fails exactly like a missing allowlist entry. Running your own gateway rather than the
+    hosted service? Your egress IP is whatever your own infrastructure uses — not this address.
+  </p>
+
+  <hr class="my-8" />
+
   <h2 id="triage-with-claude">Triage with Claude (the <code>wyre-gateway-troubleshooting</code> skill)</h2>
   <p>
     If you'd rather not walk through this page yourself, the WYRE skill set includes a


### PR DESCRIPTION
## Why

Customers whose vendors enforce IP restrictions — IT Glue, Autotask, Kaseya VSA, CIPP all support this — need to know the address WYRE's traffic arrives from. **The public docs have never stated it**, so the question arrives as a support email. One did exactly that on 2026-07-16, connecting IT Glue:

> *"We are trying to connect our Wyre Hosted Gateway Pro to IT Glue but we have IP restrictions in place and are unable to locate your public IP addresses of the Gateway?"*

This is a self-serve answer that shouldn't need a human.

## What

A new `#egress-ip` section on `getting-started/troubleshooting`:

- **The address** — `52.252.116.6/32`. Static, covers every vendor integration, so it's allowlisted once rather than per-vendor.
- **The signature symptom** — connect succeeds, then every tool call hangs ~30s and times out. Autotask and Kaseya VSA *silently drop* unapproved IPs rather than returning a `403`, so it doesn't look like an auth problem at all.
- **The egress-vs-ingress trap** — `132.196.176.48` is inbound-only. Allowlisting it fails identically to having no entry, which makes it a nasty way to lose an afternoon.
- **Self-verification** — check the vendor's own audit log, which records the source IP the vendor's firewall actually evaluated.

Placed under troubleshooting because that's where people land once it's already broken. It's a section rather than a new page, so no `Sidebar.astro` change is needed.

## Verification

Real `astro build`, not just a syntax check:

```
[build] 150 page(s) built in 1.78s
[build] Complete!
```

Confirmed the section renders into `dist/getting-started/troubleshooting/index.html` at `#egress-ip`, with the address and the ingress caveat present.

(Note: `npm ci` can't complete on my machine — `sharp` has no prebuilt binary for this toolchain and falls back to node-gyp. I installed with `--ignore-scripts` and ran `astro build` directly, skipping only the `sharp`-dependent OG-image prebuild step. That step is untouched by this PR.)

## Related

- wyre-technology/mcp-gateway#347 — codifies the egress network in IaC (it was hand-clicked, with nothing preventing deletion of the IP) and fixes vendor docs that told readers to look the address up via a command returning ~350 wrong IPs.
- wyre-technology/conduit#1005 — conduit has **no** stable egress IP and can't offer one without an environment rebuild.