### PR TITLE
docs(email-security): anti-triggers and governance for email-security plugins

### DIFF
--- a/msp-claude-plugins/email-security/checkpoint-avanan/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/email-security/checkpoint-avanan/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "checkpoint-avanan",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Claude plugins for Checkpoint Harmony Email & Collaboration (Avanan) - email security, anti-phishing, threat detection, quarantine management",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/email-security/checkpoint-avanan/GOVERNANCE.md
+++ b/msp-claude-plugins/email-security/checkpoint-avanan/GOVERNANCE.md
@@ -1,0 +1,141 @@
+# Checkpoint Harmony Email (Avanan) plugin — governance and safety model
+
+Unofficial. Community-built plugin for the Checkpoint Harmony Email &
+Collaboration API. Not affiliated with, endorsed by, or sponsored by
+the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches Harmony Email through
+the WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which
+brokers authentication centrally and scopes every call to the tenant the
+operator is authorised for.
+
+- No Checkpoint client ID, access key, or bearer token is stored on the
+  technician's machine, in this repo, or in the model's context.
+- Credential rotation happens once at the gateway, not per technician.
+  Harmony Email tokens expire hourly; the gateway handles the refresh.
+- Every call carries operator identity, so the gateway audit log answers
+  "who released that message" — Harmony Email's own log records only the
+  API application, and the `releasedBy` field on a quarantine entry will
+  show the shared integration account for every release.
+- Revoking gateway access revokes Harmony Email access with it,
+  immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change Harmony Email state or mail flow. Safe for autonomous agents. | `avanan_quarantine_list`, `avanan_quarantine_get`, `avanan_quarantine_search`, `avanan_quarantine_stats`, `avanan_threats_list`, `avanan_threats_get`, `avanan_threats_iocs`, `avanan_threats_timeline`, `avanan_threats_search`, `avanan_threats_stats`, `avanan_incidents_list`, `avanan_incidents_get`, `avanan_incidents_list_notes`, `avanan_incidents_timeline`, `avanan_incidents_stats`, `avanan_policies_list`, `avanan_policies_get`, `avanan_allow_list_get`, `avanan_block_list_get` |
+| **Write** | Creates or annotates case records. Does not touch mail or detection behaviour. | `avanan_incidents_create`, `avanan_incidents_update`, `avanan_incidents_add_note`, `avanan_incidents_add_evidence`, `avanan_threats_mark_false_positive` |
+| **Destructive** | Delivers, destroys, or blocks customer mail, or changes what the tenant scans for. Requires explicit per-call human approval. | `avanan_quarantine_release`, `avanan_quarantine_delete`, `avanan_policies_enable`, `avanan_policies_disable`, `avanan_policies_update`, `avanan_allow_list_add`, `avanan_allow_list_remove`, `avanan_block_list_add`, `avanan_block_list_remove` |
+
+Three of those classifications are worth defending, because the API
+calls them ordinary updates:
+
+**`avanan_quarantine_release` is destructive.** Releasing is not
+un-quarantining a record — it delivers a message the security stack
+already judged malicious into a real person's inbox, and there is no
+un-deliver. When the quarantine reason is `MALWARE` or `BEC`, an
+erroneous release is the exact outcome the product exists to prevent.
+The `addToAllowList: true` parameter makes it worse: a single release
+call can also write a permanent tenant-wide detection bypass for that
+sender, so an operator approving "release this one email" may be
+approving a standing policy change they never saw.
+
+**`avanan_quarantine_delete` is destructive.** The quarantine copy is
+the only copy — the message never reached the mailbox. Deleting it
+destroys the evidence for any later investigation, and the skill's own
+error table confirms an expired or deleted entry cannot be recovered.
+
+**Every policy and list mutation is destructive.** `avanan_policies_*`
+and the allow/block list tools look like configuration edits, but their
+blast radius is the tenant's entire mail flow:
+
+- Disabling an anti-phishing or anti-malware policy silently removes a
+  detection layer for every user until someone notices.
+- Enabling a policy, or updating its action to `QUARANTINE` or `BLOCK`,
+  can bury a customer's legitimate inbound mail within minutes. This is
+  a mail-flow outage, not a settings change.
+- `avanan_allow_list_add` creates a standing bypass of every detection
+  engine for a sender or domain — the first thing an attacker wants.
+- `avanan_block_list_add` on the wrong domain silently drops a
+  customer's supplier, invoice, or payroll mail with no bounce visible
+  to the recipient.
+- The `_remove` calls are equally sharp in reverse: removing a block
+  entry re-admits a sender someone deliberately excluded.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.**
+
+- Read tools: allow. Cross-tenant quarantine triage, threat sweeps, and
+  reporting are the intended autonomous use.
+- Write tools: agent drafts the exact call, human approves, then it
+  runs.
+- Destructive tools: require a named human approver per invocation. Do
+  not grant these to scheduled or unattended agents. In particular, do
+  not give an unattended agent a standing "release false positives"
+  policy — false-positive judgement is exactly the judgement being
+  delegated.
+
+## What it cannot reach
+
+- Only the Harmony Email tenants mapped to the operator's gateway
+  identity.
+- No filesystem, no shell, no other vendor's data.
+- No mailbox. Harmony Email quarantine holds mail before delivery;
+  nothing in this plugin can reach into Microsoft 365 or Google
+  Workspace to retrieve a message that was already delivered.
+- No live event stream. Every tool is point-in-time.
+- Regional scope. A tenant provisioned in the EU or AP region is served
+  by a different API gateway; credentials for one region return
+  authentication errors against another, so a misconfigured connection
+  fails closed rather than reading the wrong tenant.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session
+  and are not persisted by this plugin.
+- **Quarantine tools return message content and correspondent PII.**
+  `avanan_quarantine_list` and `avanan_quarantine_get` include
+  `subject`, `sender`, `senderDisplayName`, the full `recipients` list,
+  `attachmentNames`, and `bodyPreview` — the first 200 characters of the
+  email body. For a DLP-quarantined outbound message, that preview is
+  by definition the sensitive content the DLP rule matched.
+- `avanan_threats_get` and `avanan_threats_iocs` return sender IP
+  addresses, recipient lists, and attachment hashes.
+- `avanan_incidents_*` records name affected users
+  (`affectedUsers`) and carry analyst notes, which routinely contain
+  account names and investigation detail.
+
+Restrict quarantine and incident reads if your agents run unattended, or
+scope them to the tenants that specific operator supports.
+
+## Known sharp edges
+
+- **Release and delete are capped at 100 entities per call.** An agent
+  splitting a 500-message action into batches is performing five
+  separate irreversible operations; a failure partway through leaves the
+  tenant in a mixed state with no transaction to roll back.
+- **Queries silently truncate.** The date range maxes at 90 days and any
+  single query returns at most 10,000 results. "Show me every threat
+  this year" returns a confident partial answer with no error. Do not
+  let an agent draw all-clear conclusions from an unbounded query.
+- **Quarantine expiry is a hard deletion.** Entries auto-delete after
+  the retention period (default 30 days) and cannot be recovered. The
+  documented way to extend retention — release and re-quarantine —
+  means briefly delivering the message.
+- **Status transitions are validated server-side.** Moving an incident
+  to `RESOLVED` without a `remediationSummary`, or to `FALSE_POSITIVE`
+  without a justification, returns a 400 that reads like a malformed
+  request rather than a missing field.
+- **A wrong region looks like a bad credential.** Pointing at the US
+  gateway for an EU-provisioned tenant returns 401, which invites an
+  agent to "fix" working credentials.
+- **Marking a threat a false positive is a security decision.**
+  `avanan_threats_mark_false_positive` sits in the write tier because it
+  changes no mail flow directly, but it feeds detection tuning. Treat a
+  pattern of agent-driven false-positive marking as a signal to review,
+  not as bookkeeping.

