### PR TITLE
docs(packs): add routing anti-triggers to the ten workflow pack bundles

### DIFF
--- a/msp-claude-plugins/assets-pack/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/assets-pack/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "assets-pack",
   "displayName": "IT Asset Lifecycle",
-  "description": "Cross-vendor IT asset lifecycle management — warranty tracking, end-of-life/end-of-support flagging, and hardware refresh-cycle planning across whatever RMM platforms and documentation tools you have connected.",
-  "version": "0.1.1",
+  "description": "Cross-vendor IT asset lifecycle management \u2014 warranty tracking, end-of-life/end-of-support flagging, and hardware refresh-cycle planning across whatever RMM platforms and documentation tools you have connected.",
+  "version": "0.1.2",
   "author": {
     "name": "MSP Claude Plugins Community"
   },

--- a/msp-claude-plugins/assets-pack/skills/eol-eos-flagging/SKILL.md
+++ b/msp-claude-plugins/assets-pack/skills/eol-eos-flagging/SKILL.md
@@ -43,6 +43,16 @@ and still fully supported (an older desktop on a current, supported OS with
 no active vendor patching risk). Both signals feed `refresh-cycle-planning`,
 but they are not the same finding and should not be conflated in a report.
 
+## Anti-triggers
+
+- **Unsupported software as a scored patch/CVE finding** — an out-of-support
+  OS surfaced with an EPSS score and exploit maturity is vulnerability
+  management; use `sentinelone-vulnerabilities`.
+- **A vendor's own end-of-life field** — Auvik and ScalePad both record
+  lifecycle/EOL data natively; use `auvik-devices` or
+  `scalepad-lifecycle-manager` when the question is what that tool holds
+  rather than how to rank the risk across a fleet.
+
 ## Discovering available tools first
 
 Never assume which RMM is connected:

--- a/msp-claude-plugins/assets-pack/skills/refresh-cycle-planning/SKILL.md
+++ b/msp-claude-plugins/assets-pack/skills/refresh-cycle-planning/SKILL.md
@@ -50,6 +50,15 @@ to a quoting/sales workflow (e.g. `sales-pack`) or a PSA opportunity is a
 separate, deliberate next step, not something this skill does
 automatically.
 
+## Anti-triggers
+
+- **ScalePad Lifecycle Manager roadmaps** — LM has its own initiatives,
+  goals, QBR meetings, and budget forecasting; use
+  `scalepad-lifecycle-manager` rather than rebuilding its calendar here.
+- **Pricing the replacements** — use `scalepad-quoter`,
+  `connectwise-cpq-quotes`, or `kaseya-quote-manager-quotes`; this skill
+  produces a tiered calendar and device counts, never a dollar figure.
+
 ## Discovering available tools first
 
 Never assume which RMM or documentation platform is connected:

--- a/msp-claude-plugins/assets-pack/skills/warranty-tracking/SKILL.md
+++ b/msp-claude-plugins/assets-pack/skills/warranty-tracking/SKILL.md
@@ -37,6 +37,17 @@ a device can be fully healthy and in active use while still being three
 weeks from warranty expiration, which is exactly the case this skill exists
 to catch before it becomes a support problem.
 
+## Anti-triggers
+
+- **One platform's own warranty or lifecycle field** — "what does Auvik
+  return for warranty," "read N-central's lifecycle record" is that
+  connector's API surface; use `auvik-devices` or `ncentral-devices`.
+- **ScalePad Lifecycle Manager's warranty product** — LM holds its own
+  hardware lifecycle records and warranty pricing; use
+  `scalepad-lifecycle-manager` for anything scoped to that tool.
+- **Looking up one asset's record** — use `it-glue-configurations` or
+  `hudu-assets`; this skill sweeps warranty state across a fleet.
+
 ## Discovering available tools first
 
 Never assume which RMM or documentation platform is connected:

--- a/msp-claude-plugins/awareness-pack/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/awareness-pack/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "awareness-pack",
   "displayName": "Security Awareness & Training",
-  "description": "Cross-vendor security awareness operations — training completion tracking, phishing simulation results, and per-user risk scoring across whatever security-awareness training tools you have connected. Complements secops-pack's technical threat response with the human-layer prevention side.",
-  "version": "0.1.1",
+  "description": "Cross-vendor security awareness operations \u2014 training completion tracking, phishing simulation results, and per-user risk scoring across whatever security-awareness training tools you have connected. Complements secops-pack's technical threat response with the human-layer prevention side.",
+  "version": "0.1.2",
   "author": {
     "name": "MSP Claude Plugins Community"
   },

--- a/msp-claude-plugins/awareness-pack/skills/phishing-simulation-analysis/SKILL.md
+++ b/msp-claude-plugins/awareness-pack/skills/phishing-simulation-analysis/SKILL.md
@@ -26,6 +26,16 @@ whatever simulation platform is connected, and how to optionally enrich it
 with real-world phishing-incident data when a technical security tool is
 also available — treating that enrichment as a bonus, never a requirement.
 
