### PR TITLE
feat: anti-triggers and governance docs for email security vendor plugins

### DIFF
--- a/msp-claude-plugins/abnormal/abnormal-security/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/abnormal/abnormal-security/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "abnormal-security",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Claude plugins for Abnormal Security - AI-powered email security, threat detection, abuse mailbox cases, account takeover protection, vendor risk assessment, and message analysis for MSPs",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/abnormal/abnormal-security/GOVERNANCE.md
+++ b/msp-claude-plugins/abnormal/abnormal-security/GOVERNANCE.md
@@ -1,0 +1,101 @@
+# Abnormal Security plugin — governance and safety model
+
+Unofficial. Community-built plugin for the Abnormal Security API. Not
+affiliated with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches Abnormal Security
+through the WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`),
+which brokers authentication centrally and scopes every call to the
+tenant the operator is authorised for.
+
+- No Abnormal API token is stored on the technician's machine, in this
+  repo, or in the model's context.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers
+  "who pulled that message out of the CFO's inbox" — Abnormal's own log
+  records only the API token.
+- Revoking gateway access revokes Abnormal access with it, immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change mailbox or Abnormal state. Safe for autonomous agents. | `abnormal_threats_list`, `abnormal_threats_get`, `abnormal_messages_list`, `abnormal_messages_get`, `abnormal_cases_list`, `abnormal_cases_get`, `abnormal_abuse_list`, `abnormal_navigate`, `abnormal_status` |
+| **Write** | Empty. Abnormal exposes no reversible bookkeeping write — the only mutating tool acts directly on customer mailboxes. | — |
+| **Destructive** | Moves real mail into or out of a user's mailbox. Requires explicit per-call human approval. | `abnormal_remediation_manage` |
+
+`abnormal_remediation_manage` is a single tool carrying three actions of
+very different blast radius: `status` reads, `remediate` pulls a message
+out of every mailbox that received it, and `unremediate` puts it back.
+The gateway tiers by tool name, not by argument, so the whole tool sits
+in the destructive tier. That is the correct conservative reading — an
+agent that can call it for `status` can call it for `unremediate`.
+
+`unremediate` deserves separate attention. It reads like an undo, but
+what it actually does is deliver a message Abnormal classified as an
+attack into a user's inbox. Treat it as a delivery decision, not a
+correction.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.**
+
+- Read tools: allow. Cross-tenant threat triage and abuse-mailbox
+  reporting are the intended autonomous use.
+- Write tools: none exist here.
+- Destructive tools: require a named human approver per invocation. Do
+  not grant `abnormal_remediation_manage` to scheduled or unattended
+  agents, including for `status` checks.
+
+## What it cannot reach
+
+- Only the Abnormal tenants mapped to the operator's gateway identity.
+  An Abnormal API token is issued per tenant; multi-customer coverage
+  means multiple tokens, each separately mapped.
+- No filesystem, no shell, no other vendor's data.
+- No identity actions. The account-takeover skill describes password
+  resets, session revocation, and inbox-rule removal, but no tool here
+  performs them — those run through CIPP or Microsoft Graph against the
+  M365 tenant.
+- No pre-delivery view. Abnormal inspects mail after Microsoft has
+  delivered it; anything a gateway blocked upstream is invisible.
+- No live stream. Every tool is point-in-time.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session
+  and are not persisted by this plugin.
+- `abnormal_messages_get` and `abnormal_messages_list` return the
+  substance of a customer's email: subject lines, To/CC/BCC addresses,
+  full header sets including `Authentication-Results`, attachment
+  filenames and types, and every URL in the body.
+- `abnormal_threats_get` and `abnormal_threats_list` return sender and
+  recipient addresses, sender IP, the impersonated party, and whether
+  the recipient read the message.
+- `abnormal_cases_get`, `abnormal_cases_list`, and `abnormal_abuse_list`
+  return the reporting employee's address plus the reported message's
+  sender and subject.
+- In practice every non-navigation tool here returns recipient PII.
+  There is no PII-free read tier; scope accordingly rather than assuming
+  "read-only" means "safe to log".
+
+## Known sharp edges
+
+- **Remediation is not recall of a single copy.** It targets every
+  mailbox that received the message. A false positive removed
+  organisation-wide is a customer-visible event.
+- **`isRead` is a snapshot, not proof.** A message remediated after
+  delivery may still have been opened, clicked, and acted on. Do not let
+  an agent conclude "no exposure" from a remediated status.
+- **Skills document tools the server does not expose.** The skill files
+  reference `abnormal_ato_*`, `abnormal_vendors_*`,
+  `abnormal_threats_remediate`, `abnormal_cases_action`, and
+  `abnormal_messages_headers`. The shipped MCP server exposes only the
+  ten tools tiered above. Calls to the others fail with an unknown-tool
+  response — tier the real names, not the documented ones.
+- **Rate limits degrade mid-task.** 60 requests/minute per token; a
+  broad multi-tenant sweep will hit 429 partway through and return
+  partial results that look complete.

--- a/msp-claude-plugins/abnormal/abnormal-security/skills/account-takeover/SKILL.md
+++ b/msp-claude-plugins/abnormal/abnormal-security/skills/account-takeover/SKILL.md
@@ -19,6 +19,21 @@ when_to_use: >-
 
 Abnormal Security's Account Takeover Protection monitors sign-in activity and mailbox behavior to detect compromised internal accounts. By analyzing user behavior patterns, device fingerprints, sign-in locations, and mailbox rule changes, Abnormal identifies accounts that have been taken over by attackers. This skill covers ATO case management, investigation workflows, and remediation actions.
 
+## Anti-triggers
+
+- **Actually resetting the password or revoking the sessions** —
+  Abnormal detects the compromise; the identity change happens in the
+  M365 tenant. Use `cipp-users`.
+- **Actually deleting the malicious inbox rule or forwarding address** —
+  use `Microsoft 365 Mailboxes`.
+- **A malicious email that has not compromised anyone** — inbound attack
+  detection is `Abnormal Security Threats`.
+- **The compromised mailbox belongs to a supplier, not your customer** —
+  external senders are scored separately; use
+  `Abnormal Security Vendors`.
+- **Abuse-mailbox cases** — despite the shared `caseId` vocabulary those
+  are user-reported email submissions; use `Abnormal Security Cases`.
+
 ## Account Takeover Indicators
 
 | Indicator | Description | Risk Level |

--- a/msp-claude-plugins/abnormal/abnormal-security/skills/cases/SKILL.md
+++ b/msp-claude-plugins/abnormal/abnormal-security/skills/cases/SKILL.md
@@ -18,6 +18,21 @@ when_to_use: >-
 
 Abnormal Security's Abuse Mailbox automatically processes user-reported suspicious emails. When users forward or report emails to a designated abuse mailbox address, Abnormal analyzes the reported message and creates a case with an AI-generated judgment. This skill covers case lifecycle, triage workflows, remediation actions, and bulk operations.
 
+## Anti-triggers
+
+- **A `caseId` that came from an account-takeover alert** — ATO cases are
+  a separate object with their own IDs and remediation set, and both
+  skills call the identifier `caseId`; use
+  `Abnormal Security Account Takeover`.
+- **Threats Abnormal found on its own** — no user reported them, so no
+  case exists; use `Abnormal Security Threats`.
+- **User-reported phishing in a different platform** — IRONSCALES runs
+  its own report-to-incident loop from its Outlook and Gmail add-ins,
+  with separate IDs and its own classification verbs; use
+  `IRONSCALES Incidents`.
+- **A user who reported a simulated phish** — campaign reporting rates
+  belong to the training platform; use `KnowBe4 Phishing`.
+
 ## Case Lifecycle
 
 ```