--- a/msp-claude-plugins/email-security/checkpoint-avanan/skills/incidents/SKILL.md
+++ b/msp-claude-plugins/email-security/checkpoint-avanan/skills/incidents/SKILL.md
@@ -19,6 +19,23 @@ when_to_use: >-
 
 Checkpoint Harmony Email & Collaboration (Avanan) provides an incident management system for tracking and investigating email security events. Incidents are created when threats require coordinated investigation and response beyond simple quarantine actions. This skill covers the full incident lifecycle from creation through investigation, remediation, and closure.
 
+## Anti-triggers
+
+- **A single detection and its indicators** — an incident groups
+  threats and carries the case metadata; the detection record itself,
+  with its URLs, hashes, and engine verdict, is
+  `checkpoint-avanan-threats`.
+- **Actually releasing or deleting the messages an incident references**
+  — `relatedQuarantineEntries` names them but the operations live in
+  `checkpoint-avanan-quarantine`.
+- **Preventing recurrence after closure** — the policy and block-list
+  changes a post-incident review recommends are
+  `checkpoint-avanan-policies`.
+- **Another vendor's incident object** — IRONSCALES is
+  `ironscales-incidents`, Abnormal calls the equivalent a case
+  (`abnormal-security-cases`), and endpoint incidents are
+  `huntress-incidents`. This skill only speaks the Harmony Email API.
+
 ## Incident Status Codes
 
 | Status ID | Name | Description | Business Logic |

--- a/msp-claude-plugins/email-security/checkpoint-avanan/skills/policies/SKILL.md
+++ b/msp-claude-plugins/email-security/checkpoint-avanan/skills/policies/SKILL.md
@@ -19,6 +19,21 @@ when_to_use: >-
 
 Checkpoint Harmony Email & Collaboration (Avanan) uses a layered policy engine to detect and respond to email threats. Policies define what gets scanned, how threats are classified, and what actions are taken when threats are detected. This skill covers policy types, configuration, enable/disable workflows, and best practices for policy tuning across managed customer tenants.
 
+## Anti-triggers
+
+- **Releasing one message, even when the release adds a sender
+  exception** — the `addToAllowList` flag on a release belongs to the
+  message workflow; use `checkpoint-avanan-quarantine`. Come here when
+  the list itself is the subject.
+- **Which policy fired on a given message** — that is recorded on the
+  quarantine entry as `policyName` and on the detection record; use
+  `checkpoint-avanan-quarantine` or `checkpoint-avanan-threats`.
+- **Another vendor's allow/block lists** — SpamTitan calls them lists
+  (`spamtitan-lists`).
+- **Microsoft 365 tenant policy** — conditional access, mailbox rules,
+  and tenant security baselines are not Harmony Email policies; use
+  `cipp-standards` or `cipp-mailboxes`.
+
 ## Policy Types
 
 | Type | Code | Description | Default Action |

--- a/msp-claude-plugins/email-security/checkpoint-avanan/skills/quarantine/SKILL.md
+++ b/msp-claude-plugins/email-security/checkpoint-avanan/skills/quarantine/SKILL.md
@@ -19,6 +19,24 @@ when_to_use: >-
 
 Checkpoint Harmony Email & Collaboration (Avanan) quarantines emails that match security policies before they reach the end user's inbox. The quarantine system is the primary interface for reviewing flagged emails, releasing false positives, and managing email flow. This skill covers comprehensive quarantine management including search, review, release workflows, bulk operations, and quarantine configuration.
 
+## Anti-triggers
+
+- **Why the message was flagged, or the IOCs inside it** — the
+  quarantine entry is the held message; the detection record that
+  produced it is a separate object with its own URLs, hashes, and
+  verdicts — use `checkpoint-avanan-threats`.
+- **Changing what gets quarantined, or curating the allow/block lists**
+  — releasing with `addToAllowList` writes a single exception; policy
+  tuning and list administration are `checkpoint-avanan-policies`.
+- **Removing a message that already reached the mailbox** — Avanan
+  quarantine holds mail pre-delivery only and has no mailbox-purge
+  tool. Post-delivery removal on a Proofpoint tenant is
+  `proofpoint-forensics` (TRAP search-and-destroy).
+- **Another vendor's quarantine** — "release from quarantine" is shared
+  vocabulary across the email-security stack. Proofpoint is
+  `proofpoint-quarantine`, SpamTitan is `spamtitan-quarantine`, and
+  Mimecast calls it the held queue: `mimecast-queue-management`.
+
 ## Quarantine Reasons
 
 Emails are quarantined based on the detection engine that flagged them:

--- a/msp-claude-plugins/email-security/checkpoint-avanan/skills/threats/SKILL.md
+++ b/msp-claude-plugins/email-security/checkpoint-avanan/skills/threats/SKILL.md
@@ -19,6 +19,22 @@ when_to_use: >-
 
 Checkpoint Harmony Email & Collaboration (Avanan) uses multiple detection engines to identify email-borne threats before they reach end users. The threat detection system covers phishing, malware, business email compromise (BEC), account takeover (ATO), and zero-day attacks. This skill covers threat types, detection engines, IOC extraction, timeline analysis, and investigation workflows.
 
+## Anti-triggers
+
+- **Acting on the held message** — this skill reads detection records
+  and never releases or deletes mail; those operations are
+  `checkpoint-avanan-quarantine`.
+- **Coordinating a response with status, assignment, and notes** — a
+  threat is one detection; the investigation container that groups
+  several of them is `checkpoint-avanan-incidents`.
+- **Changing what the engines detect or how they act** — detection
+  engine configuration and block-list entries are
+  `checkpoint-avanan-policies`.
+- **Another vendor's threat objects** — "threat", "BEC", "ATO", and
+  "IOC" are common currency across email-security vendors. Abnormal is
+  `abnormal-security-threats`, Proofpoint is `proofpoint-tap`, and
+  Mimecast is `mimecast-threat-intelligence`.
+
 ## Threat Types
 
 | Type | Code | Description | Severity Range |

--- a/msp-claude-plugins/email-security/knowbe4/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/email-security/knowbe4/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "knowbe4",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Claude plugins for KnowBe4 - security awareness training, phishing simulation, user risk management",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/email-security/knowbe4/GOVERNANCE.md
+++ b/msp-claude-plugins/email-security/knowbe4/GOVERNANCE.md
@@ -1,0 +1,123 @@
+# KnowBe4 plugin — governance and safety model
+
+Unofficial. Community-built plugin for the KnowBe4 Reporting API. Not
+affiliated with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches KnowBe4 through the
+WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the tenant the
+operator is authorised for.
+
+- No KnowBe4 API token is stored on the technician's machine, in this
+  repo, or in the model's context. This matters more than usual here:
+  a KnowBe4 token grants full read access to the entire account,
+  including every employee record, and KnowBe4 does not offer
+  per-technician tokens.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers
+  "who pulled the list of employees who failed" — KnowBe4's own logging
+  sees a single API token.
+- Revoking gateway access revokes KnowBe4 access with it, immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change KnowBe4 state. Safe for autonomous agents. | `knowbe4_phishing_list_campaigns`, `knowbe4_phishing_get_campaign`, `knowbe4_phishing_list_security_tests`, `knowbe4_phishing_get_security_test`, `knowbe4_phishing_list_recipients`, `knowbe4_phishing_get_recipient`, `knowbe4_phishing_list_templates`, `knowbe4_phishing_get_template`, `knowbe4_training_list_campaigns`, `knowbe4_training_get_campaign`, `knowbe4_training_list_enrollments`, `knowbe4_training_get_enrollment`, `knowbe4_training_list_modules`, `knowbe4_training_get_module`, `knowbe4_training_list_store_purchases`, `knowbe4_training_get_store_purchase`, `knowbe4_users_list`, `knowbe4_users_get`, `knowbe4_users_risk_score_history`, `knowbe4_users_list_events`, `knowbe4_groups_list`, `knowbe4_groups_get`, `knowbe4_groups_list_members`, `knowbe4_groups_risk_score_history`, `knowbe4_reporting_account_summary`, `knowbe4_reporting_phishing_summary`, `knowbe4_reporting_training_summary`, `knowbe4_reporting_risk_overview`, `knowbe4_reporting_ppp_trend`, `knowbe4_reporting_department_breakdown` |
+| **Write** | — | None. |
+| **Destructive** | — | None. |
+
+**This plugin is read-only.** Every tool it exposes is a GET against the
+KnowBe4 Reporting API. It cannot launch a phishing simulation, enroll a
+user in training, create or archive a user, or change a group. An agent
+using this plugin cannot send email to a customer's staff under any
+circumstances.
+
+That is a genuinely strong safety property and it is worth stating to a
+buyer plainly, because the skills in this plugin describe workflows —
+"launch campaign", "enroll failed users", "archive the user" — that a
+human performs in the KnowBe4 console. An agent can plan and recommend
+those actions; it cannot execute them. Do not read the presence of a
+workflow in a skill as evidence a tool exists for it.
+
+## Recommended agent policy
+
+Because there is no write or destructive tier, the policy reduces to a
+data-access question rather than a blast-radius one.
+
+- Read tools: allow for reporting, trend analysis, and campaign review.
+- The control that matters here is **who may read employee behavioural
+  data**, not what an agent may change. See Data handling below, and
+  consider restricting the user- and recipient-level tools while
+  leaving the aggregate reporting tools open.
+
+## What it cannot reach
+
+- Only the KnowBe4 account mapped to the operator's gateway identity.
+  KnowBe4 tokens are account-scoped; there is no reseller token that
+  spans MSP clients, so each client account is a separate connection.
+- No filesystem, no shell, no other vendor's data.
+- No mail flow. KnowBe4 is a training platform. Nothing here inspects,
+  quarantines, releases, or deletes real customer email — a real
+  phishing attack is invisible to every tool in this plugin.
+- No identity system. KnowBe4 user records are training records. This
+  plugin cannot disable an account, reset a password, or revoke a
+  session.
+- No writes at all, including no ability to correct data it reports.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session
+  and are not persisted by this plugin.
+- **This plugin's read tier carries more personal data than most
+  vendors' write tiers.** `knowbe4_users_list` and `knowbe4_users_get`
+  return a near-complete HR record for every employee: full name, work
+  email, employee number, job title, department, division, office
+  location, manager name and email, hire date, last sign-in, and custom
+  fields frequently mapped to further HR attributes.
+- **Recipient and event data is individual behavioural monitoring.**
+  `knowbe4_phishing_list_recipients` and `knowbe4_phishing_get_recipient`
+  return, per named employee, whether they opened a simulated phish,
+  whether they clicked, whether they entered credentials on the landing
+  page, the timestamp of each, plus the IP address and browser used.
+  `knowbe4_users_risk_score_history` turns that into a per-person
+  trendline.
+- In several jurisdictions this class of data is subject to
+  works-council agreement or employee-monitoring rules independent of
+  any security justification. Restrict the user, recipient, and event
+  tools for unattended agents; `knowbe4_reporting_*` answers most
+  MSP reporting questions at department granularity without naming
+  individuals.
+
+## Known sharp edges
+
+- **The daily rate limit is small and shared.** KnowBe4 allows roughly
+  1,000 requests per day per token, and under the gateway that single
+  token is shared by every technician and every agent working that
+  account. One unattended agent paginating users at the default
+  `per_page=25` can consume the whole day's budget before anyone else
+  starts. Use `per_page=500` and cache; treat a sudden 429 as "a
+  colleague's agent is looping", not as a KnowBe4 outage.
+- **A wrong region reads as "the user doesn't exist".** The account's
+  region (US, EU, CA, UK, DE) is fixed at creation and cannot be
+  changed. Querying the wrong regional base URL returns 404 for valid
+  IDs, which invites an agent to conclude a user or campaign was
+  deleted.
+- **Risk scores are stale by design.** They are recalculated
+  periodically, not in real time; allow 24–48 hours. An agent comparing
+  a risk score against an event that happened this morning is comparing
+  across a gap.
+- **Archived users remain in historical reports.** This is intentional —
+  it preserves reporting integrity — but it means headcount derived from
+  KnowBe4 will not match the customer's active-user count. Do not let an
+  agent "reconcile" licence counts from KnowBe4 data.
+- **Phish-prone percentage measures simulations, not attacks.** It is
+  routinely mistaken for a security-outcome metric in client-facing
+  reporting. A falling PPP says training is working; it says nothing
+  about how many real threats reached the tenant. That number comes from
+  the mail-security vendor, not from here.
+- **Opened counts can exceed delivered counts.** Security scanners and
+  mail-client preview panes fire the tracking pixel. An agent computing
+  an open rate above 100% has hit a known artifact, not a data error.