+## Anti-triggers
+
+- **Building or sending a simulated campaign** — templates, landing pages,
+  recipient tracking, and phish-prone percentage are the vendor's surface;
+  use `knowbe4-phishing`.
+- **Real-world attack targeting rather than simulated tests** — Very
+  Attacked People reports and attack-index scoring describe genuine inbound
+  campaigns; use `proofpoint-people`. This skill reasons about controlled
+  tests, and never merges the two into one click rate.
+
 ## Step Zero: Confirm What's Connected
 
 Call `conduit__search_tools` for phishing-simulation and click-data tools

--- a/msp-claude-plugins/awareness-pack/skills/risk-scoring/SKILL.md
+++ b/msp-claude-plugins/awareness-pack/skills/risk-scoring/SKILL.md
@@ -24,6 +24,16 @@ in secops-pack prioritizes technical exposure. The design goal here is the
 same discipline that pack applies: an explainable ranked comparison with
 visible inputs, never an opaque score a reviewer has to take on faith.
 
+## Anti-triggers
+
+- **A vendor's own user risk score** — KnowBe4 and Proofpoint each compute
+  one from their own data alone; use `knowbe4-reporting` or
+  `proofpoint-people`. This skill blends inputs across tools and keeps the
+  factor table visible.
+- **Technical exposure ranking** — ranking tenants or endpoints by threat
+  and configuration posture is a different axis from human risk; use
+  `alert-severity-normalization` in secops-pack.
+
 ## Step Zero: Confirm What's Connected
 
 Call `conduit__search_tools` to determine which inputs are actually

--- a/msp-claude-plugins/awareness-pack/skills/training-completion-tracking/SKILL.md
+++ b/msp-claude-plugins/awareness-pack/skills/training-completion-tracking/SKILL.md
@@ -27,6 +27,16 @@ whatever security-awareness platform is connected, turn it into a per-org
 completion rate, and flag clients falling behind their contracted cadence —
 without assuming a specific vendor's data model.
 
+## Anti-triggers
+
+- **Running a KnowBe4 campaign** — creating campaigns, enrolling users,
+  browsing the content library, or buying store modules is the vendor's API
+  surface; use `knowbe4-training`.
+- **KnowBe4's own completion reports and benchmarks** — the platform
+  computes those natively per account; use `knowbe4-reporting`. This skill
+  exists for the portfolio rollup and the cadence judgment across whatever
+  platform is connected.
+
 ## Step Zero: Confirm What's Connected
 
 Call `conduit__search_tools` with a query like `"training campaign"` or

--- a/msp-claude-plugins/backup-pack/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/backup-pack/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "backup-pack",
   "displayName": "Backup & DR Assurance",
-  "description": "Cross-vendor backup and disaster-recovery assurance — job health monitoring, restore-test verification, retention/RPO compliance, and DR readiness across whatever backup and BCDR tools you have connected.",
-  "version": "0.1.1",
+  "description": "Cross-vendor backup and disaster-recovery assurance \u2014 job health monitoring, restore-test verification, retention/RPO compliance, and DR readiness across whatever backup and BCDR tools you have connected.",
+  "version": "0.1.2",
   "author": {
     "name": "MSP Claude Plugins Community"
   },

--- a/msp-claude-plugins/backup-pack/skills/backup-job-health/SKILL.md
+++ b/msp-claude-plugins/backup-pack/skills/backup-job-health/SKILL.md
@@ -36,6 +36,17 @@ contracted requirement (see `retention-rpo-compliance`). Treat this as the first
 most frequent layer of the DR assurance stack: if jobs aren't running, nothing
 downstream matters yet.
 
+## Anti-triggers
+
+- **Backup Radar's own health records** — ScalePad already aggregates and
+  scores backup results across vendors; use `scalepad-backup-radar` when the
+  question is what that API returns. This skill normalizes across every
+  connected backup tool, including orgs that have no Backup Radar at all.
+- **One platform's job, alert, or storage data** — use
+  `datto-bcdr-api-patterns`, `datto-saas-protection-api-patterns`,
+  `spanning-api-patterns`, or `unitrends-api-patterns` for a single vendor's
+  request shapes and field names.
+
 ## Key Concepts
 
 ### Two fundamentally different job models

--- a/msp-claude-plugins/backup-pack/skills/restore-test-verification/SKILL.md
+++ b/msp-claude-plugins/backup-pack/skills/restore-test-verification/SKILL.md
@@ -34,6 +34,17 @@ This skill assumes backup jobs are already running (see `backup-job-health` for 
 layer) and asks the next question: if this needed to be restored today, is there any
 evidence it actually could be?
 
+## Anti-triggers
+
+- **Fetching a screenshot or boot-verification record** — the screenshot,
+  activity, and asset endpoints are the appliance's own API surface; use
+  `datto-bcdr-api-patterns`. This skill weighs what that evidence proves and
+  flags where none exists.
+- **Answering "are backups tested?" on an insurance or audit form** — the
+  evidence-labelling discipline for that context lives in
+  `insurance-questionnaires` (compliance-pack), which draws on this skill's
+  finding rather than reproducing it.
+
 ## Key Concepts
 
 ### "Exists" vs. "recoverable" evidence, ranked

