### PR TITLE
fix(sentinelone): replace curl|sh installer one-liner with docs reference

### DIFF
--- a/msp-claude-plugins/sentinelone/sentinelone/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/sentinelone/sentinelone/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinelone",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Claude plugins for SentinelOne XDR - threat detection, incident response, and endpoint agent management via the Purple AI MCP server",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/sentinelone/sentinelone/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/sentinelone/sentinelone/skills/api-patterns/SKILL.md
@@ -84,10 +84,11 @@ The Purple MCP server supports three transport modes:
 
 The Purple MCP server requires Python and `uv`/`uvx`:
 
-```bash
-# Install uv (Python package manager)
-curl -LsSf https://astral.sh/uv/install.sh | sh
+Install `uv` (Python package manager) following the official
+instructions at https://docs.astral.sh/uv/getting-started/installation/
+(e.g. `pip install uv`, or your OS package manager).
 
+```bash
 # Verify installation
 uvx --version
 


### PR DESCRIPTION
The api-patterns skill's uv install instruction (curl -LsSf ... | sh) is a
genuine curl-pipe-to-shell — exactly what Conduit's skill scanner red-grades,
so the skill has been stored disabled in the gateway catalog on every sync.
Point at the official install docs (verified live) and pip instead; the
verify/test commands are unchanged.