--- a/msp-claude-plugins/email-security/knowbe4/skills/phishing/SKILL.md
+++ b/msp-claude-plugins/email-security/knowbe4/skills/phishing/SKILL.md
@@ -18,6 +18,26 @@ when_to_use: >-
 
 KnowBe4 phishing simulations are the core mechanism for testing and improving an organization's resilience to social engineering attacks. Campaigns deliver simulated phishing emails to users and track their interactions -- whether they opened the email, clicked the link, submitted data on the landing page, reported it via the Phish Alert Button, or took no action. The phish-prone percentage is the key metric derived from these campaigns.
 
+## Anti-triggers
+
+- **A real phishing email that reached a user** — every campaign,
+  click, and "failure" here is a simulation the MSP sent on purpose.
+  Genuine inbound phishing is detected by the mail-security vendor:
+  `proofpoint-tap`, `checkpoint-avanan-threats`, or
+  `abnormal-security-threats`.
+- **Finding, releasing, or pulling a message out of a mailbox** —
+  KnowBe4 never touches production mail flow. Use
+  `proofpoint-quarantine` or `checkpoint-avanan-quarantine` to release,
+  and `proofpoint-forensics` to remove delivered mail.
+- **"Phish Alert Button" reports as a threat-intake queue** — this
+  skill counts PAB reports as a pass/fail signal on a simulation; the
+  real user-reported phishing triage queue is `ironscales-incidents`.
+- **Enrolling the users who failed into remedial training** — the
+  enrollment side is `knowbe4-training`.
+- **Organization-wide phish-prone percentage or department
+  breakdowns** — per-campaign results are here; rolled-up metrics and
+  benchmarks are `knowbe4-reporting`.
+
 ## Key Concepts
 
 ### Campaign Lifecycle

--- a/msp-claude-plugins/email-security/knowbe4/skills/reporting/SKILL.md
+++ b/msp-claude-plugins/email-security/knowbe4/skills/reporting/SKILL.md
@@ -18,6 +18,17 @@ when_to_use: >-
 
 KnowBe4 reporting provides visibility into an organization's security awareness posture through phishing simulation metrics, training completion data, and risk scores. Effective reporting translates raw data into actionable insights for security teams, management, and compliance stakeholders. This skill covers how to retrieve, interpret, and present KnowBe4 metrics.
 
+## Anti-triggers
+
+- **An "email security report" covering threats actually blocked** —
+  every metric here measures simulations and training, not real
+  attacks. Threats stopped in production are `proofpoint-tap`,
+  `checkpoint-avanan-threats`, or `abnormal-security-threats`.
+- **One campaign's results or one person's risk score** — this skill
+  returns account-, department-, and trend-level aggregates; the
+  per-object detail sits in `knowbe4-phishing`, `knowbe4-training`, or
+  `knowbe4-users`.
+
 ## Key Concepts
 
 ### Core Metrics

--- a/msp-claude-plugins/email-security/knowbe4/skills/training/SKILL.md
+++ b/msp-claude-plugins/email-security/knowbe4/skills/training/SKILL.md
@@ -17,6 +17,20 @@ when_to_use: >-
 
 KnowBe4 training campaigns deliver security awareness content to users through structured enrollment workflows. Training can be assigned manually, triggered automatically after phishing test failures, or scheduled on a recurring basis. Each campaign tracks enrollment status, completion rates, and compliance deadlines. The training content library includes interactive modules, videos, games, assessments, and policy documents.
 
+## Anti-triggers
+
+- **A bare "campaign" question** — KnowBe4 has two campaign types with
+  separate ID spaces and near-identical lifecycles. If the subject is a
+  simulated phishing test, its templates, or who clicked, it is
+  `knowbe4-phishing`; this skill covers only training campaigns and
+  enrollments.
+- **The phishing failure that triggered an auto-enrollment** — the
+  trigger is configured here, but the failure data itself is
+  `knowbe4-phishing`.
+- **Completion rates rolled up across campaigns or departments** — this
+  skill reads individual campaigns and enrollments; aggregates and
+  compliance dashboards are `knowbe4-reporting`.
+
 ## Key Concepts
 
 ### Training Campaign Lifecycle