--- a/msp-claude-plugins/backup-pack/skills/retention-rpo-compliance/SKILL.md
+++ b/msp-claude-plugins/backup-pack/skills/retention-rpo-compliance/SKILL.md
@@ -32,6 +32,15 @@ what's promised against what's configured — not to audit whether backups are r
 (`backup-job-health`) or recoverable (`restore-test-verification`), both of which are
 prerequisites to this check actually meaning anything.
 
+## Anti-triggers
+
+- **Framework or control compliance** — "compliance" here means a contracted
+  retention window and RPO target, not CIS/SOC 2/HIPAA control evidence; for
+  that use `evidence-mapping` in compliance-pack.
+- **Reading the agreement itself** — pulling a client's contract terms,
+  services, or renewal dates is the PSA's surface; use `autotask-contracts`
+  or `halopsa-contracts`.
+
 ## Key Concepts
 
 ### Retention: contracted vs. configured

--- a/msp-claude-plugins/cloudops-pack/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/cloudops-pack/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "cloudops-pack",
   "displayName": "Cloud & Network Infrastructure",
-  "description": "Cross-vendor network and cloud infrastructure operations — device/network health, capacity planning, and cost management across whatever network monitoring (Auvik, Meraki, Domotz) and cloud platforms (Azure, DigitalOcean) you have connected.",
-  "version": "0.1.1",
+  "description": "Cross-vendor network and cloud infrastructure operations \u2014 device/network health, capacity planning, and cost management across whatever network monitoring (Auvik, Meraki, Domotz) and cloud platforms (Azure, DigitalOcean) you have connected.",
+  "version": "0.1.2",
   "author": {
     "name": "MSP Claude Plugins Community"
   },

--- a/msp-claude-plugins/cloudops-pack/skills/cloud-capacity-planning/SKILL.md
+++ b/msp-claude-plugins/cloudops-pack/skills/cloud-capacity-planning/SKILL.md
@@ -33,6 +33,15 @@ spend (see the `cloud-cost-management` skill, a related but separate
 concern: a resource can be correctly sized and still be a cost problem, or
 be under-provisioned and cheap).
 
+## Anti-triggers
+
+- **A one-off quota or usage-limit lookup** — "what's my quota, how much is
+  used" is a direct read against the connector; use
+  `azure-mcp-cost-and-capacity`. This skill turns repeated readings into a
+  trend and a forecast.
+- **The metric and log queries behind the utilization numbers** — use
+  `azure-mcp-observability`.
+
 ## Discovering available tools first
 
 Never assume which cloud platform is connected:

--- a/msp-claude-plugins/cloudops-pack/skills/cloud-cost-management/SKILL.md
+++ b/msp-claude-plugins/cloudops-pack/skills/cloud-cost-management/SKILL.md
@@ -32,6 +32,15 @@ managed databases, networking). It is not PSA/contract billing
 reconciliation (see `finance-pack`) — this skill is about what the cloud
 platform itself is charging, not what the MSP bills the client for it.
 
+## Anti-triggers
+
+- **Azure retail pricing and inventory lookups** — meter rates, quota
+  headroom, and subscription/resource-group listings are the connector's own
+  read-only surface; use `azure-mcp-cost-and-capacity`. This skill consumes
+  those numbers to find anomalies and reclaimable spend.
+- **The raw metric or log query behind a spend signal** — use
+  `azure-mcp-observability` for the monitor and log surface itself.
+
 ## Discovering available tools first
 
 Never assume which cloud platform is connected:

--- a/msp-claude-plugins/cloudops-pack/skills/network-health-sweep/SKILL.md
+++ b/msp-claude-plugins/cloudops-pack/skills/network-health-sweep/SKILL.md
@@ -30,6 +30,19 @@ triage (see `ops-pack`) and it is not application-layer reliability (see
 `devops-pack`, if connected) — this skill only answers whether the wires,
 switches, firewalls, and access points a client depends on are functioning.
 
+## Anti-triggers
+
+- **One vendor's device, alert, or interface data** — use `auvik-devices`,
+  `auvik-alerts`, `meraki-devices`, or `domotz-devices` when the question is
+  what that platform returns, rather than how to rank findings across all of
+  them.
+- **Hands-on diagnostics against a specific device** — ping, cable test,
+  throughput, and reboots are live tools, not a sweep; use
+  `meraki-troubleshooting`.
+- **Collector health as its own subject** — use `domotz-agents`; this skill
+  checks agent status only to decide whether "down" or "unknown" applies to
+  the devices behind it.
+
 ## Discovering available tools first
 
 Because this pack is cross-vendor, never assume which network-monitoring tool

--- a/msp-claude-plugins/compliance-pack/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/compliance-pack/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "compliance-pack",
   "displayName": "Compliance",