--- a/msp-claude-plugins/abnormal/abnormal-security/skills/messages/SKILL.md
+++ b/msp-claude-plugins/abnormal/abnormal-security/skills/messages/SKILL.md
@@ -18,6 +18,19 @@ when_to_use: >-
 
 Abnormal Security provides deep message analysis capabilities beyond basic threat detection. This skill covers message retrieval, header inspection, attachment analysis, sender authentication results, and delivery context. Use it when performing forensic analysis of specific emails or investigating delivery patterns.
 
+## Anti-triggers
+
+- **Where a message went, or why it never arrived** — Abnormal sees
+  messages only as evidence attached to a detected threat. It has no
+  delivery pipeline, no queue, and no bounce record, so "trace this
+  email" questions belong to the gateway: use
+  `Mimecast Message Tracking`.
+- **Removing the message from inboxes, or putting it back** — that is
+  the remediation surface; use `Abnormal Security Threats`.
+- **Inspecting a message a gateway is holding** — everything Abnormal
+  can show was already delivered. Pre-delivery holds are
+  `SpamTitan Quarantine` or `Proofpoint Quarantine`.
+
 ## Message Field Reference
 
 ### Core Message Fields

--- a/msp-claude-plugins/abnormal/abnormal-security/skills/threats/SKILL.md
+++ b/msp-claude-plugins/abnormal/abnormal-security/skills/threats/SKILL.md
@@ -20,6 +20,25 @@ when_to_use: >-
 
 Abnormal Security uses behavioral AI to detect email threats that bypass traditional secure email gateways (SEGs). Unlike signature or rule-based detection, Abnormal profiles normal communication patterns and detects deviations indicative of attacks. This skill covers threat types, attack vectors, severity assessment, remediation, and investigation workflows.
 
+## Anti-triggers
+
+- **An email a user reported to the abuse mailbox** — those arrive as
+  cases carrying their own AI judgment and action set; use
+  `Abnormal Security Cases`.
+- **A mailbox behaving strangely rather than an email arriving** —
+  impossible travel, new inbox rules, and lateral sending are account
+  compromise; use `Abnormal Security Account Takeover`.
+- **Header, SPF/DKIM/DMARC, or attachment forensics on one message** —
+  use `Abnormal Security Messages`.
+- **Releasing something from a quarantine queue** — Abnormal has no
+  gateway queue. It inspects mail post-delivery through the M365 API and
+  pulls it back out of inboxes. Anything sitting in a hold queue belongs
+  to the gateway holding it: `SpamTitan Quarantine`,
+  `Mimecast Message Tracking`, or `Proofpoint Quarantine`.
+- **A threat the gateway already stopped** — mail blocked before
+  delivery never reaches the mailbox, so Abnormal never sees it. Search
+  the gateway's own logs.
+
 ## Threat Types
 
 | Type | Description | Severity Range |

--- a/msp-claude-plugins/abnormal/abnormal-security/skills/vendors/SKILL.md
+++ b/msp-claude-plugins/abnormal/abnormal-security/skills/vendors/SKILL.md
@@ -18,6 +18,17 @@ when_to_use: >-
 
 Abnormal Security's VendorBase provides AI-driven vendor risk assessment by analyzing email communication patterns between your organization and its vendors. It detects compromised vendor accounts, assesses vendor risk levels, and alerts on suspicious vendor behavior. This is critical for protecting against supply chain email attacks where a trusted vendor's account is taken over and used to send malicious emails.
 
+## Anti-triggers
+
+- **"Vendor" meaning a distributor or product catalogue** — VendorBase
+  scores external parties who email your customer, not suppliers you buy
+  from. Resale catalogue, SKUs, and supplier records are `Pax8 Products`.
+- **One specific malicious email from a vendor domain** — the vendor
+  record carries the risk score; the message carries the attack. Use
+  `Abnormal Security Threats`.
+- **A compromised mailbox inside your customer's own tenant** — use
+  `Abnormal Security Account Takeover`.
+
 ## Vendor Risk Levels
 
 | Level | Score Range | Description | Action |