--- a/msp-claude-plugins/email-security/knowbe4/skills/users/SKILL.md
+++ b/msp-claude-plugins/email-security/knowbe4/skills/users/SKILL.md
@@ -16,6 +16,22 @@ when_to_use: >-
 
 Users and groups are the foundation of KnowBe4's security awareness platform. Users represent individual employees who receive phishing simulations and training. Groups organize users for targeted campaign delivery, reporting segmentation, and risk analysis. Each user has a risk score calculated from their phishing test performance and training completion, providing a quantitative measure of human security risk.
 
+## Anti-triggers
+
+- **Proofpoint's user risk data** — both vendors expose a per-user
+  "risk score", but KnowBe4's is derived from simulations the MSP ran,
+  while Proofpoint's Attack Index counts real attacks aimed at that
+  person. They are not interchangeable; use `proofpoint-people` for
+  VAP, Attack Index, and top-clicker data.
+- **Per-campaign recipient rows** — a recipient belongs to a phishing
+  security test and carries that test's click and reply timestamps;
+  use `knowbe4-phishing`.
+- **Org- or department-level risk aggregates and benchmarks** — use
+  `knowbe4-reporting`.
+- **Creating, disabling, or offboarding the actual mailbox account** —
+  KnowBe4 users are training records, not identities. Microsoft 365
+  user lifecycle is `cipp-users`.
+
 ## Key Concepts
 
 ### User Lifecycle

--- a/msp-claude-plugins/email-security/proofpoint/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/email-security/proofpoint/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "proofpoint",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Claude plugins for Proofpoint Email Protection - TAP, quarantine, threat intelligence, forensics, URL defense",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/email-security/proofpoint/GOVERNANCE.md
+++ b/msp-claude-plugins/email-security/proofpoint/GOVERNANCE.md
@@ -1,0 +1,150 @@
+# Proofpoint plugin — governance and safety model
+
+Unofficial. Community-built plugin for the Proofpoint APIs (TAP SIEM,
+Quarantine, People, Forensics/TRAP, URL Defense). Not affiliated with,
+endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches Proofpoint through the
+WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the tenant the
+operator is authorised for.
+
+- No Proofpoint service principal or service secret is stored on the
+  technician's machine, in this repo, or in the model's context. The
+  secret is displayed once at creation and cannot be re-read from the
+  dashboard, which makes central custody the only sane arrangement.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers
+  "who ordered that search-and-destroy" — Proofpoint's `initiatedBy`
+  field records the service principal, which is shared.
+- Revoking gateway access revokes Proofpoint access with it,
+  immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change Proofpoint state, mail flow, or mailboxes. Safe for autonomous agents. | `proofpoint_tap_get_all_events`, `proofpoint_tap_get_messages_blocked`, `proofpoint_tap_get_messages_delivered`, `proofpoint_tap_get_clicks_permitted`, `proofpoint_tap_get_clicks_blocked`, `proofpoint_tap_get_top_clickers`, `proofpoint_quarantine_search`, `proofpoint_quarantine_list`, `proofpoint_quarantine_get`, `proofpoint_quarantine_preview`, `proofpoint_people_get_vap`, `proofpoint_people_get_top_clickers`, `proofpoint_people_get_user_risk`, `proofpoint_people_get_attack_index`, `proofpoint_people_list_vip`, `proofpoint_forensics_get_report`, `proofpoint_forensics_get_evidence`, `proofpoint_forensics_get_operation`, `proofpoint_forensics_list_operations`, `proofpoint_forensics_message_trace`, `proofpoint_forensics_auto_pull_status`, `proofpoint_forensics_get_sandbox_report`, `proofpoint_threat_get_campaign`, `proofpoint_threat_search_campaigns`, `proofpoint_threat_get_indicators`, `proofpoint_threat_search_indicators`, `proofpoint_threat_get_family`, `proofpoint_threat_get_actor`, `proofpoint_threat_get_landscape`, `proofpoint_url_decode`, `proofpoint_url_analyze`, `proofpoint_url_get_clicks`, `proofpoint_url_get_verdict`, `proofpoint_url_batch_decode` |
+| **Write** | Changes a protection setting for one user. Reversible. | `proofpoint_people_set_vip` |
+| **Destructive** | Delivers or destroys customer mail, including mail already sitting in mailboxes. Requires explicit per-call human approval. | `proofpoint_quarantine_release`, `proofpoint_quarantine_bulk_release`, `proofpoint_quarantine_delete`, `proofpoint_quarantine_bulk_delete`, `proofpoint_forensics_search_destroy` |
+
+The classifications that a reviewer might argue with:
+
+**`proofpoint_forensics_search_destroy` is the single highest-blast-radius
+tool in this plugin, and it is not a delete-by-ID call.** It takes search
+criteria — sender, subject, message ID — and applies an action to every
+matching message across every mailbox in the tenant. A criterion that is
+one field too broad ("subject contains Invoice") reaches into hundreds of
+inboxes and removes legitimate business mail. With `action=hard-delete`
+that removal is permanent and not recoverable from Deleted Items. The
+operation is also asynchronous: `matchCount` is only visible after it has
+started, so the agent learns the true scope after the damage, not before.
+Never grant this to an unattended agent, and require the approver to see
+the literal criteria and the chosen action, not a summary of them.
+
+**Releasing is destructive even though the API treats it as a state
+change.** `proofpoint_quarantine_release` delivers a message Proofpoint
+already classified as malware, phishing, or impostor into a person's
+inbox. There is no un-deliver. `proofpoint_quarantine_bulk_release`
+multiplies that across an arbitrary ID list in one call, which is exactly
+the shape of mistake an agent makes when it collects IDs from a search it
+misfiltered.
+
+**`proofpoint_quarantine_delete` destroys the only copy.** A quarantined
+message was never delivered, so the quarantine store is the sole
+artifact. Deleting it forecloses any later forensic question about the
+campaign.
+
+**`proofpoint_forensics_get_evidence` stays in the read tier, but read
+the caveat.** It changes no vendor state, so by blast radius it is read.
+What it returns is live malware: the `sample` evidence type is the
+original malicious file and `pcap` is the traffic capture from
+detonation. Retrieving one does not execute it, but it does pull a
+weaponized binary into the session and onto whatever the operator does
+with it next. Treat it as read-tier for approval purposes and handle the
+output like the malware it is.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.**
+
+- Read tools: allow. TAP polling, VAP reporting, quarantine triage, and
+  campaign correlation are the intended autonomous uses.
+- Write tools: agent drafts the exact call, human approves, then it
+  runs.
+- Destructive tools: require a named human approver per invocation, and
+  for `proofpoint_forensics_search_destroy` require the approver to
+  review the exact criteria and action string. Do not grant these to
+  scheduled or unattended agents.
+
+## What it cannot reach
+
+- Only the Proofpoint organizations mapped to the operator's gateway
+  identity. Proofpoint service credentials are scoped to a single
+  organization — each MSP client requires its own set — so there is no
+  cross-client credential that could leak one customer's mail into
+  another's session.
+- No filesystem, no shell, no other vendor's data.
+- Mailbox reach is limited to what TRAP is integrated with. If the
+  Microsoft 365 or Google Workspace connector is not configured,
+  `proofpoint_forensics_search_destroy` fails rather than silently
+  doing nothing — but it also means an operator may believe remediation
+  is available when it is not.
+- Licensing gates several surfaces. People, Threat Response, and URL
+  Defense APIs return 403 when the tenant's licence does not include
+  them; that is a licensing boundary, not a permissions bug.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session
+  and are not persisted by this plugin.
+- **`proofpoint_quarantine_preview` returns the content of a customer's
+  email.** That is its purpose — an analyst previews before releasing —
+  but it means a technician's session can contain the full body of a
+  message the recipient has never seen. Restrict it if agents run
+  unattended.
+- **`proofpoint_quarantine_search` / `_list` / `_get` return
+  correspondent PII**: sender, recipient list, subject, and reply-to for
+  every matching message.
+- **`proofpoint_people_*` returns employee records and behavioural
+  data**: name, department, job title, VIP flag, and the individual's
+  click history on malicious links. `proofpoint_people_get_top_clickers`
+  is, in effect, a ranked list of which named employees fall for
+  attacks. Handle it as employee-performance data; in some
+  jurisdictions it is subject to works-council or data-protection
+  constraints.
+- **`proofpoint_forensics_get_evidence` returns live malware samples and
+  packet captures.** See the tier note above.
+- `proofpoint_url_get_clicks` attributes clicks to named recipients with
+  IP address and user agent.
+
+## Known sharp edges
+
+- **TAP's 24-hour ceiling produces false all-clears.** The SIEM API
+  cannot look back further than 24 hours. Asked "were we hit by this
+  campaign last month", it returns an empty result set — which reads
+  like "no threats found" rather than "no data available". An agent that
+  reports all-clear from a TAP query outside the window is wrong, not
+  reassuring. Historical questions belong to `proofpoint-forensics` or
+  `proofpoint-threat-intel`.
+- **A 204 is normal.** No content means no events in the window, not a
+  failure. Agents that retry on 204 burn the rate limit.
+- **Soft-delete is not always what happens.** If a mailbox is on legal
+  hold, deletion is blocked; the operation completes with a non-zero
+  `failedCount` rather than an error. An agent that checks only
+  `status=completed` will report a remediation that partially did not
+  happen.
+- **Hard-delete requires elevated permissions and fails loudly.** A 403
+  on hard-delete tempts an agent to retry with `soft-delete` and treat
+  the result as equivalent. It is not: the message remains recoverable
+  by the user from Deleted Items.
+- **Rate limits are per-API, not per-plugin.** TAP and URL Defense allow
+  1000 requests/hour; People, Quarantine, and Forensics allow 500. A
+  polling loop tuned for TAP will exhaust the quarantine budget at twice
+  the expected rate.
+- **Campaign correlation lags.** `proofpoint_threat_get_campaign` can
+  404 for a genuinely valid campaign ID that has not been correlated
+  yet. Absence of a campaign is not evidence the threat is isolated.