-  "description": "Cross-vendor compliance evidence collection and control drift detection — maps live tenant configuration and documentation to CIS/SOC 2/HIPAA controls and cyber-insurance questionnaire line items.",
-  "version": "0.1.1",
+  "description": "Cross-vendor compliance evidence collection and control drift detection \u2014 maps live tenant configuration and documentation to CIS/SOC 2/HIPAA controls and cyber-insurance questionnaire line items.",
+  "version": "0.1.2",
   "author": {
     "name": "MSP Claude Plugins Community"
   },

--- a/msp-claude-plugins/compliance-pack/skills/evidence-mapping/SKILL.md
+++ b/msp-claude-plugins/compliance-pack/skills/evidence-mapping/SKILL.md
@@ -30,6 +30,17 @@ Evidence in an MSP's toolchain comes from three vendor families, each proving a 
 
 Treat these as different evidentiary weights, not interchangeable sources.
 
+## Anti-triggers
+
+- **ControlMap's own control library and evidence store** — ScalePad already
+  models risks, controls, evidence, policies, and framework objectives per
+  client; use `scalepad-controlmap` when working inside that product. This
+  skill maps a control statement onto live queries across whatever happens
+  to be connected.
+- **Reading a single evidence source** — pulling standards results,
+  inspection state, or a document is that connector's surface; use
+  `cipp-standards`, `liongard-systems`, or `it-glue-documents`.
+
 ## Key Concept: Configured vs. Documented Evidence
 
 This is the single most important judgment call in evidence mapping, and getting it wrong is what turns an evidence package into a liability during an actual audit.

--- a/msp-claude-plugins/compliance-pack/skills/standards-drift/SKILL.md
+++ b/msp-claude-plugins/compliance-pack/skills/standards-drift/SKILL.md
@@ -26,6 +26,18 @@ Drift detection has two distinct data sources in this pack's grounding:
 - **CIPP standards checks** (`cipp__list_standards`, `cipp__run_standards_check`, `cipp__list_bpa`) — these represent MSP-defined or CIS-aligned configuration standards applied to a tenant. A standard that previously passed and now fails is drift. `cipp__list_standards` shows which standards are assigned to a tenant and their last-known state; `cipp__run_standards_check` re-evaluates live.
 - **Liongard change detection** (`liongard__detections_list`, `liongard__detections_get`, `liongard__timeline_list`) — Liongard inspects systems on a schedule and diffs each inspection against the prior one, surfacing detections when tracked properties change. The timeline is the authoritative "what changed and when" record for anything Liongard inspects (network gear, servers, cloud tenants, and whatever else an org has connected inspectors for).
 
+## Anti-triggers
+
+- **Running or reading a CIPP standards check** — the Report/Alert/Remediate
+  modes, BPA reports, and domain-health results are the connector's own
+  surface; use `cipp-standards`. This skill decides whether a delta is real
+  drift, whether it was authorized, and how it ranks against other findings.
+- **Liongard detection and alert-rule configuration** — detection types,
+  severities, alert rules, and custom metrics live in `liongard-detections`.
+- **Inforcer baseline alignment scores** — Inforcer computes tenant-versus-
+  baseline drift natively with its own alignment model; use
+  `inforcer-baseline-alignment`.
+
 ## What Counts as Drift
 
 Drift is any observed difference between the current state of a tracked control or configuration item and its last known-good (i.e., previously verified-compliant) state. Three things are required to call something drift rather than noise:

--- a/msp-claude-plugins/devops-pack/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/devops-pack/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "devops-pack",
   "displayName": "DevOps & Reliability",
-  "description": "Cross-vendor engineering reliability operations — on-call handoffs, incident postmortems, deploy health, and error-budget tracking across whatever incident-management, observability, and platform tools you have connected.",
-  "version": "0.1.1",
+  "description": "Cross-vendor engineering reliability operations \u2014 on-call handoffs, incident postmortems, deploy health, and error-budget tracking across whatever incident-management, observability, and platform tools you have connected.",
+  "version": "0.1.2",
   "author": {
     "name": "MSP Claude Plugins Community"
   },

--- a/msp-claude-plugins/devops-pack/skills/error-budget-tracking/SKILL.md
+++ b/msp-claude-plugins/devops-pack/skills/error-budget-tracking/SKILL.md
@@ -27,6 +27,16 @@ from whatever observability data is actually available, and — just as
 importantly — knows when there isn't enough to compute a formal burn rate at
 all, and falls back to something honest instead of a fabricated number.
 
+## Anti-triggers
+
+- **Contractual SLAs on service-desk tickets** — a response or resolution
+  target on a client agreement is a different measurement from an SLO burn
+  rate; use `sla-escalation-playbooks` in ops-pack.
+- **Vendor-computed response metrics** — MTTA, MTTR, and incident counts are
+  already calculated by the platform; use `pagerduty-analytics`.
+- **Configuring the checks behind the SLI** — check types, heartbeats, and
+  monitor groups are `betterstack-monitors`.
+
 ## Discovering available tools first
 
 This pack is cross-vendor. Before pulling any observability data:

--- a/msp-claude-plugins/devops-pack/skills/incident-postmortem/SKILL.md
+++ b/msp-claude-plugins/devops-pack/skills/incident-postmortem/SKILL.md
@@ -37,6 +37,15 @@ This skill assembles that reconstruction from the systems of record, and
 structures the analysis so contributing factors don't get collapsed into a
 single "root cause" that oversimplifies what actually happened.
 
+## Anti-triggers
+
+- **Creating or editing a postmortem record in the vendor** — templates,
+  action-item tracking, and Rootly's automatic timeline import are its own
+  surface; use `rootly-postmortems`. This skill reconstructs the timeline
+  from every connected system, including tools the incident record never saw.
+- **The incident record itself while it is still live** — use
+  `rootly-incidents`, `pagerduty-incidents`, or `betterstack-incidents`.
+
 ## Discovering available tools first
 
 This pack is cross-vendor. Before pulling any incident or observability data:

--- a/msp-claude-plugins/devops-pack/skills/oncall-handoff/SKILL.md
+++ b/msp-claude-plugins/devops-pack/skills/oncall-handoff/SKILL.md
@@ -33,6 +33,15 @@ This skill produces that handoff from whatever incident-management tool is
 actually connected, plus whatever corroborating alert/monitor state is
 available, rather than from the outgoing responder's memory alone.
 
+## Anti-triggers
+
+- **Reading or editing a schedule, rotation, or escalation policy** — who is
+  on call and when is the vendor's own surface; use `rootly-oncall`,
+  `pagerduty-oncall`, or `betterstack-oncall`. This skill assembles the
+  state transfer between two shifts, not the roster behind it.
+- **An MSP service-desk shift handover** — ticket-board state belongs to
+  `board-hygiene` in ops-pack; this skill covers the engineering pager.
+
 ## Discovering available tools first
 
 This pack is cross-vendor. Never assume which incident-management tool is

--- a/msp-claude-plugins/finance-pack/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/finance-pack/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "finance-pack",
   "displayName": "Finance & Billing",
-  "description": "Cross-vendor billing and agreement reconciliation — matches PSA contracts against accounting invoices and cloud-marketplace subscriptions, catches license true-up gaps, and ranks client profitability.",
-  "version": "0.1.1",
+  "description": "Cross-vendor billing and agreement reconciliation \u2014 matches PSA contracts against accounting invoices and cloud-marketplace subscriptions, catches license true-up gaps, and ranks client profitability.",
+  "version": "0.1.2",
   "author": {
     "name": "MSP Claude Plugins Community"
   },

--- a/msp-claude-plugins/finance-pack/skills/agreement-reconciliation/SKILL.md
+++ b/msp-claude-plugins/finance-pack/skills/agreement-reconciliation/SKILL.md
@@ -59,6 +59,15 @@ tolerance bands, severity tiers) rather than re-deriving one — the logic
 transfers directly from "subscription line vs invoice line" to "contract term vs
 invoice line."
 
+## Anti-triggers
+
+- **Working a contract record itself** — contract types, service and service-
+  bundle associations, block hours, and renewals are the PSA's surface; use
+  `autotask-contracts` or `halopsa-contracts`.
+- **Working an invoice itself** — creating, sending, or querying invoices is
+  the accounting connector's surface; use `xero-invoices` or
+  `quickbooks-online-invoices`.
+
 ## Connected Systems
 
 | System | Role | Required? |

--- a/msp-claude-plugins/finance-pack/skills/license-true-up/SKILL.md
+++ b/msp-claude-plugins/finance-pack/skills/license-true-up/SKILL.md
@@ -42,6 +42,15 @@ invoice, and tenant in agreement" without needing the full contract-entitlement
 layer; pair it with `agreement-reconciliation` when the contract layer matters
 too.
 
+## Anti-triggers
+
+- **One system's seat count on its own** — "how many Pax8 seats does this
+  client have," "which M365 licenses are unassigned" is a single-axis read;
+  use `pax8-subscriptions`, `cipp-licenses`, or `m365-licensing`. This skill
+  exists for the disagreement *between* those numbers.
+- **Assigning or removing a license** — use `m365-licensing`; this skill
+  reports the gap and its dollar impact, it does not remediate.
+
 ## Connected Systems
 
 | System | Role | Required? |

