### PR TITLE
feat(security): anti-triggers + governance docs — runzero, saas-alerts, sentinelone, threatlocker

### DIFF
--- a/msp-claude-plugins/runzero/runzero/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/runzero/runzero/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "runzero",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Claude plugins for RunZero - asset discovery, network scanning, service inventory, OS fingerprinting, wireless detection, and vulnerability reporting for MSPs",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/runzero/runzero/GOVERNANCE.md
+++ b/msp-claude-plugins/runzero/runzero/GOVERNANCE.md
@@ -1,0 +1,114 @@
+# runZero plugin — governance and safety model
+
+Unofficial. Community-built plugin for the runZero API. Not affiliated
+with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches runZero through the
+WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the tenant the
+operator is authorised for.
+
+- No runZero Account API Token is stored on the technician's machine, in
+  this repo, or in the model's context.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers
+  "who launched that scan" — runZero's own task record shows only the
+  API account.
+- Revoking gateway access revokes runZero access with it, immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change runZero state and puts no traffic on the customer's network. Safe for autonomous agents. | `runzero_assets_list`, `runzero_assets_get`, `runzero_assets_search`, `runzero_assets_export`, `runzero_services_list`, `runzero_services_get`, `runzero_services_export`, `runzero_sites_list`, `runzero_sites_get`, `runzero_wireless_list`, `runzero_wireless_get`, `runzero_explorers_list`, `runzero_explorers_get`, `runzero_tasks_list`, `runzero_tasks_get` |
+| **Write** | Changes runZero-side records. Reversible, no customer-network effect. | `runzero_sites_create`, `runzero_tasks_stop` |
+| **Destructive** | Puts active traffic on a customer's production network, now or later. Requires explicit per-call human approval. | `runzero_tasks_create`, `runzero_sites_update` |
+
+`runzero_tasks_create` is the reason this plugin needs a governance
+document at all. It is a `create` against runZero's own API, but what it
+creates is active scanning traffic aimed at a live customer network.
+Discovery probes routinely knock over the fragile end of an MSP's
+estate — PLCs and building-management controllers, medical devices,
+older network printers, legacy embedded appliances — and a `fast` or
+`max` scan rate can saturate a thin branch WAN link or trip the client's
+own IDS into a security incident. The blast radius is the customer's
+production network during business hours. Never grant it to a scheduled
+or unattended agent.
+
+`runzero_sites_update` is the same hazard with a delay. A site's
+excluded ranges are a safety interlock: they are how you record "do not
+touch the CT scanner subnet". Editing scope or removing an exclusion
+does nothing visible at the time, then puts probes on a protected
+network the next time a scheduled scan fires — with nobody watching and
+no obvious link back to the change. It is classified destructive for
+that reason, not for what the call itself does.
+
+`runzero_tasks_stop` sits in Write rather than Destructive: it is the
+one call that makes a customer's network quieter, not busier. It is
+still a real change — an aborted scan leaves partial, misleading
+inventory, and stopping a compliance scan silently creates an evidence
+gap — so it needs approval, just not the same ceremony.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve a scan.**
+
+- Read tools: allow. Inventory queries, service and exposure reporting,
+  rogue-AP review, explorer health checks, and scan-history summaries
+  are the intended autonomous use.
+- Write tools: agent drafts the exact call, human approves, then it runs.
+- Destructive tools: require a named human approver per invocation, and
+  make the approver confirm the target ranges, the scan rate, and the
+  time of day before the call goes out. Do not grant these to scheduled
+  or unattended agents.
+
+## What it cannot reach
+
+- Only the runZero organization and sites mapped to the operator's
+  gateway identity.
+- No filesystem, no shell, no other vendor's data.
+- No control over the explorers themselves — an agent cannot install,
+  upgrade, move, or delete a scan agent through this plugin.
+- No credentialed scanning configuration. Scan-time credentials live in
+  the runZero console and are not exposed here.
+- No live view. Every result is what the last completed scan saw, not
+  current network state.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session
+  and are not persisted by this plugin.
+- `runzero_assets_export` and `runzero_services_export` are bulk
+  egress. They pull a client's entire inventory — hostnames, MAC and IP
+  addressing, OS and firmware versions, open ports, and service
+  banners — in one call. That is a complete network map of the customer,
+  and it is exactly what an attacker would want. Restrict these if your
+  agents run unattended, and never let their output leave your systems
+  unreviewed.
+- `runzero_wireless_*` returns SSIDs, BSSIDs, and encryption modes,
+  including for neighbouring organisations whose RF an explorer can hear.
+- Asset records commonly include the last logged-in user and other
+  attributes that identify individuals.
+
+## Known sharp edges
+
+- **Scan rate is a production risk dial, not a speed preference.** Treat
+  `fast` and `max` as requiring the same approval as maintenance-window
+  work. `normal` is the default for a reason.
+- **runZero data is a snapshot with a timestamp.** An agent reporting
+  "this host is offline" is reporting what a scan saw hours or days ago.
+  Always state the scan time alongside the finding.
+- **Discovery is not vulnerability assessment.** runZero reports what is
+  listening and which version answered; it does not test or score CVEs.
+  An agent that infers "vulnerable" from a version banner is guessing.
+- **Explorer coverage defines the truth.** A site with an offline
+  explorer returns stale-but-plausible results rather than an error.
+  Check explorer health before treating an empty or shrinking inventory
+  as a real finding.
+- **The tier table is derived from this plugin's skills.** Unlike most
+  connectors in this repo there is no local `runzero-mcp` checkout to
+  cross-check tool names against, so confirm the live tool list at the
+  gateway before writing automation that depends on an exact name.

--- a/msp-claude-plugins/runzero/runzero/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/runzero/runzero/skills/api-patterns/SKILL.md
@@ -17,6 +17,14 @@ when_to_use: >-
 
 The RunZero MCP server provides AI tool integration with the RunZero asset discovery and network security platform. It exposes tools covering asset inventory, network scanning, site management, service discovery, wireless detection, and vulnerability reporting. The API uses Bearer token authentication with an Account API Token.
 
+## Anti-triggers
+
+- **Running an export.** This skill explains the Export API's mechanics;
+  the tools that actually pull bulk data are `runzero_assets_export` in
+  `runzero-assets` and `runzero_services_export` in `runzero-services`.
+- **Deciding what to scan.** Query-language syntax lives here, but scan
+  scope and rate belong to `runzero-tasks` and `runzero-sites`.
+
 ## Connection & Authentication
 
 ### Bearer Token Auth