--- a/msp-claude-plugins/ironscales/ironscales/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/ironscales/ironscales/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironscales",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Claude plugins for IRONSCALES - AI-powered anti-phishing, incident triage, email classification, and crowdsourced threat intelligence",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/ironscales/ironscales/GOVERNANCE.md
+++ b/msp-claude-plugins/ironscales/ironscales/GOVERNANCE.md
@@ -1,0 +1,114 @@
+# IRONSCALES plugin — governance and safety model
+
+Unofficial. Community-built plugin for the IRONSCALES API. Not
+affiliated with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches IRONSCALES through the
+WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the tenant the
+operator is authorised for.
+
+- No IRONSCALES API key or company ID is stored on the technician's
+  machine, in this repo, or in the model's context.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers
+  "who classified that as legitimate" — IRONSCALES records only the API
+  account.
+- Revoking gateway access revokes IRONSCALES access with it,
+  immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change mailbox, incident, or policy state. Safe for autonomous agents. | `ironscales_incidents_list`, `ironscales_incidents_get`, `ironscales_stats_company`, `ironscales_email_classify`, `ironscales_navigate`, `ironscales_status`, `ironscales_back` |
+| **Write** | Empty. Nothing here changes a record without also changing mail delivery or detection coverage. | — |
+| **Destructive** | Deletes mail, alters what the filter will catch in future, or notifies end users. Requires explicit per-call human approval. | `ironscales_remediation_act`, `ironscales_allowlist_manage` |
+
+`ironscales_remediation_act` is destructive under every value of its
+`action` argument, not only `delete`:
+
+- `delete` removes the message from all mailboxes permanently — the
+  evidence goes with it.
+- `quarantine` moves mail out of inboxes across the tenant.
+- `block_sender` changes deliverability for every future message from
+  that address.
+- `mark_false_positive` restores a message that was classified as
+  phishing back to the users who received it.
+- `report_to_microsoft` transmits a customer's email to a third party
+  and cannot be recalled.
+
+It also accepts `notify_users`, which fans out mail to affected end
+users. That notification cannot be unsent.
+
+`ironscales_allowlist_manage` sits in the destructive tier as a
+judgement call. Adding an entry permanently exempts a sender, domain, or
+IP from phishing detection for the whole company — a silent, durable
+reduction in the customer's protection that produces no alert and no
+visible change until an attacker spoofs the exempted sender. The verb is
+benign; the blast radius is not. Reasonable operators may argue this
+belongs in Write; we would rather it require an approver.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.**
+
+- Read tools: allow. Triage sweeps, backlog review, and weekly
+  statistics reporting are the intended autonomous use.
+- Write tools: none exist here.
+- Destructive tools: require a named human approver per invocation. Do
+  not grant either destructive tool to scheduled or unattended agents.
+  In particular, an agent that auto-classifies high-confidence incidents
+  and then auto-remediates them is one model error away from deleting a
+  customer's legitimate mail.
+
+## What it cannot reach
+
+- Only the IRONSCALES company ID mapped to the operator's gateway
+  identity. IRONSCALES scopes credentials per company, so an MSP with
+  many customers has many mappings — there is no cross-tenant query.
+- No filesystem, no shell, no other vendor's data.
+- No pre-delivery queue. IRONSCALES acts on mail already sitting in
+  mailboxes; anything a gateway held upstream is out of scope.
+- No identity actions. Remediation removes mail and blocks senders; it
+  cannot reset a credential a phish harvested.
+- Remediation reach depends on the customer's M365/Exchange integration,
+  not on this plugin's permissions. Partial success is normal and
+  reported as such.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session
+  and are not persisted by this plugin.
+- `ironscales_incidents_get` and `ironscales_incidents_list` return
+  subject lines, sender and reply-to addresses, sender IP, per-URL
+  verdicts, and recipient counts for a customer's real mail.
+- `ironscales_stats_company` returns `topTargetedUsers` — a named list
+  of the customer's most-attacked employees. Treat it as sensitive
+  security information, not a metric.
+- `ironscales_email_classify` is the inverse flow: the operator supplies
+  raw headers, plain-text and HTML bodies, and URLs, which are sent to
+  IRONSCALES for analysis. It changes no state, so it is tiered Read,
+  but it exports customer email content outbound. Do not paste content
+  from a tenant the operator is not authorised for.
+
+## Known sharp edges
+
+- **Classification fires remediation automatically.** Classifying an
+  incident as phishing can trigger the configured remediation without a
+  second call. An agent that "just labels" the backlog may find it has
+  deleted mail. Check `remediationTriggered` before assuming a
+  classification was inert.
+- **Closed incidents cannot be reclassified.** The resulting error reads
+  like a permissions failure. Verify status first.
+- **Allowlist scope is narrower than it looks.** An entry for a single
+  address does not cover other addresses on the same domain; an agent
+  told to "allowlist this vendor" will under-deliver unless it uses a
+  domain entry — which is a much larger trust grant.
+- **Federated learning is one-way but not private-by-default.**
+  Classification decisions feed IRONSCALES' cross-tenant model. That is
+  the product working as designed, and worth stating to customers with
+  data-residency requirements.

--- a/msp-claude-plugins/ironscales/ironscales/skills/incidents/SKILL.md
+++ b/msp-claude-plugins/ironscales/ironscales/skills/incidents/SKILL.md
@@ -20,6 +20,22 @@ when_to_use: >-
 
 Ironscales combines AI-powered threat detection with crowdsourced employee phishing reports to identify and remediate phishing attacks. When a user reports a suspicious email (via the Ironscales Outlook add-in or Gmail extension) or Ironscales AI auto-detects a threat, an incident is created. Security administrators triage these incidents, classify each email, and take remediation actions. Ironscales uses federated learning — decisions made on one tenant inform the global threat model, improving detection over time.
 