--- a/msp-claude-plugins/email-security/proofpoint/skills/forensics/SKILL.md
+++ b/msp-claude-plugins/email-security/proofpoint/skills/forensics/SKILL.md
@@ -19,6 +19,20 @@ Proofpoint Forensics provides deep investigation capabilities for email-borne th
 
 TRAP integrates with Microsoft 365 and Google Workspace to move or delete messages from user mailboxes after delivery, closing the gap between detection and remediation.
 
+## Anti-triggers
+
+- **Stopping a message before it is delivered** — everything here acts
+  after delivery. Releasing or deleting mail still held pre-delivery is
+  `proofpoint-quarantine`.
+- **The threat event that prompted the investigation** — GUIDs,
+  dispositions, scores, and click records come from `proofpoint-tap`;
+  this skill starts once you already have a GUID or threat ID.
+- **Campaign attribution, actor names, and IOC context** — use
+  `proofpoint-threat-intel`.
+- **"Search and destroy" on endpoints rather than mailboxes** — TRAP
+  reaches Microsoft 365 and Google Workspace mailboxes only. Killing
+  processes or removing persistence on a host is `huntress-incidents`.
+
 ## Key Concepts
 
 ### Remediation Actions

--- a/msp-claude-plugins/email-security/proofpoint/skills/people/SKILL.md
+++ b/msp-claude-plugins/email-security/proofpoint/skills/people/SKILL.md
@@ -20,6 +20,19 @@ Proofpoint People-Centric Security provides user-level threat analytics that ide
 
 The core concept is that people - not infrastructure - are the primary target of modern email attacks. By understanding who is targeted and who clicks, you can focus security resources where they have the most impact.
 
+## Anti-triggers
+
+- **Simulated-phishing risk scores** — KnowBe4 also reports a per-user
+  "risk score" and a click rate, but those measure tests the MSP sent
+  deliberately. Attack Index and VAP count real attacks. For simulation
+  performance use `knowbe4-users`.
+- **Enrolling a high-risk user in awareness training** — this skill
+  identifies who needs it; the enrollment itself is
+  `knowbe4-training`.
+- **The individual threat events behind a user's Attack Index** — use
+  `proofpoint-tap`, and `proofpoint-threat-intel` for the campaigns
+  named in `topCampaigns`.
+
 ## Key Concepts
 
 ### Very Attacked People (VAP)