--- a/msp-claude-plugins/runzero/runzero/skills/assets/SKILL.md
+++ b/msp-claude-plugins/runzero/runzero/skills/assets/SKILL.md
@@ -15,6 +15,22 @@ when_to_use: >-
 
 RunZero discovers and inventories every asset on the network -- servers, workstations, IoT devices, OT systems, cloud instances, and more. Each asset includes OS fingerprinting, hardware details, network interfaces, open services, and a full attribute history. This skill covers searching, filtering, and inspecting assets.
 
+## Anti-triggers
+
+- **Live device state.** runZero records what the last scan saw, so it
+  cannot answer "is it up right now", "what is the CPU doing", or "which
+  port is it plugged into". Continuous monitoring and topology are
+  `auvik-devices`; up/down and remote access are `domotz-devices`; the
+  switch or AP's own configuration is `meraki-devices`.
+- **Agent-managed endpoints.** runZero is agentless and discovers from
+  the network, so its record of a workstation is thinner than the
+  sensor's. Agent health, OS build, and logged-in user come from
+  `sentinelone-inventory` or `threatlocker-computers`.
+- **Launching or scheduling the scan** that produces this data — use
+  `runzero-tasks`.
+- **Ports, banners, and protocols** rather than the machine itself — each
+  is its own record; use `runzero-services`.
+
 ## Key Concepts
 
 ### Asset Types

--- a/msp-claude-plugins/runzero/runzero/skills/services/SKILL.md
+++ b/msp-claude-plugins/runzero/runzero/skills/services/SKILL.md
@@ -16,6 +16,17 @@ when_to_use: >-
 
 RunZero discovers services running on every asset -- open ports, protocols, software versions, and TLS configurations. Service data is critical for vulnerability assessment, compliance auditing, and attack surface management. This skill covers listing, filtering, and analyzing discovered services.
 
+## Anti-triggers
+
+- **CVE findings.** runZero reports what is listening and which version
+  answered — it does not score or track vulnerabilities. Patch
+  prioritisation is `sentinelone-vulnerabilities`; cloud posture is
+  `sentinelone-misconfigurations`.
+- **Firewall rules and port forwarding.** An open port here was observed
+  from the explorer's vantage point; the rule that permits it is
+  `meraki-security-appliance`.
+- **The machine rather than the listener** — use `runzero-assets`.
+
 ## Key Concepts
 
 ### Service Attributes

--- a/msp-claude-plugins/runzero/runzero/skills/sites/SKILL.md
+++ b/msp-claude-plugins/runzero/runzero/skills/sites/SKILL.md
@@ -15,6 +15,18 @@ when_to_use: >-
 
 Sites are the primary organizational unit in RunZero. Each site represents a network boundary -- typically a client location, office, data center, or cloud environment. Sites contain assets, define scan targets, and have explorers assigned for discovery. For MSPs, each client typically maps to one or more sites.
 
+## Anti-triggers
+
+- **The customer as a business record.** A runZero site is a network
+  boundary, not a client account — one customer often has several, and
+  the names rarely match. Company records, contacts, and contracts are
+  `connectwise-manage-companies`.
+- **A monitored network in another tool.** Auvik and Meraki both call
+  their boundary a "network"; the IDs are unrelated to runZero site IDs.
+  Use `auvik-networks` or `meraki-devices`.
+- **Launching a scan against the site's ranges** — the site holds the
+  scope, `runzero-tasks` runs it.
+
 ## Key Concepts
 
 ### Site Structure

--- a/msp-claude-plugins/runzero/runzero/skills/tasks/SKILL.md
+++ b/msp-claude-plugins/runzero/runzero/skills/tasks/SKILL.md
@@ -15,6 +15,21 @@ when_to_use: >-
 
 RunZero tasks represent network discovery scans. Each scan is executed by an explorer (scan agent), targets a set of IP ranges or subnets, and discovers assets, services, and network topology. This skill covers creating, managing, and reviewing scan tasks.
 
+## Anti-triggers
+
+- **Vulnerability scanning.** A runZero task fingerprints and inventories;
+  it does not test for CVEs or produce findings. CVE posture is
+  `sentinelone-vulnerabilities`.
+- **A unit of work rather than a network scan.** "Task" collides badly —
+  PSA project tasks and tickets are `connectwise-manage-projects` or
+  `connectwise-manage-tickets`, and an RMM script run is
+  `connectwise-automate-scripts`.
+- **Continuous polling.** Auvik and Domotz watch the network without a
+  scan to launch, so there is no task to create — use `auvik-devices` or
+  `domotz-devices`.
+- **Reading what a scan found** — results live on the records, not the
+  task; use `runzero-assets` or `runzero-services`.
+
 ## Key Concepts
 
 ### Explorers

--- a/msp-claude-plugins/runzero/runzero/skills/wireless/SKILL.md
+++ b/msp-claude-plugins/runzero/runzero/skills/wireless/SKILL.md
@@ -15,6 +15,16 @@ when_to_use: >-
 
 RunZero discovers wireless networks visible from explorer locations, including authorized corporate networks, guest networks, and potential rogue access points. Wireless discovery helps MSPs maintain visibility into the RF environment and identify unauthorized network infrastructure.
 
+## Anti-triggers
+
+- **Configuring or fixing a wireless network.** runZero only observes the
+  RF a nearby explorer can hear; it cannot change an SSID, PSK, channel,
+  or radio setting, and it has no view of client roaming or throughput.
+  Wireless configuration and client troubleshooting are `meraki-devices`
+  and `meraki-troubleshooting`.
+- **The wired side of an AP.** The access point as an inventoried device
+  is `runzero-assets`; its uplink and switch port are `auvik-devices`.
+
 ## Key Concepts
 
 ### Wireless Network Attributes