+## Anti-triggers
+
+- **A phishing report that arrived in a different platform** — Ironscales
+  incidents originate from its own add-in or its own AI. Abnormal's abuse
+  mailbox produces separate objects with separate IDs; use
+  `Abnormal Security Cases`.
+- **A simulated phish, or who clicked one** — Ironscales incidents come
+  from real inbound mail. Campaign results and click rates are
+  `KnowBe4 Phishing`.
+- **Mail held at a gateway before it reached anyone** — Ironscales acts
+  on mail already sitting in mailboxes and has no pre-delivery queue. Use
+  `SpamTitan Quarantine` or `Mimecast Message Tracking`.
+- **Resetting the credentials a phish harvested** — remediation here
+  removes mail and blocks senders. The identity action happens in the
+  tenant; use `cipp-users`.
+
 ## Key Concepts
 
 ### Incident Sources

--- a/msp-claude-plugins/mimecast/mimecast/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/mimecast/mimecast/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mimecast",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Claude plugins for Mimecast Email Security - message tracking, threat intelligence, queue management, and email security operations",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/mimecast/mimecast/GOVERNANCE.md
+++ b/msp-claude-plugins/mimecast/mimecast/GOVERNANCE.md
@@ -1,0 +1,114 @@
+# Mimecast plugin — governance and safety model
+
+Unofficial. Community-built plugin for the Mimecast API. Not affiliated
+with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches Mimecast through the
+WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the tenant the
+operator is authorised for.
+
+- No Mimecast client ID or client secret is stored on the technician's
+  machine, in this repo, or in the model's context. The gateway performs
+  the OAuth 2.0 client-credentials exchange and refreshes the token.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers
+  "who released that message" — Mimecast's own audit log records the API
+  application, and the release then appears under the same actor for
+  every technician.
+- Revoking gateway access revokes Mimecast access with it, immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change mail flow or Mimecast state. Safe for autonomous agents. | `mimecast_find_message`, `mimecast_get_message_info`, `mimecast_get_queue_status`, `mimecast_get_threat_incidents`, `mimecast_get_ttp_logs`, `mimecast_get_audit_events`, `mimecast_navigate`, `mimecast_status` |
+| **Write** | Stops one message reaching one recipient. Reversible, and visible to the customer as a delayed email. | `mimecast_hold_message` |
+| **Destructive** | Delivers mail the platform decided not to deliver. Requires explicit per-call human approval. | `mimecast_release_message` |
+
+`mimecast_release_message` is destructive despite doing nothing that
+looks like a deletion. A message is in the hold queue because a policy
+or a Targeted Threat Protection verdict objected to it. Releasing it
+overrides that verdict and puts the message — attachment, links, and all
+— into a named user's inbox. Once delivered it cannot be recalled
+through this plugin. The blast radius is a customer's endpoint, which is
+the same reason `huntress_incidents_bulk_approve` sits in the
+destructive tier: the tier follows what happens on the customer's side,
+not the HTTP verb.
+
+`mimecast_hold_message` is the mirror image and belongs one tier lower.
+It has a customer-visible cost — legitimate business mail stops moving —
+but release undoes it, and the reach is a single message.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.**
+
+- Read tools: allow. Message tracing, queue health checks, and TTP
+  reporting are the intended autonomous use.
+- Write tools: agent drafts the exact `mimecast_hold_message` call,
+  human approves, then it runs.
+- Destructive tools: require a named human approver per invocation. Do
+  not grant `mimecast_release_message` to scheduled or unattended
+  agents. "Release everything held for this user" is a request that
+  should always terminate at a human.
+
+## What it cannot reach
+
+- Only the Mimecast tenants mapped to the operator's gateway identity,
+  in the region that identity is configured for.
+- No filesystem, no shell, no other vendor's data.
+- No mailbox-side actions. Mimecast sits in front of the tenant; it
+  cannot remove a message that has already been delivered, and message
+  recall depends on the customer's Mimecast subscription rather than on
+  this plugin.
+- No policy configuration. Nothing here creates, edits, or deletes a
+  Mimecast policy — policy changes stay in the Administration Console.
+- No archive or e-discovery surface. The audit log records
+  administrative actions, not historical message content.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session
+  and are not persisted by this plugin.
+- `mimecast_find_message` and `mimecast_get_message_info` return the
+  substance of a customer's email: subject lines, both parties'
+  addresses, sender IP, spam score, attachment filenames, the full
+  delivery route, and header sets including `Authentication-Results`.
+- `mimecast_get_ttp_logs` returns every URL a named user clicked,
+  together with the message that carried it. This is a
+  browsing-history-shaped dataset about identified employees; in several
+  jurisdictions it attracts employee-monitoring obligations independent
+  of its security purpose.
+- `mimecast_get_audit_events` returns administrator identities, source
+  IP addresses, and login outcomes.
+- `mimecast_get_queue_status` returns in-flight sender/recipient pairs
+  and subject lines.
+- Restrict TTP and audit tools if your agents run unattended.
+
+## Known sharp edges
+
+- **Release is one-way; hold is not.** Design any approval flow around
+  that asymmetry — holding first and releasing after review is always
+  the safer ordering.
+- **The wrong region succeeds and returns nothing.** A tenant configured
+  for the wrong regional endpoint answers HTTP 200 with an empty `data`
+  array. An agent reads that as "no threats found." Confirm the region
+  before trusting a negative result.
+- **HTTP 200 can carry an error.** Mimecast returns failures inside
+  `meta.status` and a `fail[]` block while the transport says success.
+  A tool wrapper that checks only the HTTP code will report a failed
+  release as done.
+- **Tracking data expires at 30 days.** Absence of a message from
+  `mimecast_find_message` is not evidence the message never existed.
+- **Threat remediation may need the console.** Incidents from
+  `mimecast_get_threat_incidents` can sit at `remediationStatus:
+  pending` awaiting manual approval in the Administration Console. This
+  plugin cannot approve them, so an agent reporting "remediation
+  underway" may be describing something that has not started.
+- **Skills document one tool name the server does not expose.** The
+  skills reference `mimecast_get_queue`; the shipped MCP server exposes
+  `mimecast_get_queue_status`. Tier the real name.