--- a/msp-claude-plugins/finance-pack/skills/margin-analysis/SKILL.md
+++ b/msp-claude-plugins/finance-pack/skills/margin-analysis/SKILL.md
@@ -41,6 +41,16 @@ Cost    = marketplace wholesale cost (Pax8/Sherweb) + estimated labor cost
           (PSA time entries × loaded technician rate, when available)
 ```
 
+## Anti-triggers
+
+- **Accounting-platform financial reports** — Profit and Loss, Balance
+  Sheet, and Aged Receivables are prebuilt reports with their own parameters
+  and response shape; use `xero-reports` or `quickbooks-online-reports`.
+  Neither produces per-client or per-service-line margin, which is what this
+  skill assembles.
+- **Time entries or billing items as records** — use
+  `autotask-time-entries` or `autotask-billing`.
+
 ## Connected Systems
 
 | System | Role | Required? |

--- a/msp-claude-plugins/ops-pack/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/ops-pack/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "ops-pack",
   "displayName": "MSP Operations",
-  "description": "Cross-vendor service-desk operations — board health, dispatch prioritization, SLA monitoring, and shift handoffs across whatever PSA/RMM you have connected.",
-  "version": "0.1.1",
+  "description": "Cross-vendor service-desk operations \u2014 board health, dispatch prioritization, SLA monitoring, and shift handoffs across whatever PSA/RMM you have connected.",
+  "version": "0.1.2",
   "author": {
     "name": "MSP Claude Plugins Community"
   },

--- a/msp-claude-plugins/ops-pack/skills/board-hygiene/SKILL.md
+++ b/msp-claude-plugins/ops-pack/skills/board-hygiene/SKILL.md
@@ -23,6 +23,16 @@ becomes a place tickets go to be forgotten, and workload quietly piles onto whoe
 answers fastest. None of this shows up in a single-ticket view — it only shows up
 when you look at the board as a whole. This skill is that recurring sweep.
 
+## Anti-triggers
+
+- **Working an individual ticket** — searching, updating, adding notes, or
+  closing one ticket is the PSA's surface; use `autotask-tickets`,
+  `halopsa-tickets`, or `connectwise-psa-tickets`.
+- **Correlating a ticket with device, asset, or change data** — pulling
+  cross-vendor context for one investigation is
+  `shared-skills-incident-correlation`; this sweep reads the board's shape,
+  not any single ticket's story.
+
 ## Key Concepts
 
 ### Stale-ticket detection

--- a/msp-claude-plugins/ops-pack/skills/dispatch-prioritization/SKILL.md
+++ b/msp-claude-plugins/ops-pack/skills/dispatch-prioritization/SKILL.md
@@ -23,6 +23,15 @@ This skill scores each unassigned ticket on a small set of factors and turns tha
 score into a defensible assignment order — the same judgment a good dispatcher
 applies, made explicit and repeatable.
 
+## Anti-triggers
+
+- **Triaging one incoming ticket** — setting a single ticket's priority,
+  category, owner, and first response is `shared-skills-ticket-triage`; this
+  skill orders and staffs a whole unassigned queue.
+- **Searching, creating, or updating tickets** — use `autotask-tickets`,
+  `halopsa-tickets`, or `connectwise-psa-tickets` for the PSA's own ticket
+  surface.
+
 ## Discovering available tools first
 
 Because this pack is cross-vendor, never assume which PSA or RMM is connected, or

--- a/msp-claude-plugins/ops-pack/skills/sla-escalation-playbooks/SKILL.md
+++ b/msp-claude-plugins/ops-pack/skills/sla-escalation-playbooks/SKILL.md
@@ -33,6 +33,16 @@ how to fetch a ticket and its SLA fields via the connected vendor's tools (or vi
 adds is the cross-vendor decision logic for what to do with that data once you have
 it.
 
+## Anti-triggers
+
+- **A platform's SLA policy configuration** — policy fields, business-hours
+  calendars, and how a vendor computes its own due dates are that
+  connector's surface; use `freshdesk-sla-business-hours`, `autotask-tickets`,
+  or `halopsa-tickets`.
+- **Engineering error budgets** — SLO burn rate against an uptime or
+  error-rate target is a different measurement from a contractual response
+  time; use `error-budget-tracking` in devops-pack.
+
 ## Key Concepts
 
 ### How each PSA family models SLA state

--- a/msp-claude-plugins/sales-pack/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/sales-pack/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "sales-pack",
   "displayName": "Sales & Deal Desk",
-  "description": "Cross-vendor sales pipeline operations — deal health, quote-to-close tracking, proposal follow-up, and warm-lead routing across whatever CRM, proposal, distribution, and scheduling tools you have connected.",
-  "version": "0.1.1",
+  "description": "Cross-vendor sales pipeline operations \u2014 deal health, quote-to-close tracking, proposal follow-up, and warm-lead routing across whatever CRM, proposal, distribution, and scheduling tools you have connected.",
+  "version": "0.1.2",
   "author": {
     "name": "MSP Claude Plugins Community"
   },

--- a/msp-claude-plugins/sales-pack/skills/pipeline-health/SKILL.md
+++ b/msp-claude-plugins/sales-pack/skills/pipeline-health/SKILL.md
@@ -34,6 +34,15 @@ sent/viewed/signed → deal marked closed-won), use the
 [`quote-to-close-tracking`](../quote-to-close-tracking/SKILL.md) skill, which
 builds on top of this one's stalled-deal detection.
 
+## Anti-triggers
+
+- **Working deal records** — searching, creating, updating, or reporting on
+  deals, stages, amounts, and forecast categories is the CRM's own surface;
+  use `hubspot-deals` or `salesbuildr-opportunities`. This skill judges
+  whether the pipeline those records describe is actually moving.
+- **Contact and company records behind a deal** — use `hubspot-contacts` or
+  `hubspot-companies`.
+
 ## Discovering available tools first
 
 Never assume HubSpot (or any specific CRM) is connected just because it is

--- a/msp-claude-plugins/sales-pack/skills/quote-to-close-tracking/SKILL.md
+++ b/msp-claude-plugins/sales-pack/skills/quote-to-close-tracking/SKILL.md
@@ -37,6 +37,16 @@ stale." That distinction matters because the fix is different at every stage
 — chasing a rep to build a proposal is a different action than following up
 with a client who hasn't opened their inbox.
 
+## Anti-triggers
+
+- **Building or sending the artifact** — creating a quote, generating a
+  proposal from a template, or sending a document for signature is each
+  tool's own surface; use `pandadoc-documents`, `connectwise-cpq-quotes`,
+  `kaseya-quote-manager-quotes`, `salesbuildr-quotes`, or `scalepad-quoter`.
+- **One document's status in isolation** — the full status enum and its
+  transition errors live in `pandadoc-documents`; this skill uses that status
+  only to locate a stall in the chain.
+
 ## The quote-to-close chain
 
 ```