--- a/msp-claude-plugins/saas-alerts/saas-alerts/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/saas-alerts/saas-alerts/.claude-plugin/plugin.json
@@ -1,8 +1,10 @@
 {
   "name": "saas-alerts",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "SaaS Alerts - SaaS security monitoring and alerting for M365 / Google Workspace: alerts, events, anomaly detection, and multi-tenant response",
-  "author": { "name": "WYRE AI" },
+  "author": {
+    "name": "WYRE AI"
+  },
   "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
   "repository": "https://github.com/wyre-technology/msp-claude-plugins",
   "license": "Apache-2.0"

--- a/msp-claude-plugins/saas-alerts/saas-alerts/GOVERNANCE.md
+++ b/msp-claude-plugins/saas-alerts/saas-alerts/GOVERNANCE.md
@@ -1,0 +1,114 @@
+# SaaS Alerts plugin — governance and safety model
+
+Unofficial. Community-built plugin for the SaaS Alerts API. Not
+affiliated with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches SaaS Alerts through
+the WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which
+brokers authentication centrally and scopes every call to the tenant the
+operator is authorised for.
+
+- No SaaS Alerts partner API key is stored on the technician's machine,
+  in this repo, or in the model's context.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers
+  "who suppressed that alert" — SaaS Alerts' own log records only the
+  partner API account.
+- Revoking gateway access revokes SaaS Alerts access with it,
+  immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change SaaS Alerts state or monitored tenants. Safe for autonomous agents. | `saas_alerts_status`, `saas_alerts_navigate`, `saas_alerts_customers_list`, `saas_alerts_customers_get`, `saas_alerts_events_query`, `saas_alerts_events_query_advanced`, `saas_alerts_events_count`, `saas_alerts_events_count_advanced`, `saas_alerts_events_scroll`, `saas_alerts_recommended_actions`, `saas_alerts_users_get_msp`, `saas_alerts_users_list_partner`, `saas_alerts_users_list_by_customer`, `saas_alerts_devices_list_mapped`, `saas_alerts_devices_list_unmapped`, `saas_alerts_devices_list_ignored`, `saas_alerts_devices_list_orgs`, `saas_alerts_reports_list_scheduled`, `saas_alerts_reports_get_scheduled`, `saas_alerts_billing_list_dates`, `saas_alerts_billing_get_details`, `saas_alerts_partner_get_profile` |
+| **Write** | Creates or modifies records. Reversible, but visible to the customer. | `saas_alerts_customers_create`, `saas_alerts_customers_update`, `saas_alerts_reports_create_scheduled`, `saas_alerts_partner_update_branding` |
+| **Destructive** | Removes monitoring or blinds detection. Requires explicit per-call human approval. | `saas_alerts_customers_set_whitelists`, `saas_alerts_customers_set_account_whitelists`, `saas_alerts_customers_delete`, `saas_alerts_reports_delete_scheduled` |
+
+The two whitelist setters are the entries most likely to be
+mis-classified, so state the reasoning plainly. A whitelist in SaaS
+Alerts **suppresses detection**. Adding an entry does not adjust a
+preference — it stops the platform raising alerts for that condition, in
+that customer's tenant, from that moment on. Nothing fires to announce
+it; the effect is an absence, and absences do not show up in a triage
+sweep. That is a security control being switched off for a paying
+client, which is destructive by blast radius no matter how ordinary the
+HTTP verb looks.
+
+They are also **set**, not **add**. Each call replaces the customer's
+whitelist with whatever payload it is given, so an agent that
+"adds an entry" by sending a single item silently deletes every existing
+entry. Always read the current list first, and require the approver to
+confirm the full resulting list rather than just the new item.
+
+`saas_alerts_customers_delete` removes a monitored customer outright,
+which ends monitoring for that tenant and takes its alert history with
+it.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve a suppression.**
+
+- Read tools: allow. Cross-tenant critical sweeps, per-customer
+  summaries, and impossible-travel pattern hunts are the intended
+  autonomous use.
+- Write tools: agent drafts the exact call, human approves, then it runs.
+  `saas_alerts_partner_update_branding` reaches customer-facing reports,
+  so treat it as customer-visible even though it is trivially
+  reversible.
+- Destructive tools: require a named human approver per invocation. Do
+  not grant these to scheduled or unattended agents. Whitelist changes
+  in particular should carry a documented reason and an expiry review —
+  a suppression added during one incident tends to outlive it by years.
+
+## What it cannot reach
+
+- Only the SaaS Alerts customers beneath the partner account mapped to
+  the operator's gateway identity.
+- No filesystem, no shell, no other vendor's data.
+- **No Microsoft 365 or Google Workspace tenant.** This is the boundary
+  that surprises people most. SaaS Alerts observes SaaS audit logs; it
+  cannot disable an account, revoke sessions, reset MFA, block a
+  sign-in, or remove a mailbox rule. `saas_alerts_recommended_actions`
+  returns guidance for a human to carry out elsewhere, not an executable
+  step. Actual M365 remediation runs through the CIPP connector, under
+  its own governance.
+- No live event stream. Every query is point-in-time.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session
+  and are not persisted by this plugin.
+- `saas_alerts_users_list_by_customer` and `saas_alerts_users_list_partner`
+  return end-user PII — names and email addresses — for every managed
+  tenant. Event payloads add source IP addresses, geolocation, device
+  fingerprints, and sign-in times, which together describe an
+  identifiable person's movements. Restrict these if your agents run
+  unattended.
+- `saas_alerts_billing_*` returns commercial data. `saas_alerts_partner_get_profile`
+  returns MSP account details.
+- Cross-tenant queries (`*_advanced`) can pull the whole customer base
+  into a single context window. Scope them.
+
+## Known sharp edges
+
+- **An empty result is a real answer.** No events for a customer means
+  no events, not a failed call. An agent that invents alerts to fill a
+  quiet report is worse than one that reports nothing; the MCP server's
+  `emptyGuard` signal distinguishes a genuine empty from an error.
+- **Missing alerts may be suppressed, not absent.** If an expected alert
+  never appears, check the customer's whitelist configuration before
+  concluding the tenant is clean.
+- **Time window changes the answer.** A one-hour sweep that returns
+  nothing may return dozens at twenty-four hours. Every finding an agent
+  reports must state the window it used.
+- **Per-partner rate limits bite mid-sweep.** A large multi-tenant run
+  can start returning 429s partway through, which looks like "those
+  customers were clean". Back off and re-run rather than reporting a
+  truncated sweep as complete.
+- **Recommended actions are vendor-generated text.** They are a starting
+  point for an analyst, not a validated runbook, and they assume
+  permissions this plugin does not have.

--- a/msp-claude-plugins/saas-alerts/saas-alerts/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/saas-alerts/saas-alerts/skills/api-patterns/SKILL.md
@@ -20,6 +20,15 @@ anomalies, and policy violations across all managed customer tenants.
 The MSP (partner) sees all customers under their account; each customer
 has one or more accounts (e.g., an M365 tenant, a Google Workspace domain).
 
+## Anti-triggers
+
+- **Working the alert queue.** This skill covers filters, cursors, and
+  the customer hierarchy; sweeping, ranking, and dispositioning events is
+  `saas-alerts-triage`.
+- **A SaaS Alerts customer treated as an M365 tenant.** They describe the
+  same organisation but are separate records with separate IDs, and this
+  API cannot read or change tenant configuration — use `cipp-tenants`.
+
 ## Connection & Authentication
 
 SaaS Alerts uses an API key passed as a request header. The key is issued

--- a/msp-claude-plugins/saas-alerts/saas-alerts/skills/triage/SKILL.md
+++ b/msp-claude-plugins/saas-alerts/saas-alerts/skills/triage/SKILL.md
@@ -23,6 +23,24 @@ The SaaS Alerts MCP surface is well-suited to this: event queries are
 customer-scoped or cross-tenant, severity is a first-class filter, and
 recommended actions are machine-generated per alert.
 
+## Anti-triggers
+
+- **Doing anything about the alert in M365.** SaaS Alerts observes; it
+  cannot disable an account, revoke sessions, reset MFA, or block a
+  sign-in. Once triage says act, the remediation surface is `cipp-users`
+  and `cipp-security` — this skill's `recommended_actions` output is
+  guidance, not an executable step.
+- **Reading tenant configuration.** Whether Conditional Access, MFA
+  enrolment, or a mailbox rule is actually in place comes from the tenant,
+  not the alert feed — use `cipp-security`, `cipp-standards`, or
+  `m365-security`.
+- **Malicious email.** Phishing, quarantine, and message-level verdicts
+  are the email-security stack, not SaaS Alerts sign-in telemetry — use
+  `ironscales-incidents`.
+- **An endpoint compromise.** These events come from SaaS audit logs, so
+  they carry no process, file, or host detail. Endpoint detections are
+  `sentinelone-alerts` or `huntress-incidents`.
+
 ## API Tools
 
 | Tool | Role in Triage |

--- a/msp-claude-plugins/sentinelone/sentinelone/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/sentinelone/sentinelone/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinelone",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Claude plugins for SentinelOne XDR - threat detection, incident response, and endpoint agent management via the Purple AI MCP server",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/sentinelone/sentinelone/GOVERNANCE.md
+++ b/msp-claude-plugins/sentinelone/sentinelone/GOVERNANCE.md
@@ -1,0 +1,108 @@
+# SentinelOne plugin — governance and safety model
+
+Unofficial. Community-built plugin for the SentinelOne Purple MCP
+server. Not affiliated with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches SentinelOne through
+the WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which
+brokers authentication centrally and scopes every call to the tenant the
+operator is authorised for.
+
+- No SentinelOne Service User token is stored on the technician's
+  machine, in this repo, or in the model's context.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers
+  "who ran that Data Lake query" — SentinelOne's own log records only the
+  Service User.
+- Revoking gateway access revokes SentinelOne access with it,
+  immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change SentinelOne or endpoint state. Safe for autonomous agents. | `list_alerts`, `search_alerts`, `get_alert`, `get_alert_notes`, `get_alert_history`, `list_vulnerabilities`, `search_vulnerabilities`, `get_vulnerability`, `get_vulnerability_notes`, `get_vulnerability_history`, `list_misconfigurations`, `search_misconfigurations`, `get_misconfiguration`, `get_misconfiguration_notes`, `get_misconfiguration_history`, `list_inventory_items`, `search_inventory_items`, `get_inventory_item`, `powerquery`, `get_timestamp_range`, `iso_to_unix_timestamp`, `purple_ai` |
+| **Write** | — | None. |
+| **Destructive** | — | None. |
+
+**This plugin is read-only.** There is no tool here that isolates a
+host, kills a process, quarantines a file, rolls back a remediation,
+changes an alert's status, or applies a patch. An agent given every tool
+in this plugin cannot alter a single byte of customer state. For an MSP
+owner deciding what to allow, that is the whole answer.
+
+Two qualifications worth understanding before you rely on it:
+
+- **The read-only property belongs to the tool surface, not to the
+  credential.** The Service User token behind the gateway may well carry
+  response permissions in SentinelOne. Nothing in this plugin exercises
+  them, but if SentinelOne ships response tools in a future Purple MCP
+  release they would appear through the same connection. Re-read this
+  table after a vendor upgrade rather than assuming it still holds.
+- **Read-only is not free.** `powerquery` and `purple_ai` consume real
+  platform quota and can run long — see the sharp edges below.
+
+## Recommended agent policy
+
+With no write or destructive tier, the usual "propose and approve"
+ceremony has nothing to apply to. The policy that matters here is about
+data volume and cost, not about state:
+
+- Allow the alert, vulnerability, misconfiguration, and inventory tools
+  to scheduled and unattended agents. Cross-tenant triage sweeps and QBR
+  reporting are the intended autonomous use.
+- Bound `powerquery` and `purple_ai` — require an explicit time range on
+  every Data Lake query and cap how many an unattended agent may issue
+  per run.
+- Restrict `list_inventory_items` / `search_inventory_items` on the
+  `IDENTITY` surface if your agents run unattended; see data handling.
+
+## What it cannot reach
+
+- Only the SentinelOne accounts and sites mapped to the operator's
+  gateway identity. Purple MCP rejects Global-scope tokens outright, so
+  the connection is Account- or Site-bounded by construction.
+- No filesystem, no shell, no other vendor's data.
+- No response, policy, exclusion, or agent-management surface. Those
+  exist in the SentinelOne console and are not brokered here.
+- No live event stream. Every tool is point-in-time.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session
+  and are not persisted by this plugin.
+- `list_inventory_items` with `surface=IDENTITY` returns end-user PII
+  from Active Directory, Entra ID, and Okta — names, email addresses,
+  department, last-login time, and MFA state, across every managed
+  client. This is the single most sensitive read in the plugin.
+- `powerquery` returns raw endpoint telemetry: command lines, file paths,
+  usernames, and network destinations. A broad query can pull far more
+  customer detail into context than the question required.
+- `purple_ai` sends your prompt to SentinelOne's own model. Treat the
+  query text as leaving your boundary, and do not paste customer
+  credentials or ticket contents into it.
+
+## Known sharp edges
+
+- **Unprefixed tool names.** Purple MCP names its tools `list_alerts`,
+  `get_alert`, and so on, with no vendor prefix. In a session that also
+  has an EDR or PSA connector loaded, an agent can pick the wrong
+  `list_alerts`. Confirm the connector namespace before trusting a
+  cross-vendor comparison.
+- **A broad PowerQuery is a self-inflicted outage.** Queries without a
+  time range scan the whole Data Lake, time out, and burn quota that the
+  SOC needs during a live incident. Always set `fromDate` / `toDate`.
+- **Purple AI writes queries; it does not check them.** Generated
+  PowerQuery is usually right and occasionally wrong in ways that return
+  plausible-but-empty results. An empty result is not proof of a clean
+  environment.
+- **Alert IDs are not stable.** They change after merge operations, so a
+  `get_alert` that 404s does not mean the alert was resolved. Re-query
+  rather than reporting it closed.
+- **Read-only invites over-trust.** Because nothing can be broken, it is
+  tempting to let an agent report findings straight to a customer. The
+  data is point-in-time and scoped to whatever the gateway identity can
+  see; a "zero critical vulnerabilities" summary may simply mean the
+  agent never had visibility of that site.

--- a/msp-claude-plugins/sentinelone/sentinelone/skills/alerts/SKILL.md
+++ b/msp-claude-plugins/sentinelone/sentinelone/skills/alerts/SKILL.md
@@ -15,6 +15,25 @@ All alert tools are **read-only** — you can view, search, and investigate aler
 
 For full field definitions, response examples, and error details see [REFERENCE.md](./REFERENCE.md).
 
+## Anti-triggers
+
+- **A threat the Huntress SOC found.** Both products call their findings
+  alerts or incidents, and both speak of severity, detection, and
+  remediation — the vocabulary overlaps almost completely, the data does
+  not. This skill reads only the SentinelOne console; a Huntress finding
+  appears nowhere in it. Route by which sensor is on the endpoint, not by
+  the word the ticket used — for Huntress use `huntress-incidents`.
+- **Acting on an endpoint** — isolating a host, killing a process,
+  quarantining a file, or rolling back a remediation. Every SentinelOne
+  tool here is read-only; those actions exist only in the SentinelOne
+  console. On a Huntress-managed endpoint the approve/execute
+  remediation flow is `huntress-incidents`.
+- **A CVE finding rather than a detection.** Vulnerabilities carry the
+  same severity, status, notes, and history shape as alerts and are
+  easily mistaken for them; use `sentinelone-vulnerabilities`.
+- **A cloud or Kubernetes posture finding.** Same tool shape again, but
+  the XSPM misconfiguration surface — use `sentinelone-misconfigurations`.
+
 ## MCP Tools
 
 ### list_alerts — List alerts with filters

--- a/msp-claude-plugins/sentinelone/sentinelone/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/sentinelone/sentinelone/skills/api-patterns/SKILL.md
@@ -24,6 +24,16 @@ The Purple MCP server has a dual API architecture:
 - **GraphQL API** - Used for Purple AI, alerts, vulnerabilities, and misconfigurations
 - **REST API** - Used for asset inventory
 
+## Anti-triggers
+
+- **"SentinelOne endpoint" meaning a machine.** This skill's `endpoint`
+  is an HTTP route; a workstation, server, or agent is
+  `sentinelone-inventory`.
+- **Writing or running an actual query.** This skill covers filter and
+  pagination mechanics only — PowerQuery execution is
+  `sentinelone-threat-hunting`, and natural-language investigation is
+  `sentinelone-purple-ai`.
+
 ## Connection & Authentication
 
 ### Service User Token

--- a/msp-claude-plugins/sentinelone/sentinelone/skills/inventory/SKILL.md
+++ b/msp-claude-plugins/sentinelone/sentinelone/skills/inventory/SKILL.md
@@ -22,6 +22,20 @@ The SentinelOne unified asset inventory provides a single view of all assets acr
 
 The inventory uses the **REST API** (not GraphQL), with offset-based pagination and direct filter parameters. All inventory tools are **read-only**.
 
+## Anti-triggers
+
+- **Dedicated network discovery.** The `NETWORK_DISCOVERY` surface is
+  Ranger's passive by-product of the agents you already have. A question
+  about scanning a subnet, fingerprinting an unmanaged device, or
+  inventorying OT/IoT gear belongs to `runzero-assets`; live topology and
+  interface state belong to `auvik-devices`.
+- **What an endpoint detected.** This skill covers the asset record and
+  its agent health; findings on that asset are `sentinelone-alerts`,
+  `sentinelone-vulnerabilities`, or `sentinelone-misconfigurations`.
+- **A Huntress or ThreatLocker agent.** Different vendors' sensors are
+  different fleets with no shared record — use `huntress-agents` or
+  `threatlocker-computers`.
+
 ## MCP Tools
 
 ### Available Tools

--- a/msp-claude-plugins/sentinelone/sentinelone/skills/misconfigurations/SKILL.md
+++ b/msp-claude-plugins/sentinelone/sentinelone/skills/misconfigurations/SKILL.md
@@ -25,6 +25,18 @@ For MSPs, misconfiguration detection is essential for maintaining client securit
 
 All misconfiguration tools are **read-only**. You can view, search, and report on misconfigurations, but you cannot remediate them through the MCP tools.
 
+## Anti-triggers
+
+- **A missing patch rather than a bad setting.** CVEs share this skill's
+  severity/status/notes/history shape and the same XSPM module — use
+  `sentinelone-vulnerabilities`.
+- **M365 tenant baseline drift.** "Compliance" and "posture" here mean
+  cloud and Kubernetes resource configuration. Conditional Access,
+  secure-score, and standards-template drift across managed M365 tenants
+  are `cipp-standards`; mailbox and identity settings are `m365-security`.
+- **An active detection.** A misconfiguration is a standing weakness, not
+  an event — for something that fired, use `sentinelone-alerts`.
+
 ## MCP Tools
 
 ### Available Tools

--- a/msp-claude-plugins/sentinelone/sentinelone/skills/purple-ai/SKILL.md
+++ b/msp-claude-plugins/sentinelone/sentinelone/skills/purple-ai/SKILL.md
@@ -21,6 +21,18 @@ Purple AI is SentinelOne's natural language cybersecurity assistant built into t
 
 Purple AI is the primary starting point for any investigation -- describe what you want to find and it will generate the appropriate PowerQuery or provide analysis. It is **read-only** and cannot take any remediation actions.
 
+## Anti-triggers
+
+- **Executing a query you already have.** `purple_ai` writes PowerQuery;
+  it does not run it. Hand the generated string to
+  `sentinelone-threat-hunting`.
+- **Working the existing alert queue.** Purple AI answers open-ended
+  questions against telemetry — listing, filtering, or reading notes on
+  alerts that already exist is `sentinelone-alerts`.
+- **Hunting on non-SentinelOne telemetry.** Purple AI reasons only over
+  the Singularity Data Lake. Huntress detections are `huntress-signals`;
+  ThreatLocker execution history is `threatlocker-audit-log`.
+
 ## MCP Tools
 
 ### Available Tools

--- a/msp-claude-plugins/sentinelone/sentinelone/skills/threat-hunting/SKILL.md
+++ b/msp-claude-plugins/sentinelone/sentinelone/skills/threat-hunting/SKILL.md
@@ -21,6 +21,17 @@ PowerQuery is SentinelOne's query language for searching the Singularity Data La
 
 > **IMPORTANT:** PowerQuery is a Scalyr-based pipeline query language. It is **NOT** Splunk SPL, SQL, KQL (Kusto), or Elasticsearch Query DSL. The syntax is fundamentally different. The recommended approach is to use the `purple_ai` tool to generate PowerQuery strings from natural language descriptions, then execute them with the `powerquery` tool.
 
+## Anti-triggers
+
+- **A natural-language question with no query yet.** Do not hand-write
+  PowerQuery from a plain-English prompt — `sentinelone-purple-ai`
+  generates it correctly, and this skill executes what it returns.
+- **"Threat hunting" on a Huntress tenant.** The phrase belongs to both
+  products; the telemetry does not. Huntress raw detections are
+  `huntress-signals` and its confirmed threats are `huntress-incidents`.
+- **A specific alert's timeline.** Alert notes and history come from the
+  alert object, not the Data Lake — use `sentinelone-alerts`.
+
 ## MCP Tools
 
 ### Available Tools

--- a/msp-claude-plugins/sentinelone/sentinelone/skills/vulnerabilities/SKILL.md
+++ b/msp-claude-plugins/sentinelone/sentinelone/skills/vulnerabilities/SKILL.md
@@ -21,6 +21,19 @@ Vulnerabilities in SentinelOne are tracked through the Extended Security Posture
 
 All vulnerability tools are **read-only**. You can view, search, and report on vulnerabilities, but you cannot change vulnerability status, apply patches, or take remediation actions through the MCP tools.
 
+## Anti-triggers
+
+- **A bad setting rather than a missing patch.** Exposed buckets,
+  permissive firewall rules, and unrotated keys are the sibling XSPM
+  surface with an identical tool shape — use
+  `sentinelone-misconfigurations`.
+- **"Remediation" meaning deploying the patch.** These tools report; they
+  do not patch or change status. Identify affected endpoints with
+  `sentinelone-inventory`, then drive the actual patch job from the RMM.
+- **Exposure discovered by scanning rather than by an agent.** CVEs here
+  come from endpoints already running a SentinelOne agent; open ports and
+  service banners on unmanaged devices are `runzero-services`.
+
 ## MCP Tools
 
 ### Available Tools

--- a/msp-claude-plugins/threatlocker/threatlocker/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/threatlocker/threatlocker/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "threatlocker",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Claude plugins for ThreatLocker - zero-trust application allowlisting, approval request triage, audit log investigation, and computer/group inventory for MSPs",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/threatlocker/threatlocker/GOVERNANCE.md
+++ b/msp-claude-plugins/threatlocker/threatlocker/GOVERNANCE.md
@@ -1,0 +1,109 @@
+# ThreatLocker plugin — governance and safety model
+
+Unofficial. Community-built plugin for the ThreatLocker Portal API. Not
+affiliated with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches ThreatLocker through
+the WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which
+brokers authentication centrally and scopes every call to the tenant the
+operator is authorised for.
+
+- No ThreatLocker API key is stored on the technician's machine, in this
+  repo, or in the model's context.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers
+  "who pulled that org's auth key" — ThreatLocker's own log records only
+  the partner API account.
+- Revoking gateway access revokes ThreatLocker access with it,
+  immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change ThreatLocker or endpoint state. Safe for autonomous agents. | `threatlocker_status`, `threatlocker_navigate`, `threatlocker_computers_list`, `threatlocker_computers_get`, `threatlocker_computers_get_checkins`, `threatlocker_computer_groups_list`, `threatlocker_computer_groups_dropdown`, `threatlocker_approvals_list`, `threatlocker_approvals_get`, `threatlocker_approvals_pending_count`, `threatlocker_approvals_get_permit_application`, `threatlocker_audit_search`, `threatlocker_audit_get`, `threatlocker_audit_file_history`, `threatlocker_organizations_list_children`, `threatlocker_organizations_for_move_computers` |
+| **Write** | — | None. |
+| **Destructive** | Discloses a live tenant credential. Requires explicit per-call human approval. | `threatlocker_organizations_get_auth_key` |
+
+**Nothing in this plugin can change a ThreatLocker policy.** There is no
+tool that approves an application, permits a hash, edits a policy, moves
+a computer between groups, or changes an org's mode. Those actions exist
+only in the ThreatLocker portal. This matters more than usual for a
+default-deny product: a wrong allowlist change locks a customer out of
+their line-of-business application, and an agent using this plugin
+cannot make one.
+
+`threatlocker_organizations_get_auth_key` sits in the destructive tier
+despite being a plain read. It returns a live per-organization
+credential — the value used to enrol agents into that tenant. Judged by
+HTTP verb it is a `get`; judged by blast radius, one call hands the
+model, the transcript, and anything downstream of them a working key to
+a customer's ThreatLocker tenant, and the key keeps working until
+someone rotates it. Treat every invocation as a credential checkout with
+a named approver, exactly as you would a password-manager retrieval.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, never self-approve the auth-key
+call.**
+
+- Read tools: allow. Fleet audits, offline-agent triage, per-tenant
+  approval-queue counts, and Action Log forensics are the intended
+  autonomous use.
+- Write tools: none exist. An agent asked to "just approve it" should
+  hand the operator a reviewed recommendation and stop.
+- `threatlocker_organizations_get_auth_key`: require a named human
+  approver per invocation, and do not grant it to scheduled or
+  unattended agents at all.
+
+## What it cannot reach
+
+- Only the ThreatLocker organizations beneath the partner org mapped to
+  the operator's gateway identity. A child-scoped key sees one tenant; a
+  partner key sees the whole tree.
+- No filesystem, no shell, no other vendor's data.
+- No policy, application, or approval-decision surface — read-only
+  against the entities listed above.
+- No live event stream. The Action Log is queried point-in-time.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session
+  and are not persisted by this plugin.
+- `threatlocker_organizations_get_auth_key` returns a **secret**. Never
+  let it land in a ticket, a chat message, a commit, or an unencrypted
+  note. If one is exposed, rotate it in the portal — a previously issued
+  key keeps working until you do.
+- The Action Log (`threatlocker_audit_*`) returns end-user PII by
+  design: usernames, computer names, full file paths including user
+  profile directories, and parent-process command context.
+- `threatlocker_approvals_*` returns free-text user justifications, which
+  routinely contain ticket numbers, client names, and occasionally
+  credentials a user typed into the wrong box.
+
+## Known sharp edges
+
+- **Blocks are not detections.** ThreatLocker denies everything not
+  explicitly permitted, so a wall of Block entries is normal operation,
+  not evidence of an attack. An agent that reports block volume as a
+  threat metric will generate false alarms every time a client installs
+  new software.
+- **Approval recommendations carry real consequences.** The queue is
+  where an agent's analysis actually reaches a customer: a confident
+  "approve" on an unsigned binary that a technician then rubber-stamps
+  in the portal is how malware gets allowlisted. Require the reasoning,
+  the hash, and the permit scope
+  (`threatlocker_approvals_get_permit_application`) in every
+  recommendation.
+- **Permits land at group scope, not on one machine.** Approving for one
+  requester applies the policy to every computer in that group. Agents
+  routinely under-state this.
+- **Partner keys fan out silently.** With `childOrganizations: true` a
+  single call sweeps every client at once. Convenient for reporting, and
+  the reason a careless query can pull the whole customer base into
+  context.
+- **POST-based list endpoints.** ThreatLocker's "list" calls are POSTs
+  against `GetByParameters`. Do not infer safety from the HTTP verb
+  anywhere in this API — use the tier table above.

--- a/msp-claude-plugins/threatlocker/threatlocker/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/threatlocker/threatlocker/skills/api-patterns/SKILL.md
@@ -24,6 +24,16 @@ that surprise people: the auth header does NOT use `Bearer`, and most
 "list" endpoints are POSTs against `/Entity/EntityGetByParameters` with
 a structured body — not GETs with query strings.
 
+## Anti-triggers
+
+- **Enumerating or pivoting between tenants.** This skill explains the
+  `organizationId` header and the `childOrganizations` flag; the tools
+  that actually list children, fetch auth keys, and resolve move targets
+  are `threatlocker-organizations`.
+- **Reading or storing an organization's auth key.** The header mechanics
+  are here, but the tool that returns a live credential is in
+  `threatlocker-organizations` — treat its output as a secret.
+
 ## Connection & Authentication
 
 ### Raw API Key Header

--- a/msp-claude-plugins/threatlocker/threatlocker/skills/approval-requests/SKILL.md
+++ b/msp-claude-plugins/threatlocker/threatlocker/skills/approval-requests/SKILL.md
@@ -22,6 +22,19 @@ computer it ran on, and a free-text justification. Triaging this queue
 well is the difference between a productive ThreatLocker deployment
 and a frustrated client.
 
+## Anti-triggers
+
+- **A malware detection.** ThreatLocker is default-deny allowlisting, not
+  EDR — it blocks everything unlisted and has no verdict on whether a
+  binary is malicious. A request in this queue means "policy said no",
+  not "something was detected". Convictions and confirmed threats are
+  `sentinelone-alerts` or `huntress-incidents`.
+- **What the binary actually did on the endpoint.** The request record
+  carries only the metadata the user submitted; execution history,
+  process chain, and prior blocks are `threatlocker-audit-log`.
+- **Which endpoints an approval would cover.** Permits land at group
+  scope, so the blast radius question is `threatlocker-computer-groups`.
+
 ## API Tools
 
 ### List Approval Requests

--- a/msp-claude-plugins/threatlocker/threatlocker/skills/audit-log/SKILL.md
+++ b/msp-claude-plugins/threatlocker/threatlocker/skills/audit-log/SKILL.md
@@ -20,6 +20,22 @@ every block, every permit, every audit-only match generates an entry.
 This is your forensics surface: when something happened on an endpoint,
 this is where you find out what.
 
+## Anti-triggers
+
+- **Admin change history.** The Action Log records what executed on
+  endpoints, not who edited a policy or approved a request in the
+  console. For approval decisions use
+  `threatlocker-approval-requests`; for who invoked a tool through the
+  gateway, see the plugin's `GOVERNANCE.md`.
+- **A pending request rather than a past block.** A user waiting on an
+  application is in the queue, not the log — use
+  `threatlocker-approval-requests`.
+- **Detection telemetry.** Every entry here is a policy outcome (Block,
+  Permit, Audit), never a threat verdict. Behavioural detections are
+  `sentinelone-threat-hunting` or `huntress-signals`.
+- **Whether an agent is reporting at all.** An empty log usually means a
+  stale agent; check check-in state with `threatlocker-computers`.
+
 ## API Tools
 
 ### Search Action Log

--- a/msp-claude-plugins/threatlocker/threatlocker/skills/computer-groups/SKILL.md
+++ b/msp-claude-plugins/threatlocker/threatlocker/skills/computer-groups/SKILL.md
@@ -20,6 +20,19 @@ A computer must belong to exactly one group, and moving a computer
 between groups changes which policy set applies to it. Groups can be
 **global** (visible across all child organizations) or **org-specific**.
 
+## Anti-triggers
+
+- **A directory group.** "Group" here is a ThreatLocker policy boundary
+  with no relationship to Entra ID or Active Directory membership.
+  Security and distribution groups in a managed M365 tenant are
+  `cipp-groups`.
+- **The client a computer belongs to.** Tenancy is the organization, not
+  the group; a computer sits in exactly one of each — use
+  `threatlocker-organizations`.
+- **Why a specific execution was blocked.** The group only says which
+  policy set applied; the individual block and the resulting request are
+  `threatlocker-audit-log` and `threatlocker-approval-requests`.
+
 ## API Tools
 
 ### List Computer Groups (Full)

--- a/msp-claude-plugins/threatlocker/threatlocker/skills/computers/SKILL.md
+++ b/msp-claude-plugins/threatlocker/threatlocker/skills/computers/SKILL.md
@@ -20,6 +20,17 @@ is bound to a computer group, which in turn carries the policies that
 govern allow/deny behavior. This skill covers fleet inventory, offline
 agent identification, and drilling into a single endpoint's history.
 
+## Anti-triggers
+
+- **Machines without a ThreatLocker agent.** This list is the protected
+  fleet only, so it can never answer "what else is on this network".
+  Discovery of unmanaged, IoT, and OT devices is `runzero-assets`; live
+  network devices and topology are `auvik-devices`.
+- **Another vendor's sensor fleet.** Agent counts do not reconcile
+  across products — use `sentinelone-inventory` or `huntress-agents`.
+- **Which policies apply to a machine.** Policy is attached to the group,
+  never to the computer — use `threatlocker-computer-groups`.
+
 ## API Tools
 
 ### List Computers

--- a/msp-claude-plugins/threatlocker/threatlocker/skills/organizations/SKILL.md
+++ b/msp-claude-plugins/threatlocker/threatlocker/skills/organizations/SKILL.md
@@ -19,6 +19,15 @@ authenticate with belongs to a parent (partner) org and can see all
 of its children. Most fleet-wide reporting and any tenant pivot work
 runs through this skill.
 
+## Anti-triggers
+
+- **Policy scope.** An organization is a tenant boundary; the thing that
+  decides which allow/deny rules apply is the computer group — use
+  `threatlocker-computer-groups`.
+- **An M365 tenant.** ThreatLocker child orgs and Microsoft tenants are
+  separate directories that happen to describe the same customer; tenant
+  onboarding, GDAP, and standards live in `cipp-tenants`.
+
 ## API Tools
 
 ### List Child Organizations


### PR DESCRIPTION
Applies the repo-wide connector-quality standard to security batch B.
Branched from `feat/skill-anti-triggers-governance`, so that PR should land first.

Authorities followed: `_templates/skill-template/SKILL.md`,
`_standards/skill-quality-checklist.md`, `_templates/governance-template.md`,
and the `huntress` worked exemplar.

## Task A — `## Anti-triggers`

| Plugin | Skills | Added | Skipped |
|---|---|---|---|
| `runzero` | 6 | 6 | 0 |
| `saas-alerts` | 2 | 2 | 0 |
| `sentinelone` | 7 | 7 | 0 |
| `threatlocker` | 6 | 6 | 0 |

**21/21 added, 0 skipped.** Nothing was skipped because every skill in this
batch sits in a genuine collision — the four vendors overlap each other
(SentinelOne/Huntress EDR, ThreatLocker/EDR, runZero/auvik/domotz/meraki,
SaaS Alerts/CIPP/M365) *and* have confusable siblings inside their own plugin.
Where a section would have been filler it was cut rather than padded: four
`api-patterns` skills initially carried a "gateway handles auth" bullet, which
was removed because it named a doc rather than a skill to load, which the
checklist requires.

Referenced destinations were verified to resolve to real skill directories
(`auvik-devices`, `auvik-networks`, `domotz-devices`, `meraki-devices`,
`meraki-security-appliance`, `meraki-troubleshooting`, `cipp-users`,
`cipp-security`, `cipp-standards`, `cipp-tenants`, `cipp-groups`,
`m365-security`, `ironscales-incidents`, `connectwise-manage-*`,
`connectwise-automate-scripts`, `huntress-*`). No files outside this batch
were edited.

## Task B — `GOVERNANCE.md`

One per plugin. Tool names derived from each plugin's own skills and
cross-checked against `~/mcp/<vendor>-mcp/src/` where a checkout exists
(saas-alerts, threatlocker, sentinelone). Nothing invented.

Classified by **blast radius, not HTTP verb**:

- **`saas-alerts`** — `saas_alerts_customers_set_whitelists` and
  `..._set_account_whitelists` are **destructive**. A whitelist suppresses
  detection: it switches a security control off for a paying client, silently,
  and the effect is an absence that never shows up in a triage sweep. They are
  also *set* (replace) semantics, so an agent "adding" one entry wipes the rest.
  Plus `customers_delete`, `reports_delete_scheduled`.
- **`threatlocker`** — `threatlocker_organizations_get_auth_key` is
  **destructive** despite being a plain read. It returns a live per-tenant
  credential that keeps working until rotated; one call hands the model and the
  transcript a working key to a customer's tenant. Treated as a credential
  checkout with a named approver.
- **`runzero`** — `runzero_tasks_create` is **destructive**: it creates active
  scanning traffic against a live customer network, which routinely knocks over
  PLCs, medical devices, and legacy printers. `runzero_sites_update` is
  **destructive** too, because a site's excluded ranges are a safety interlock —
  removing one does nothing visible now and probes a protected subnet on the
  next scheduled run. `runzero_tasks_stop` was deliberately left in **Write**:
  it makes the network quieter, not busier; its harm is truncated inventory and
  compliance evidence gaps.
- **`sentinelone`** — **read-only, no write or destructive tier.** All 22 tools
  are reads. The doc says so plainly and adds the qualification that matters:
  read-only is a property of the upstream Purple MCP *tool surface*, not of the
  Service User credential, so the table must be re-read after a vendor upgrade.
- **`threatlocker`** — **no write tier.** No tool approves an application,
  edits a policy, or moves a computer. Stated explicitly, because for a
  default-deny product "the agent cannot lock your client out of their LOB app"
  is the answer an MSP owner is actually looking for.

## Judgement calls worth review

1. **The parent brief anticipated isolate / kill-process / rollback tools on
   SentinelOne and policy-change tools on ThreatLocker. Neither exists.** Both
   plugins are read-only. Rather than invent tool names, both governance docs
   state the absence as the finding and explain what it does and does not
   protect you from.
2. **`runzero_sites_update` as destructive** is the most arguable call — the
   call itself changes only a runZero record. It is tiered on delayed effect.
3. **`runzero_tasks_stop` as Write, not Destructive** — argued the other way in
   the doc; happy to promote it if reviewers disagree.
4. **Tool-name drift found, not fixed** (additive-only constraint): several
   skills reference tools the MCP servers do not expose —
   `saas_alerts_users_get`, `saas_alerts_devices_get`, `saas_alerts_billing_get`,
   `threatlocker_organizations_get`, `threatlocker_computer_groups_get`. The
   governance tables use the server-verified names. Worth a follow-up PR.
5. **`runzero` has no local `runzero-mcp` checkout**, so its tier table is
   skill-derived only. Flagged as a sharp edge inside the doc itself.

## Constraints honoured

- Touched only `msp-claude-plugins/{runzero,saas-alerts,sentinelone,threatlocker}/`
- No `_standards/`, `_templates/`, `marketplace.json`, or `plugins.ts` changes
- `npm run generate` not run
- No `triggers:` frontmatter (#158)
- Additive only — 262 insertions, 0 deletions across the 21 skills
- All SKILL.md files remain under the ~350-line guideline