--- a/msp-claude-plugins/mimecast/mimecast/skills/message-tracking/SKILL.md
+++ b/msp-claude-plugins/mimecast/mimecast/skills/message-tracking/SKILL.md
@@ -17,6 +17,23 @@ when_to_use: >-
 
 Message tracking is the primary diagnostic tool in Mimecast for investigating email delivery issues, tracing suspicious messages, and managing held email. The Mimecast MCP server provides tools to search messages across the full delivery pipeline, retrieve detailed per-message metadata, and control message disposition (hold or release). This is the first tool to reach for when investigating reported phishing emails, delivery failures, or missing messages.
 
+## Anti-triggers
+
+- **Mail that is late rather than blocked** — deferred, retrying, and
+  backlogged messages are a delivery condition, not a hold, and they are
+  not searchable here until they land in a final state. Use
+  `Mimecast Queue Management`.
+- **Whether the user clicked the link, or what the sandbox found** — URL,
+  attachment, and impersonation verdicts live in TTP; use
+  `Mimecast Threat Intelligence`.
+- **A quarantine belonging to a different gateway** — Mimecast's
+  equivalent is the hold queue, and these message IDs address only it.
+  Use `SpamTitan Quarantine`, `Proofpoint Quarantine`, or
+  `Checkpoint Avanan Quarantine`.
+- **Mail that was delivered clean and only later turned out to be an
+  attack** — Mimecast decides at the perimeter; behavioural detection
+  after delivery is `Abnormal Security Threats`.
+
 ## Key Concepts
 
 ### Message States

--- a/msp-claude-plugins/mimecast/mimecast/skills/queue-management/SKILL.md
+++ b/msp-claude-plugins/mimecast/mimecast/skills/queue-management/SKILL.md
@@ -16,6 +16,18 @@ when_to_use: >-
 
 The Mimecast delivery queue holds messages that are in transit — inbound messages being scanned and processed, outbound messages awaiting delivery to recipient servers. Queue monitoring is essential for detecting delivery backlogs, identifying stuck messages due to recipient server issues, and understanding the state of mail flow during incidents (e.g. a downstream mail server outage). A healthy queue processes messages within seconds; messages sitting in the queue for minutes or longer indicate a potential problem.
 
+## Anti-triggers
+
+- **Releasing or deleting a held message** — this skill reports queue
+  contents and cannot change a message's disposition; use
+  `Mimecast Message Tracking`.
+- **Finding one specific email** — the queue shows current in-transit
+  state only. Anything already delivered, bounced, or rejected has left
+  it; search with `Mimecast Message Tracking`.
+- **Why a message was blocked** — queueing is a delivery outcome, not a
+  security verdict. For the threat reasoning use
+  `Mimecast Threat Intelligence`.
+
 ## Key Concepts
 
 ### Queue Types

--- a/msp-claude-plugins/mimecast/mimecast/skills/threat-intelligence/SKILL.md
+++ b/msp-claude-plugins/mimecast/mimecast/skills/threat-intelligence/SKILL.md
@@ -17,6 +17,18 @@ when_to_use: >-
 
 Mimecast's Targeted Threat Protection (TTP) is an advanced security layer that inspects URLs and attachments in real time and detects impersonation attempts. When TTP events occur — a user clicking a suspicious URL, a malicious attachment being sandboxed, or an impersonation attempt being identified — Mimecast logs these as TTP events that feed into threat remediation incidents. This skill covers reading TTP logs, reviewing threat remediation incidents, and using audit events to investigate security events.
 
+## Anti-triggers
+
+- **Tracing, holding, or releasing the message that carried the threat**
+  — TTP logs are read-only evidence and carry no disposition controls;
+  use `Mimecast Message Tracking`.
+- **Detection based on how a sender normally behaves** — TTP is
+  reputation, sandbox, and lookalike-domain driven. Behavioural BEC
+  modelling of established relationships is a different product; use
+  `Abnormal Security Threats`.
+- **Mail that is delayed rather than attacked** — use
+  `Mimecast Queue Management`.
+
 ## Key Concepts
 
 ### Targeted Threat Protection (TTP)