--- a/msp-claude-plugins/sales-pack/skills/warm-lead-routing/SKILL.md
+++ b/msp-claude-plugins/sales-pack/skills/warm-lead-routing/SKILL.md
@@ -33,6 +33,15 @@ precise the scoring, but a CRM alone (no Warmly, no Calendly) still produces
 a usable, if coarser, read. Never treat missing intent tools as a reason to
 skip lead scoring entirely — degrade the signal set, not the output.
 
+## Anti-triggers
+
+- **Warmly's own visitor and account surface** — choosing between the
+  visitor and account lists, ICP filtering, and credit-burn checks belong to
+  `warmly-visitor-intelligence`. This skill blends that signal with CRM
+  activity into one warmth tier and a routing proposal.
+- **Contact records and email engagement as data** — use `hubspot-contacts`
+  or `hubspot-activities`.
+
 ## Signal sources and what they contribute
 
 | Signal source | Signal | Weight (relative) |

--- a/msp-claude-plugins/secops-pack/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/secops-pack/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "secops-pack",
   "displayName": "Security Operations",
-  "description": "Cross-vendor security alert triage and incident response — normalizes severity, runs containment playbooks, and builds incident timelines across whatever EDR/MDR/SIEM stack you have connected.",
-  "version": "0.1.1",
+  "description": "Cross-vendor security alert triage and incident response \u2014 normalizes severity, runs containment playbooks, and builds incident timelines across whatever EDR/MDR/SIEM stack you have connected.",
+  "version": "0.1.2",
   "author": {
     "name": "MSP Claude Plugins Community"
   },

--- a/msp-claude-plugins/secops-pack/skills/alert-severity-normalization/SKILL.md
+++ b/msp-claude-plugins/secops-pack/skills/alert-severity-normalization/SKILL.md
@@ -39,6 +39,17 @@ confidence, mitigation state, classification) and place it into the
 normalized tier using the criteria below, not by naively copying the
 vendor's label across.
 
+## Anti-triggers
+
+- **One vendor's queue on its own** — triaging, filtering, or dispositioning
+  inside a single tool is that connector's surface; use
+  `huntress-incidents`, `sentinelone-alerts`, `blumira-findings`,
+  `cipp-alerts`, `saas-alerts-triage`, or `blackpoint-incident-response`.
+  This skill only earns its tokens when two or more of them have to be
+  ranked against each other.
+- **Pulling non-security context around an alert** — ticket, device, and
+  asset correlation is `shared-skills-incident-correlation`.
+
 ## Step Zero: Discover What's Actually Connected
 
 Never assume a vendor is connected. Before running any severity sweep, call

--- a/msp-claude-plugins/secops-pack/skills/bec-response/SKILL.md
+++ b/msp-claude-plugins/secops-pack/skills/bec-response/SKILL.md
@@ -29,6 +29,19 @@ skill covers how to detect BEC from the connected M365 tenant and any
 connected email security vendor, and the response sequence once it's
 confirmed or strongly suspected.
 
+## Anti-triggers
+
+- **A vendor's own account-takeover case** — Abnormal models ATO as a case
+  type with its own investigation and remediation actions; use
+  `abnormal-security-account-takeover` when working inside it.
+- **The inbound phishing message itself** — quarantine, release, and
+  message-level forensics are the email-security connector's surface; use
+  `checkpoint-avanan-quarantine`, `ironscales-incidents`,
+  `proofpoint-forensics`, or `mimecast-message-tracking`.
+- **The individual CIPP calls behind each step** — session revocation,
+  mailbox rules, and user state are `cipp-users`, `cipp-mailboxes`, and
+  `cipp-security`; what this skill supplies is the order they must run in.
+
 ## Step Zero: Confirm What's Connected
 
 Call `conduit__search_tools` to confirm which of CIPP, the M365/Entra

--- a/msp-claude-plugins/secops-pack/skills/containment-playbooks/SKILL.md
+++ b/msp-claude-plugins/secops-pack/skills/containment-playbooks/SKILL.md
@@ -35,6 +35,17 @@ a deeper investigation or a formal incident report is built (see
 [Incident Timeline Builder](../../agents/incident-timeline-builder.md) for
 that phase).
 