--- a/msp-claude-plugins/email-security/proofpoint/skills/quarantine/SKILL.md
+++ b/msp-claude-plugins/email-security/proofpoint/skills/quarantine/SKILL.md
@@ -21,6 +21,23 @@ Quarantine operates at two levels:
 - **Admin quarantine** - Managed by administrators, holds threats and policy violations
 - **End-user quarantine** - Self-service spam quarantine with digests
 
+## Anti-triggers
+
+- **Removing a message that already reached the mailbox** — quarantine
+  only holds mail that was stopped before delivery. Pulling a delivered
+  message back out of Microsoft 365 or Google Workspace is TRAP
+  auto-pull and search-and-destroy: use `proofpoint-forensics`.
+- **Why the message scored the way it did** — the quarantine entry
+  carries the scores but not the threat event, its classification, or
+  its campaign; use `proofpoint-tap`.
+- **A rewritten link found inside a quarantined message** — decoding
+  and re-checking `urldefense.proofpoint.com` URLs is
+  `proofpoint-url-defense`.
+- **Another vendor's quarantine** — release and delete vocabulary is
+  shared across the stack. Checkpoint Harmony is
+  `checkpoint-avanan-quarantine`, SpamTitan is `spamtitan-quarantine`,
+  and Mimecast calls it the held queue: `mimecast-queue-management`.
+
 ## Key Concepts
 
 ### Quarantine Reasons

--- a/msp-claude-plugins/email-security/proofpoint/skills/tap/SKILL.md
+++ b/msp-claude-plugins/email-security/proofpoint/skills/tap/SKILL.md
@@ -23,6 +23,23 @@ TAP identifies three primary threat vectors:
 - **Attachment threats** - Malicious files attached to messages
 - **Message-level threats** - Threats classified at the message level (e.g., BEC, impostor)
 
+## Anti-triggers
+
+- **Anything older than 24 hours** — the SIEM API's maximum lookback is
+  24 hours and it answers an out-of-range window with an empty result,
+  not an error. "Did we see this last week?" needs
+  `proofpoint-forensics` for a specific message or
+  `proofpoint-threat-intel` for a campaign.
+- **Acting on a message** — TAP is a read-only event feed. Release and
+  delete are `proofpoint-quarantine`; removing delivered mail is
+  `proofpoint-forensics`.
+- **Which people are most targeted** — TAP returns per-event rows; the
+  per-user rollup, Attack Index, and VAP list are `proofpoint-people`.
+- **Another vendor's threat events** — Checkpoint Harmony is
+  `checkpoint-avanan-threats`, Abnormal is `abnormal-security-threats`,
+  and Mimecast message-level delivery tracking is
+  `mimecast-message-tracking`.
+
 ## Key Concepts
 
 ### Threat Classifications

--- a/msp-claude-plugins/email-security/proofpoint/skills/threat-intel/SKILL.md
+++ b/msp-claude-plugins/email-security/proofpoint/skills/threat-intel/SKILL.md
@@ -19,6 +19,17 @@ Proofpoint Threat Intelligence provides contextual information about threat camp
 
 Proofpoint processes billions of messages daily and correlates threats across its entire customer base, providing unique visibility into large-scale email threat campaigns.
 
+## Anti-triggers
+
+- **What hit your own tenant** — this is Proofpoint's cross-customer
+  intelligence: campaigns, families, and actors observed network-wide.
+  A campaign returned here may never have targeted your organization.
+  Your tenant's own events are `proofpoint-tap`.
+- **Evidence artifacts for one message** — sandbox reports, pcaps,
+  screenshots, and samples are `proofpoint-forensics`.
+- **Another vendor's intelligence feed** — Mimecast's near-identically
+  named skill is `mimecast-threat-intelligence`.
+
 ## Key Concepts
 
 ### Campaigns

--- a/msp-claude-plugins/email-security/proofpoint/skills/url-defense/SKILL.md
+++ b/msp-claude-plugins/email-security/proofpoint/skills/url-defense/SKILL.md
@@ -20,6 +20,19 @@ Proofpoint URL Defense rewrites URLs in email messages to route clicks through P
 
 URL Defense is a critical layer of protection because many attacks use time-delayed weaponization: a URL is clean when the email is sent but becomes malicious hours or days later.
 
+## Anti-triggers
+
+- **The click event feed across all users and threats** — this skill
+  answers "who clicked *this* URL". The full permitted/blocked click
+  stream is `proofpoint-tap`.
+- **Removing the message that carried the link** — use
+  `proofpoint-quarantine` if it is still held, or
+  `proofpoint-forensics` if it was delivered.
+- **Turning URL rewriting on or off** — rewrite behaviour is a
+  Proofpoint policy setting, not something these tools change. On a
+  Checkpoint Harmony tenant the equivalent `URL_REWRITE` policy is
+  `checkpoint-avanan-policies`.
+
 ## Key Concepts
 
 ### URL Rewriting


### PR DESCRIPTION
Applies the connector-quality standard from `feat/skill-anti-triggers-governance` to the plugins under `msp-claude-plugins/email-security/`.

## Scope note for the reviewer

The task described `email-security` as a double-nested plugin at `email-security/email-security/`. On this branch that path does not exist — `msp-claude-plugins/email-security/` is a **category** directory holding three plugins:

- `checkpoint-avanan` (5 skills)
- `knowbe4` (5 skills)
- `proofpoint` (7 skills)

That is exactly the 17 SKILL.md files in the batch, so I treated those three as the batch and wrote **one GOVERNANCE.md per plugin**, matching the exemplar's placement (`huntress/huntress/GOVERNANCE.md` sits beside `.claude-plugin/plugin.json`). Nothing outside `msp-claude-plugins/email-security/` is touched. `ironscales`, `mimecast`, `spamtitan`, and `abnormal` are top-level directories and belong to the other agent — I only *reference* their skills in anti-trigger bullets.

## Task A — Anti-triggers

**Added: 14 of 17. Skipped: 3.**

| Plugin | Added | Skipped |
|---|---|---|
| checkpoint-avanan | quarantine, threats, incidents, policies | api-patterns |
| knowbe4 | phishing, training, users, reporting | api-patterns |
| proofpoint | quarantine, forensics, tap, people, threat-intel, url-defense | api-patterns |