--- a/msp-claude-plugins/spamtitan/spamtitan/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/spamtitan/spamtitan/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spamtitan",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Claude plugins for SpamTitan by TitanHQ \u2014 quarantine queue management, email flow statistics, sender allowlist and blocklist management for MSPs",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/spamtitan/spamtitan/GOVERNANCE.md
+++ b/msp-claude-plugins/spamtitan/spamtitan/GOVERNANCE.md
@@ -1,0 +1,129 @@
+# SpamTitan plugin — governance and safety model
+
+Unofficial. Community-built plugin for the SpamTitan (TitanHQ) API. Not
+affiliated with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches SpamTitan through the
+WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the tenant the
+operator is authorised for.
+
+- No SpamTitan API key is stored on the technician's machine, in this
+  repo, or in the model's context.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers
+  "who allowlisted that domain" — SpamTitan records only the API key.
+- Revoking gateway access revokes SpamTitan access with it, immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change mail flow or filter policy. Safe for autonomous agents. | `spamtitan_get_queue`, `spamtitan_get_message`, `spamtitan_get_stats`, `spamtitan_navigate`, `spamtitan_status` |
+| **Write** | Empty. Every mutating tool here either delivers mail or changes what the filter will do to a customer's future mail. | — |
+| **Destructive** | Delivers held mail, destroys evidence, or silently changes deliverability. Requires explicit per-call human approval. | `spamtitan_release_message`, `spamtitan_delete_message`, `spamtitan_manage_allowlist`, `spamtitan_manage_blocklist` |
+
+Why each of the four is destructive:
+
+- **`spamtitan_release_message`** — the message is in quarantine because
+  the filter classified it as spam, phishing, or malware. Releasing
+  overrides that and delivers the payload to the recipient's inbox. Once
+  delivered, this plugin cannot take it back. Nothing in the verb warns
+  you; it reads like an undo and behaves like a delivery.
+- **`spamtitan_delete_message`** — irreversible, and it removes the only
+  copy of the evidence. If the message turns out to be part of a
+  campaign under investigation, the headers, links, and score breakdown
+  are gone. The MCP server marks this `destructiveHint: true`.
+- **`spamtitan_manage_blocklist`** — one call can silently stop a
+  customer's legitimate mail. There is no bounce visible to the
+  recipient and no alert; the sender simply stops arriving, sometimes
+  for weeks before anyone notices. A domain-scoped entry against a
+  shared sending service takes out every customer using it. The MCP
+  server marks this `destructiveHint: true`.
+- **`spamtitan_manage_allowlist`** — the tier call most likely to be
+  argued down, and we would keep it here. Allowlisting bypasses spam
+  scoring entirely for that sender, and spoofed mail claiming to be the
+  allowlisted sender inherits the exemption. It is a durable hole in the
+  customer's filtering that produces no visible symptom until it is
+  used. The server does not annotate it as destructive; blast radius
+  says it is.
+
+All four `manage_*` and disposition tools accept a read-only `list`
+action or otherwise behave benignly under some arguments. The gateway
+tiers by tool name, not by argument, so the whole tool takes the
+highest tier its arguments can reach. That is the correct conservative
+reading.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.**
+
+- Read tools: allow. Daily quarantine review, per-domain statistics, and
+  false-positive hunting are the intended autonomous use.
+- Write tools: none exist here.
+- Destructive tools: require a named human approver per invocation. Do
+  not grant any of the four to scheduled or unattended agents. An agent
+  running "clear the quarantine backlog" on a schedule is an agent
+  deleting mail nobody reviewed.
+- Note that `spamtitan_manage_allowlist`, `spamtitan_manage_blocklist`,
+  and `spamtitan_get_queue` will elicit a missing argument from the
+  caller. An unattended agent cannot answer an elicitation, so these
+  calls stall rather than proceeding — useful, but not a safety control
+  you should rely on.
+
+## What it cannot reach
+
+- Only the SpamTitan appliance and domains the operator's gateway
+  identity is scoped to. In multi-tenant deployments the API key is the
+  only tenant boundary — see the sharp edge below.
+- No filesystem, no shell, no other vendor's data.
+- No mailbox-side actions. SpamTitan filters in front of the tenant; it
+  cannot reach a message that has already been delivered.
+- No filter-rule or policy configuration. Scoring thresholds, content
+  rules, and appliance settings stay in the SpamTitan admin interface —
+  only the sender lists are reachable from here.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session
+  and are not persisted by this plugin.
+- `spamtitan_get_queue` returns sender, recipient, subject, and
+  quarantine reason for every held message — a customer's inbound mail
+  metadata in bulk, including personal mail that happens to have been
+  caught.
+- `spamtitan_get_message` returns the same plus the spam score
+  breakdown, header set including `Reply-To` and SPF/DKIM results, and
+  every link in the body.
+- `spamtitan_manage_allowlist` and `spamtitan_manage_blocklist` with
+  `action: list` return the customer's full sender-policy configuration,
+  including any free-text notes previous technicians left on entries.
+- Every read tool here returns recipient PII. There is no PII-free read
+  tier.
+
+## Known sharp edges
+
+- **`spamtitan_get_queue` has no domain filter.** The skill documents a
+  `domain` parameter; the shipped server accepts only page, per_page,
+  sender, recipient, subject, and reason. In a multi-tenant appliance
+  the quarantine listing is therefore not scoped by customer, and the
+  release or delete that follows it is scoped only by the API key. Use
+  recipient filters deliberately, and never let an agent act on "the
+  first result" from an unfiltered listing.
+  `spamtitan_get_stats` does accept `domain`.
+- **Virus-quarantined messages refuse to release.** SpamTitan blocks it
+  server-side. Treat a release failure on a virus item as the control
+  working, not as an error to route around.
+- **Deleted means gone.** There is no soft delete and no retention
+  fallback once the message is removed from quarantine storage.
+- **The retention window is a deadline.** Quarantined mail is purged
+  automatically after the configured period, typically 30 days. A
+  false positive nobody reviewed in time is unrecoverable, and its
+  absence looks identical to a message that never arrived.
+- **Skills document tools the server does not expose.** The skills
+  reference `spamtitan_list_allowlist`, `spamtitan_list_blocklist`, and
+  `spamtitan_get_domain_stats`. The shipped server covers those through
+  the `list` action on the `manage_*` tools and the `domain` argument on
+  `spamtitan_get_stats`. Tier the real names.

--- a/msp-claude-plugins/spamtitan/spamtitan/skills/lists/SKILL.md
+++ b/msp-claude-plugins/spamtitan/spamtitan/skills/lists/SKILL.md
@@ -17,6 +17,19 @@ when_to_use: >-
 
 SpamTitan maintains two key sender policy lists that override the spam filtering engine: the allowlist (trusted senders whose mail is always delivered) and the blocklist (blocked senders whose mail is always rejected or quarantined). Proper list management is essential for MSPs to balance effective spam filtering against business continuity — preventing false positives from disrupting client workflows while blocking persistent unwanted senders.
 