+## Anti-triggers
+
+- **Executing the action in one vendor** — approving a Huntress remediation,
+  isolating a SentinelOne endpoint, or disabling a CIPP user is that
+  connector's surface; use `huntress-incidents`, `sentinelone-alerts`,
+  `threatlocker-computers`, or `cipp-users`. This skill supplies the ordering
+  and the tool-family map, not the call.
+- **Investigating a detection rather than stopping it** — drill-down across
+  assets, detections, and vulnerabilities is `blackpoint-incident-response`
+  or `sentinelone-threat-hunting`.
+
 ## Step Zero: Confirm What's Connected
 
 Call `conduit__search_tools` before assuming which tool handles which step


### PR DESCRIPTION
Applies the connector-quality standard from `feat/skill-anti-triggers-governance` to the ten `*-pack` workflow bundles. **Task A (`## Anti-triggers`) only — see "Why no GOVERNANCE.md" below.**

> **Reviewing:** branched from `feat/skill-anti-triggers-governance`, not `main`. Because that branch has not merged yet, the diff against `main` shows **54 files — only 29 are mine.** The other 25 (`_standards/`, `_templates/`, `huntress/`, `connectwise/cpq/`, `marketplace.json`, `docs/`) are inherited from the base branch and will disappear once it lands. Review `feat/skill-anti-triggers-governance...feat/quality-workflow-packs`, or just the single commit `d07bf89`.

## The routing boundary this encodes

A pack skill and the vendor skills it composes answer different questions, and their `when_to_use` keywords collide badly — "backup health", "on-call", "standards drift", "pipeline", "license", "SLA" all appear on both sides. The rule every bullet in this PR encodes:

> **A pack skill owns the cross-vendor decision flow** — what to check, in what order, how to weigh the evidence, and how to rank the result across whatever tools happen to be connected.
> **A vendor skill owns one product's API surface** — what a tool returns, its fields, enums, request shapes, and the operations it supports.
>
> Corollary: if the question can be answered by querying a single product, it belongs to that product's skill. The pack skill earns its tokens only when two or more sources must be reconciled, or when the judgment (is this drift authorized? is this backup actually recoverable? is this deal really stalled?) is not something any one vendor computes.

Worked examples now written into the skills:

| Pack skill | Loses to | Because |
|---|---|---|
| `backup-job-health` | `scalepad-backup-radar` | Backup Radar already aggregates and scores backup results; the pack skill normalizes across every connected tool, including orgs with no Backup Radar |
| `standards-drift` | `cipp-standards`, `liongard-detections`, `inforcer-baseline-alignment` | Each vendor computes its own drift; the pack skill decides whether a delta was authorized and how it ranks |
| `oncall-handoff` | `rootly-oncall`, `pagerduty-oncall`, `betterstack-oncall` | The roster is vendor data; the shift state-transfer is not |
| `license-true-up` | `pax8-subscriptions`, `cipp-licenses`, `m365-licensing` | Each is one axis; the pack skill exists for the *disagreement between* them |
| `error-budget-tracking` | `sla-escalation-playbooks` (ops-pack) | SLO burn rate ≠ contractual ticket response time — a same-acronym trap worth naming explicitly |

## Counts

- **30** pack skills reviewed (3 each across assets, awareness, backup, cloudops, compliance, devops, finance, ops, sales, secops)
- **29** received `## Anti-triggers`
- **1** skipped: `compliance-pack/insurance-questionnaires` — "cyber insurance questionnaire" / "underwriter" / "renewal application" has no competing vendor vocabulary anywhere in the marketplace, and its two siblings already route into it. A section there would only negate its own `when_to_use`, which the checklist calls filler.
- **115** skill references across the 29 sections, **all** machine-validated against `marketplace.json` + on-disk skill dirs. Every bullet names a destination skill (no bare "don't use this for X" negations).
- **0** lines removed — purely additive.

## Why no GOVERNANCE.md for this batch

The packs are cross-vendor **workflow bundles**, not vendor connectors. They ship no credentials and define no auth surface of their own — every tool call they make is dispatched through `conduit__search_tools` into some *other* plugin's connector, whose GOVERNANCE.md already covers the auth, scope, and blast radius of that call. A GOVERNANCE.md here would either duplicate ten other files or document a surface that does not exist. Task B was skipped deliberately, not missed.

## Constraints honored

- Touched only the ten `*-pack` directories — no vendor plugin edited, including for reciprocal anti-triggers (parallel agents own those).
- No edits to `_standards/`, `_templates/`, `.claude-plugin/marketplace.json`, or `docs/src/data/plugins.ts`.
- `npm run generate` not run.
- No `triggers:` frontmatter added (#158).
- Additive only — no restructuring or rewording of existing content.
- `CHANGELOG.md` intentionally left alone: it is outside the ten pack dirs and would conflict across every parallel batch. Worth one consolidated entry when the batches land.

## Placement

Every section sits immediately after the opening overview paragraph and before the next `##` heading, matching the `huntress/{incidents,signals,agents}` exemplar.