**Why the three `api-patterns` skills got nothing.** Every plugin in the repo has one, so "authentication" and "rate limit" are shared vocabulary — but the only bullet available is "don't use this for another vendor's API", which is precisely the negation of `when_to_use` the checklist calls filler. The exemplar agrees: huntress added anti-triggers to 3 of its 7 skills and left `api-patterns`, `billing`, `escalations`, and `organizations` bare.

Every bullet names a destination skill. All referenced skills were verified to exist on disk as real plugin-dir + skill-dir pairs (including the cross-plugin ones: `ironscales-incidents`, `mimecast-queue-management`, `spamtitan-quarantine`, `abnormal-security-threats`, `huntress-incidents`, `cipp-users`).

### The three most valuable

1. **`knowbe4-phishing` — simulated vs. real.** Every "phishing campaign", "click", and "failure" in KnowBe4 is a test the MSP sent deliberately. The word is identical to what Proofpoint, Checkpoint, and Abnormal use for genuine attacks. Without this bullet, "show me the phishing that hit this client" plausibly loads the simulation platform and returns a confident, entirely wrong answer.
2. **`proofpoint-tap` — the 24-hour ceiling.** The SIEM API cannot look back further than 24 hours and answers an out-of-range window with an **empty result, not an error**. "Were we hit by this campaign last month?" returns something that reads as *all-clear*. The bullet routes historical questions to `proofpoint-forensics` / `proofpoint-threat-intel`.
3. **`proofpoint-quarantine` vs. `proofpoint-forensics` — pre- vs. post-delivery.** Quarantine only holds mail that was stopped before delivery; it has no mailbox reach. "Get that email out of everyone's inbox" needs TRAP search-and-destroy. Loading the wrong one produces an agent that reports success having done nothing. The same bullet appears inverted on `checkpoint-avanan-quarantine`, where there is *no* post-delivery tool at all.

## Task B — GOVERNANCE.md

Three files, tool inventories derived strictly from each plugin's own `skills/*/SKILL.md`. **No invented tool names** — verified mechanically: 33 + 30 + 40 = 103 tools cited, every one resolving to a skill file, and every tool in every skill accounted for in a tier.

Conduit-gateway framing kept throughout: auth brokered centrally, no local secrets, per-operator audit identity.

### Destructive-tier calls a reviewer might dispute

**`avanan_quarantine_release` / `proofpoint_quarantine_release` / `_bulk_release` — destructive, not write.** The API models release as a status change. Its actual effect is delivering a message the security stack already judged malicious into a real inbox, with no un-deliver. Same reasoning the exemplar uses for `huntress_incidents_bulk_approve`.

**`avanan_quarantine_release` carries a hidden policy change.** Its `addToAllowList: true` parameter writes a permanent tenant-wide detection bypass for the sender. An operator approving "release this one email" may be approving a standing policy change they never saw. Called out explicitly.

**All `avanan_policies_*` and allow/block-list mutations — destructive, including `_enable`.** Disabling a policy silently removes a detection layer. But *enabling* one, or updating its action to `QUARANTINE`/`BLOCK`, can bury a customer's legitimate inbound mail within minutes — a mail-flow outage, not a settings change. The `_remove` calls are sharp in reverse: removing a block entry re-admits a sender someone deliberately excluded. **This is the broadest call in the PR and the most arguable** — an "enable protection" verb landing in the destructive tier is counterintuitive. I think blast radius justifies it; happy to split `_enable` down to write if you disagree.

**`proofpoint_forensics_search_destroy` — the highest blast radius in the batch.** Not a delete-by-ID call: it takes *search criteria* and applies an action across every mailbox in the tenant. One field too broad reaches hundreds of inboxes; with `action=hard-delete` the removal is unrecoverable. It is also asynchronous, so `matchCount` is only visible **after** it starts — the agent learns the true scope after the damage. The doc requires the approver to see literal criteria and action, not a summary.

**`proofpoint_forensics_get_evidence` — left in Read, with a caveat.** It changes no vendor state, so by blast radius it is read. But the `sample` evidence type is live malware and `pcap` is detonation traffic. Documented as read-tier for approval purposes while flagging that it pulls a weaponized binary into the session.

**KnowBe4 is read-only — all 30 tools.** Stated plainly as a selling point. Worth a reviewer's eye: the skills describe workflows ("launch campaign", "enroll failed users", "archive the user") that are **console-only** — no tool implements them. The doc warns against reading a workflow in a skill as evidence a tool exists.

### Data handling

Flagged per the brief:

- **checkpoint-avanan** — `bodyPreview` returns the first 200 chars of the email body; for a DLP-quarantined outbound message that preview *is* the sensitive content the rule matched.
- **proofpoint** — `_quarantine_preview` returns full message content the recipient has never seen; `people_get_top_clickers` is effectively a ranked list of which named employees fall for attacks.
- **knowbe4** — the read tier carries more personal data than most vendors' write tiers: near-complete HR records, plus per-employee click/credential-entry timestamps with IP and browser. Noted that this may attract works-council or employee-monitoring constraints independent of security justification, and that `knowbe4_reporting_*` answers most questions at department granularity without naming individuals.

## Constraints

- Additive only — no existing content reworded or restructured (diff is 212 insertions, 0 deletions).
- No `triggers:` frontmatter arrays (#158). Verified.
- `_standards/`, `_templates/`, `marketplace.json`, `plugins.ts` untouched. `npm run generate` not run.
- Two pre-existing files exceed the ~350-line guidance (`knowbe4/api-patterns` 394, `proofpoint/api-patterns` 376). Both were left alone — splitting them into `references/` would violate the additive-only constraint. Flagging for a follow-up.

---

**Stacking note.** This branch is cut from `feat/skill-anti-triggers-governance` as instructed, but the PR targets `main`, so the diff shown includes that branch's standards commit (`64389eb`) as well as mine. **My commit is `aa43621` — 17 files, 626 insertions, 0 deletions**, all under `msp-claude-plugins/email-security/`. Merge the standards branch first, or retarget this PR at it, and the diff reduces to my commit alone.