+## Anti-triggers
+
+- **Deciding what to do with a message already sitting in quarantine** —
+  use `SpamTitan Quarantine`.
+- **Blocking a sender in another vendor's engine** — sender lists do not
+  federate. Ironscales keeps its own allowlist behind
+  `IRONSCALES Incidents`, and every other gateway keeps its own too;
+  allowlisting here changes nothing anywhere else.
+- **Mail-flow rules inside the tenant** — these lists live in the
+  SpamTitan gateway, upstream of Exchange Online. Forwarding, inbox
+  rules, and mailbox-level mail flow are `Microsoft 365 Mailboxes` or
+  `cipp-mailboxes`.
+
 ## Key Concepts
 
 ### Allowlist (Trusted Senders)

--- a/msp-claude-plugins/spamtitan/spamtitan/skills/quarantine/SKILL.md
+++ b/msp-claude-plugins/spamtitan/spamtitan/skills/quarantine/SKILL.md
@@ -16,6 +16,19 @@ when_to_use: >-
 
 SpamTitan's quarantine holds inbound emails that its filtering engine determines are likely spam, phishing, or malware. Administrators and end users can review held messages and either release legitimate emails (false positives) or permanently delete spam. For MSPs managing multiple clients, efficient quarantine management is critical to preventing false positives from disrupting business communications while ensuring malicious mail is never delivered.
 
+## Anti-triggers
+
+- **Managing a sender list as a decision in its own right** — releasing
+  with `add_to_allowlist` is a side effect of one message. Auditing,
+  scoping, or removing list entries is `SpamTitan Lists`.
+- **Mail that already reached the mailbox** — SpamTitan filters in front
+  of the tenant and cannot reach into an inbox. Clawing back delivered
+  mail is `Abnormal Security Threats` or `IRONSCALES Incidents`.
+- **A quarantine belonging to a different gateway** — every mail security
+  product in this fleet has one and none of them share message IDs. Use
+  `Mimecast Message Tracking` for its hold queue, `Proofpoint Quarantine`,
+  or `Checkpoint Avanan Quarantine`.
+
 ## Key Concepts
 
 ### Quarantine Types


### PR DESCRIPTION
Applies the repo-wide connector-quality standard to the four near-substitute email security **vendor** plugins. Branched from `feat/skill-anti-triggers-governance`, which carries the standard.

> Scope note: the separate `email-security` plugin directory (knowbe4 / proofpoint / checkpoint-avanan) is owned by a parallel agent and is **not** touched here. This PR only references its skills by name.

## What each of these four uniquely owns

The whole value of this batch is cross-vendor disambiguation. These plugins are near-substitutes — "quarantine", "phishing", "release message", "threat", and "policy" match all of them equally, plus the `email-security` bundle and the `cipp` / `m365` tenant plugins. So each anti-trigger section leads with the boundary:

| Plugin | Uniquely owns |
|---|---|
| **abnormal** | Post-delivery behavioural detection via the M365 API — the only one that reaches into an inbox that already received the mail, and the only one modelling how a sender *normally* behaves (BEC, supply-chain, ATO). |
| **ironscales** | The user-report loop — its own Outlook/Gmail add-in turning employee reports into incidents, with a classify-then-remediate lifecycle and federated learning across tenants. |
| **mimecast** | The delivery pipeline — the only one that can answer "where is this email right now": hold queue, deferred/retrying states, SMTP errors, delivery route, and TTP click-time verdicts. |
| **spamtitan** | Pre-delivery gateway filtering — the spam-score quarantine in front of the tenant, and the sender allow/blocklists that override the scoring engine. |

## Task A — `## Anti-triggers`

**11 added / 4 skipped.**

| Plugin | Added | Skipped |
|---|---|---|
| abnormal | 5 — `threats`, `cases`, `messages`, `account-takeover`, `vendors` | 1 — `api-patterns` |
| ironscales | 1 — `incidents` | 1 — `api-patterns` |
| mimecast | 3 — `message-tracking`, `queue-management`, `threat-intelligence` | 1 — `api-patterns` |
| spamtitan | 2 — `quarantine`, `lists` | 1 — `api-patterns` |

**Why the four `api-patterns` skills were skipped:** any bullet there would only negate `when_to_use` ("don't use for non-Mimecast questions"), which the checklist calls filler. This also matches the exemplar — Huntress has 7 skills and only 3 carry the section; `api-patterns`, `billing`, `escalations`, and `organizations` were all deliberately left alone.

Every bullet names the skill to load instead, using each skill's frontmatter `name` (the Huntress convention).

### Judgement calls

- **Anti-triggers go on the skill that gets *wrongly loaded*, not symmetrically.** `abnormal-messages` gets one pointing at `Mimecast Message Tracking` because "trace this email / check these headers" pulls it wrongly; Mimecast doesn't get the mirror bullet, because nobody reaches for a delivery-pipeline skill when they want Abnormal.
- **The `caseId` collision is real and gets bullets on both sides.** `Abnormal Security Cases` and `Abnormal Security Account Takeover` both call their identifier `caseId` and both are reached by the word "case". That is a genuine two-way mistake, so both carry it.
- **M365-tenant overlap is routed out explicitly.** Abnormal's ATO skill documents `FORCE_PASSWORD_RESET` / `REVOKE_SESSIONS` / `REMOVE_RULES` as remediation actions, but no tool in the shipped MCP server performs them — those are `cipp-users` and `Microsoft 365 Mailboxes`. Same for Ironscales: remediation removes mail and blocks senders, it cannot reset a harvested credential.
- **`abnormal-vendors` got a section for a vocabulary reason, not a sibling one.** In MSP-land "vendor risk" overwhelmingly means a distributor. VendorBase means the opposite — an external party that emails your customer. That bullet routes to `Pax8 Products`, mirroring the exemplar's "agent means a sensor, not a Claude subagent".
- **Cross-gateway quarantine gets a bullet in three places** (`spamtitan-quarantine`, `mimecast-message-tracking`, `abnormal-threats`) because it is the single highest-traffic routing error in this batch, and the message IDs do not federate between vendors.

## Task B — `GOVERNANCE.md`

One per plugin, from `_templates/governance-template.md`, with Conduit-gateway framing kept intact (centralised auth, no local secrets, per-operator audit identity).

Tool names were derived from each plugin's own `skills/*/SKILL.md` and then cross-checked against the shipped MCP servers (`abnormal-mcp`, `ironscales-mcp`, `mimecast-mcp`, `spamtitan-mcp`). **No tool name is invented.**

### Tiers by blast radius, not HTTP verb

| Plugin | Read | Write | Destructive |
|---|---|---|---|
| abnormal | 9 | **empty** | `abnormal_remediation_manage` |
| ironscales | 7 | **empty** | `ironscales_remediation_act`, `ironscales_allowlist_manage` |
| mimecast | 8 | `mimecast_hold_message` | `mimecast_release_message` |
| spamtitan | 5 | **empty** | `spamtitan_release_message`, `spamtitan_delete_message`, `spamtitan_manage_allowlist`, `spamtitan_manage_blocklist` |

Three of the four have an **empty Write tier**, and that is stated plainly rather than padded. These are mail-flow products: there is no reversible bookkeeping middle ground between reading a queue and moving a customer's mail.

The sharp edges the brief called out are all reflected: release delivers possible malware and cannot be recalled (`mimecast_release_message`, `spamtitan_release_message`); purge destroys the only copy of the evidence (`spamtitan_delete_message`); a filter-policy change silently drops legitimate mail with no bounce and no alert (`spamtitan_manage_blocklist`). Each carries a written justification in the style of the exemplar's `incidents_bulk_approve` note.

### Disputable destructive-tier calls

Flagged in the docs themselves so a reviewer can argue them:

1. **`spamtitan_manage_allowlist` → destructive.** The server does *not* annotate it `destructiveHint` (unlike its blocklist sibling). But allowlisting bypasses spam scoring entirely, and spoofed mail claiming to be the allowlisted sender inherits the exemption. It is a durable hole in the customer's filtering with no visible symptom until it is used. **Most likely to be argued down to Write.**
2. **`ironscales_allowlist_manage` → destructive**, same reasoning: a permanent, company-wide, silent exemption from phishing detection.
3. **`abnormal_remediation_manage` → destructive as a whole tool.** Its `action` enum straddles read (`status`), destructive-removal (`remediate`), and destructive-*delivery* (`unremediate`). The gateway tiers by tool name, not by argument, so the tool takes the highest tier its arguments can reach. Same pattern noted for SpamTitan's `manage_*` tools, whose `list` action is read-only but lives inside a destructive-tier tool.
4. **`mimecast_hold_message` → Write, not destructive.** Deliberate asymmetry with release: hold is undone by release, reaches one message, and its cost is a delayed email. Release is one-way.

### Data handling

Every tool returning message bodies, headers, or recipient PII is flagged. Two are worth a reviewer's attention:

- **`mimecast_get_ttp_logs`** returns every URL a *named* user clicked. That is a browsing-history-shaped dataset about identified employees and may attract employee-monitoring obligations independent of its security purpose.
- **`ironscales_email_classify`** is the inverse flow — the operator *supplies* raw headers, bodies, and URLs outbound to Ironscales. It changes no state so it is tiered Read, but it exports customer email content.

For abnormal and spamtitan the honest summary is recorded as-is: **there is no PII-free read tier.**

## Drift found along the way (documented, not fixed)

Cross-checking against the shipped servers surfaced skill-vs-server tool-name drift. Fixing it is out of scope for an additive PR, so each `GOVERNANCE.md` records the real names under *Known sharp edges* — an operator tiering tools at the gateway needs names that exist:

- **abnormal** — skills reference `abnormal_ato_*`, `abnormal_vendors_*`, `abnormal_threats_remediate`, `abnormal_cases_action`, `abnormal_messages_headers`. The server exposes 10 tools; none of those are among them.
- **ironscales** — skills say `ironscales_list_incidents` / `ironscales_classify_email`; server exposes `ironscales_incidents_list` / `ironscales_email_classify`.
- **mimecast** — skills say `mimecast_get_queue`; server exposes `mimecast_get_queue_status`.
- **spamtitan** — skills say `spamtitan_list_allowlist` / `spamtitan_list_blocklist` / `spamtitan_get_domain_stats`; the server covers those via the `list` action and a `domain` argument instead.
- **spamtitan multi-tenancy** — `spamtitan_get_queue` has **no `domain` parameter** in the shipped server, though the skill documents one. In a multi-tenant appliance the quarantine listing is not scoped by customer, and the release/delete that follows is scoped only by the API key. Called out prominently; probably worth its own issue.

## Constraints observed

- Touched only `msp-claude-plugins/{abnormal,ironscales,mimecast,spamtitan}/`. Diff is **+614 / -0** — purely additive.
- Did not touch `_standards/`, `_templates/`, `.claude-plugin/marketplace.json`, or `docs/src/data/plugins.ts`.
- Did not run `npm run generate`. No `triggers:` frontmatter (#158).

## Verification

- `node scripts/check-marketplace-drift.mjs` → `✔ marketplace drift check passed (76 entries)`
- `claude plugin validate` → `✔ Validation passed` for all four plugins
