### PR TITLE
feat(security-a): anti-triggers and governance docs for blackpoint, blumira, cipp, inforcer

### DIFF
--- a/msp-claude-plugins/blackpoint/blackpoint/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/blackpoint/blackpoint/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "blackpoint",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Blackpoint Cyber / CompassOne MDR - tenant, asset, detection, and vulnerability data for MSP incident response",
   "author": {
     "name": "WYRE AI"

--- a/msp-claude-plugins/blackpoint/blackpoint/GOVERNANCE.md
+++ b/msp-claude-plugins/blackpoint/blackpoint/GOVERNANCE.md
@@ -1,0 +1,98 @@
+# Blackpoint Cyber plugin — governance and safety model
+
+Unofficial. Community-built plugin for the Blackpoint Cyber
+(CompassOne) API. Not affiliated with, endorsed by, or sponsored by the
+vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches CompassOne through the
+WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the partner account
+the operator is authorised for.
+
+- No CompassOne API token is stored on the technician's machine, in this
+  repo, or in the model's context. The gateway maps
+  `BLACKPOINT_API_TOKEN` onto the `X-Blackpoint-Api-Token` header and
+  forwards it upstream as a Bearer token.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers
+  "who pulled this customer's dark-web exposure" — CompassOne's own log
+  records only the API account.
+- Revoking gateway access revokes CompassOne access with it,
+  immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change CompassOne or endpoint state. Safe for autonomous agents. | `blackpoint_tenants_list`, `blackpoint_tenants_get`, `blackpoint_assets_list`, `blackpoint_assets_get`, `blackpoint_assets_search`, `blackpoint_assets_relationships`, `blackpoint_detections_list`, `blackpoint_detections_get`, `blackpoint_vulnerabilities_list`, `blackpoint_vulnerabilities_scans_list`, `blackpoint_vulnerabilities_darkweb_list`, `blackpoint_vulnerabilities_external_list`, `blackpoint_navigate`, `blackpoint_back`, `blackpoint_status` |
+| **Write** | — | *Empty.* |
+| **Destructive** | — | *Empty.* |
+
+**This plugin is read-only.** There is no tool that mutates CompassOne
+state, acknowledges a detection, isolates a host, or opens a ticket.
+Every response action must be taken in the CompassOne portal by a human.
+That makes Blackpoint one of the safest connectors to hand to an
+unattended agent — and it means an agent that claims to have "responded
+to" or "closed" a detection is describing something it did not do.
+
+`blackpoint_navigate` and `blackpoint_back` move a cursor through the
+MCP server's own decision-tree context. They change nothing at the
+vendor and belong in the read tier.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.** With no write or destructive tier
+here, that reduces to:
+
+- Read tools: allow. Cross-tenant detection sweeps, exposure roll-ups,
+  and QBR reporting are the intended autonomous use.
+- Restrict `blackpoint_vulnerabilities_darkweb_list` separately if your
+  agents run unattended — see Data handling.
+
+## What it cannot reach
+
+- Only the CompassOne tenants under the partner account mapped to the
+  operator's gateway identity. A tenant-scoped token sees one customer;
+  only a partner token sees the portfolio.
+- No filesystem, no shell, no other vendor's data.
+- No live event stream. Every tool is point-in-time; CompassOne's own
+  notification channels carry the push feed.
+- Six tool domains — `alerts`, `cloud security`, `notifications`,
+  `partners`, `threat intel`, `tickets` — are stubbed in the MCP server
+  and not implemented. They are not an alternative surface; do not call
+  them.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session
+  and are not persisted by this plugin.
+- `blackpoint_vulnerabilities_darkweb_list` returns **breached
+  credentials and leaked personal data** for the customer's users. It is
+  the most sensitive read in this plugin and the one most worth
+  restricting from unattended agents and from any transcript that gets
+  shared with the customer verbatim.
+- `blackpoint_assets_*` returns hostnames, serial numbers, IP addresses,
+  and — for the `identity` class — user-identifying records.
+- `blackpoint_tenants_list` returns the MSP's full customer list.
+  Partner-level output leaks the client roster if it reaches the wrong
+  customer's report.
+
+## Known sharp edges
+
+- **"Incident response" is a misnomer for the API.** The skill is named
+  for the workflow, not a mutable incident object. CompassOne has
+  detections; the MCP surface can only read them.
+- **Asset identity drift.** A re-imaged endpoint can produce two asset
+  records. Dedupe on hostname or serial via `blackpoint_assets_search`
+  before reporting counts, or the same machine is counted twice in a
+  QBR.
+- **`blackpoint_assets_list` requires a class.** It returns one of
+  `endpoint`, `server`, `network`, `cloud`, `mobile`, `iot` per call. An
+  agent that calls it once and reports "the tenant's assets" has
+  reported a sixth of them.
+- **Pagination silently truncates.** Detections and vulnerabilities run
+  into the thousands. An unfinished page reads as a clean, small result
+  — the failure mode looks like good news.

--- a/msp-claude-plugins/blackpoint/blackpoint/skills/asset-inventory/SKILL.md
+++ b/msp-claude-plugins/blackpoint/blackpoint/skills/asset-inventory/SKILL.md
@@ -19,6 +19,20 @@ Assets are the leaves of the CompassOne hierarchy — every detection
 and vulnerability fires against one. This skill covers enumerating
 them, searching across classes, and mapping how they connect.
 
+## Anti-triggers
+
+- **Another vendor's asset inventory** — "asset" is one of the most
+  overloaded words in the stack. Network discovery is
+  `runzero-assets`, EDR-managed endpoints are `sentinelone-inventory`
+  or `huntress-agents`, and RMM device records are the RMM plugin's.
+  A CompassOne asset only exists because CompassOne monitors it.
+- **What is wrong with an asset** — findings against it are
+  `blackpoint-vulnerability-management` (exposure) or
+  `blackpoint-incident-response` (detections).
+- **Counting assets across every customer** — use
+  `blackpoint-multi-tenant-operations`; `blackpoint_assets_list` is
+  scoped to one tenant and one class per call.
+
 ## Asset Classes
 
 `blackpoint_assets_list` requires an asset **class**. The supported

--- a/msp-claude-plugins/blackpoint/blackpoint/skills/incident-response/SKILL.md
+++ b/msp-claude-plugins/blackpoint/blackpoint/skills/incident-response/SKILL.md
@@ -20,6 +20,24 @@ on detections and the assets they fire against. This skill walks the
 investigation flow: tenant → asset → detections → vulnerabilities,
 plus dark-web and external-vulnerability cross-references.
 
+## Anti-triggers
+
+- **Responding, acknowledging, isolating, or closing** — despite the
+  skill name there is no incident *object* and no write tool here. The
+  MCP surface cannot mutate CompassOne state; response happens in the
+  portal. If the intent is an actionable incident lifecycle, the
+  operator is probably thinking of `huntress-incidents` or
+  `sentinelone-alerts`.
+- **`blackpoint_alerts_*` and `blackpoint_tickets_*`** — those domains
+  are stubs, not an alternative alerting surface. Detections are the
+  only detection object Blackpoint exposes.
+- **Exposure work in its own right** — CVE filtering, scan history,
+  dark-web, and external exposure have their own skill:
+  `blackpoint-vulnerability-management`. Use this one only when a
+  detection is the starting point.
+- **Sweeping every customer rather than investigating one** — use
+  `blackpoint-multi-tenant-operations`.
+
 ## API Tools
 
 ### Tenants

--- a/msp-claude-plugins/blackpoint/blackpoint/skills/multi-tenant-operations/SKILL.md
+++ b/msp-claude-plugins/blackpoint/blackpoint/skills/multi-tenant-operations/SKILL.md
@@ -18,6 +18,19 @@ The CompassOne partner account sees every customer tenant. This
 skill covers the partner-level operating loop: enumerate tenants,
 sweep across them, and roll up into a portfolio view.
 
+## Anti-triggers
+
+- **`blackpoint_partners_*`** — the partners domain is a stub. Partner
+  scope comes from the token itself; `blackpoint_tenants_list` is the
+  only enumeration that works.
+- **Investigating one detection** — the drill-down flow is
+  `blackpoint-incident-response`; this skill is the sweep across
+  tenants, not the deep dive within one.
+- **A tenant portfolio in another product** — M365 tenants are
+  `cipp-tenants` or `inforcer-tenant-management`; Blumira client
+  accounts are `blumira-msp`. A CompassOne tenant maps to none of them
+  automatically.
+
 ## The Partner-Tenant Model
 
 ```

--- a/msp-claude-plugins/blackpoint/blackpoint/skills/vulnerability-management/SKILL.md
+++ b/msp-claude-plugins/blackpoint/blackpoint/skills/vulnerability-management/SKILL.md
@@ -21,6 +21,21 @@ host-level vulnerabilities, scan history, dark-web leaks, and
 internet-facing external exposures. This skill covers all four and
 how to combine them into a prioritized remediation view.
 
+## Anti-triggers
+
+- **Patching, suppressing, or marking a finding fixed** — the
+  `status` values (`fixed`, `ignored`, `false_positive`) are filters on
+  a read, not actions. Nothing here writes; remediation happens in the
+  CompassOne portal or the patching tool.
+- **Another vendor's vulnerability view** — `sentinelone-vulnerabilities`
+  and `sentinelone-misconfigurations` cover different scanners with
+  different CVE coverage. Do not merge severity counts across products.
+- **Live threat activity** — a vulnerability is a latent weakness;
+  something actually happening is a detection, in
+  `blackpoint-incident-response`.
+- **Which host a CVE lands on** — asset detail and topology are
+  `blackpoint-asset-inventory`.
+
 ## API Tools
 
 | Tool | Purpose |

--- a/msp-claude-plugins/blumira/blumira/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/blumira/blumira/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "blumira",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Claude plugins for Blumira - SIEM findings management, device inventory, MSP multi-tenant operations, and security posture analysis",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/blumira/blumira/GOVERNANCE.md
+++ b/msp-claude-plugins/blumira/blumira/GOVERNANCE.md
@@ -1,0 +1,106 @@
+# Blumira plugin — governance and safety model
+
+Unofficial. Community-built plugin for the Blumira API. Not affiliated
+with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches Blumira through the
+WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the organization — or,
+with an MSP-scoped token, the managed accounts — the operator is
+authorised for.
+
+- No Blumira JWT is stored on the technician's machine, in this repo, or
+  in the model's context.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers
+  "who closed this finding as a false positive" — Blumira's own log
+  records only the API principal.
+- Revoking gateway access revokes Blumira access with it, immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change Blumira state. Safe for autonomous agents. | `blumira_status`, `blumira_navigate`, `blumira_back`, `blumira_findings_list`, `blumira_findings_get`, `blumira_findings_details`, `blumira_findings_comments_list`, `blumira_resolutions_list`, `blumira_users_list`, `blumira_agents_devices_list`, `blumira_agents_devices_get`, `blumira_agents_keys_list`, `blumira_agents_keys_get`, `blumira_msp_accounts_list`, `blumira_msp_accounts_get`, `blumira_msp_findings_all`, `blumira_msp_findings_list`, `blumira_msp_findings_get`, `blumira_msp_findings_comments_list`, `blumira_msp_devices_list`, `blumira_msp_devices_get`, `blumira_msp_keys_list`, `blumira_msp_keys_get`, `blumira_msp_users_list` |
+| **Write** | Changes the finding record. Reversible, but visible to anyone reading the security queue. | `blumira_findings_assign`, `blumira_findings_resolve`, `blumira_findings_comments_add`, `blumira_msp_findings_assign`, `blumira_msp_findings_resolve`, `blumira_msp_findings_comments_add` |
+| **Destructive** | — | *Empty.* |
+
+**There is no destructive tier.** Blumira's API cannot isolate a host,
+block an IP, kill a process, disable an account, or delete a record. The
+blast radius of every write stops at the Blumira finding queue.
+
+`blumira_findings_resolve` is deliberately **not** in the destructive
+tier, unlike Huntress's `huntress_incidents_bulk_approve`. Approving a
+Huntress remediation instructs software to act on a customer endpoint;
+resolving a Blumira finding closes a record. The status is reversible
+and no customer machine changes.
+
+That said, it is the write worth watching. A resolve carries a
+disposition code, and `30` (False Positive) feeds Blumira's detection
+tuning. An agent that batch-closes a noisy rule as False Positive is
+not just clearing a queue — it is training the platform to stop
+detecting that behaviour.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.**
+
+- Read tools: allow. Cross-account triage sweeps, coverage audits, and
+  posture reporting are the intended autonomous use — with the agent-key
+  exception below.
+- Write tools: agent drafts the exact call — finding ID, resolution
+  code, and notes — human approves, then it runs. Require a human on
+  every resolve that uses code `30`, however small the batch.
+- Destructive tools: none exist. Do not let that be read as "Blumira is
+  safe to automate end-to-end" — the risk here is a *silenced* detection,
+  not a broken endpoint.
+
+## What it cannot reach
+
+- Only the Blumira organization mapped to the operator's gateway
+  identity. `/msp/*` tools additionally require an **MSP-scoped** JWT;
+  an org-level token returns 403 on every one of them, and cannot see
+  another account's data at all.
+- No filesystem, no shell, no other vendor's data.
+- No response or containment capability of any kind — Blumira detects
+  and reports; remediation happens in the EDR, firewall, or identity
+  provider.
+- No live event stream. Every tool is point-in-time; Blumira's own
+  notification channels carry the push feed.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session
+  and are not persisted by this plugin.
+- **`blumira_agents_keys_get`, `blumira_agents_keys_list`,
+  `blumira_msp_keys_get`, and `blumira_msp_keys_list` return agent
+  deployment keys — credential material.** They sit in the read tier
+  because they change nothing, but a read that emits an enrolment token
+  into a transcript is the sharpest exposure in this plugin. Restrict
+  them from unattended agents and from any shared transcript.
+- `blumira_users_list` and `blumira_msp_users_list` return analyst PII
+  (names, email addresses, roles).
+- `blumira_findings_details` returns enriched evidence — source IPs,
+  usernames, hostnames, and the log excerpts that triggered the
+  detection.
+- `blumira_msp_accounts_list` returns the MSP's full client roster.
+
+## Known sharp edges
+
+- **Two parallel tool families, one wrong answer.** `/org/*` and
+  `/msp/*` tools take near-identical arguments. Calling an `/org/*` tool
+  with MSP credentials does not error usefully — it answers about the
+  *MSP's own* organization, so an agent can confidently report "no open
+  findings" for a client it never queried.
+- **Resolution codes are integers with no guardrail.** `10` Valid, `20`
+  Not Applicable, `30` False Positive. A transposed digit records the
+  opposite security conclusion and is not flagged by the API.
+- **Cross-account queries time out rather than page.**
+  `blumira_msp_findings_all` across a large portfolio fails on breadth;
+  the fix is narrower filters, not a retry.
+- **Status codes, not labels.** Findings use `10`/`20`/`30` for
+  Open/In Progress/Resolved. Filtering on the wrong integer returns a
+  clean empty set that reads as "nothing to triage."

--- a/msp-claude-plugins/blumira/blumira/skills/agents/SKILL.md
+++ b/msp-claude-plugins/blumira/blumira/skills/agents/SKILL.md
@@ -15,6 +15,19 @@ when_to_use: >-
 
 Blumira agents (sensors) are deployed on devices to collect log data and detect threats. This skill covers device inventory management, agent health monitoring, and agent key management for deployments.
 
+## Anti-triggers
+
+- **Claude subagents** — "agent" here is a Blumira log sensor, never an
+  AI subagent definition under `agents/*.md`.
+- **An EDR agent** — a Blumira agent ships logs; it does not detect or
+  remediate on the endpoint. Endpoint sensors are `huntress-agents`,
+  `sentinelone-inventory`, or `blackpoint-asset-inventory`.
+- **What the agent detected** — telemetry becomes a finding; use
+  `blumira-findings`.
+- **Devices in another client account** — these are `/org/*` calls;
+  per-account device lists are `blumira_msp_devices_list` in
+  `blumira-msp`.
+
 ## Key Concepts
 
 ### Devices

--- a/msp-claude-plugins/blumira/blumira/skills/findings/SKILL.md
+++ b/msp-claude-plugins/blumira/blumira/skills/findings/SKILL.md
@@ -16,6 +16,23 @@ when_to_use: >-
 
 Findings are Blumira's primary security detection unit — they represent threats, suspicious activity, or policy violations detected across your environment. This skill covers the full finding lifecycle from discovery through resolution.
 
+## Anti-triggers
+
+- **Any client account other than your own org** — every tool here is
+  an `/org/*` call scoped to the credential's own organization. With
+  MSP credentials these return 403 or an empty set; use `blumira-msp`
+  and its `blumira_msp_findings_*` equivalents.
+- **Choosing between Valid / Not Applicable / False Positive** — the
+  resolve *call* is here, but the disposition semantics and their effect
+  on detection tuning are `blumira-resolutions`.
+- **A detection from another security product** — "finding", "alert",
+  and "detection" are shared vocabulary. Use `huntress-incidents`,
+  `sentinelone-alerts`, `blackpoint-incident-response`, or
+  `cipp-alerts` depending on which platform raised it.
+- **Containing or remediating the threat** — Blumira has no isolate,
+  kill, or block action; resolving a finding is a bookkeeping change
+  only. Response happens in the EDR or firewall.
+
 ## Key Concepts
 
 ### Finding Statuses

--- a/msp-claude-plugins/blumira/blumira/skills/msp/SKILL.md
+++ b/msp-claude-plugins/blumira/blumira/skills/msp/SKILL.md
@@ -16,6 +16,19 @@ when_to_use: >-
 
 Blumira's MSP path group (`/msp/*`) enables managed service providers to operate across multiple client organizations from a single set of credentials. This skill covers account management, cross-account queries, and per-account operations.
 
+## Anti-triggers
+
+- **Working inside a single organization with org-level credentials** —
+  the `/msp/*` tools need an MSP-scoped JWT and an `account_id` on
+  every call. Use `blumira-findings`, `blumira-agents`, or
+  `blumira-users`.
+- **"MSP" meaning the multi-tenant view of another vendor** — an
+  M365-tenant portfolio is `cipp-tenants` or
+  `inforcer-tenant-management`; a CompassOne partner sweep is
+  `blackpoint-multi-tenant-operations`.
+- **Resolution-type semantics** — the codes behave identically at MSP
+  and org level and are documented once, in `blumira-resolutions`.
+
 ## Key Concepts
 
 ### MSP vs Org Paths

--- a/msp-claude-plugins/blumira/blumira/skills/resolutions/SKILL.md
+++ b/msp-claude-plugins/blumira/blumira/skills/resolutions/SKILL.md
@@ -15,6 +15,19 @@ when_to_use: >-
 
 Resolutions are the final disposition applied to findings when closing them. Choosing the correct resolution type is critical for accurate security metrics, detection tuning, and compliance reporting.
 
+## Anti-triggers
+
+- **Triaging, investigating, assigning, or commenting** — this skill
+  covers only the disposition decision at close. The rest of the
+  lifecycle is `blumira-findings` (or `blumira-msp` for a client
+  account).
+- **`blumira_resolutions_list`** — that tool enumerates the resolution
+  catalogue and is unrelated to remediation actions; Blumira cannot
+  isolate, block, or kill anything.
+- **Huntress remediation approve/reject** — superficially similar
+  close-out language, entirely different mechanics (Huntress acts on
+  the endpoint). Use `huntress-incidents`.
+
 ## Key Concepts
 
 ### Resolution Types

--- a/msp-claude-plugins/blumira/blumira/skills/users/SKILL.md
+++ b/msp-claude-plugins/blumira/blumira/skills/users/SKILL.md
@@ -14,6 +14,17 @@ when_to_use: >-
 
 Blumira users are organization members who can access the portal, investigate findings, and manage the environment. This skill covers user listing and lookup, primarily for finding assignment workflows.
 
+## Anti-triggers
+
+- **The end user named in a finding** — these are Blumira *portal*
+  members (your analysts), not the M365 or AD account that triggered a
+  detection. Look that account up in `cipp-users` or
+  `inforcer-identity-governance`.
+- **Creating, disabling, or offboarding anyone** — Blumira's user
+  surface is list-only; account lifecycle is `cipp-users`.
+- **Users in a managed client account** — `blumira_users_list` is an
+  `/org/*` call; use `blumira_msp_users_list` in `blumira-msp`.
+
 ## Key Concepts
 
 ### User Roles

--- a/msp-claude-plugins/cipp/cipp/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/cipp/cipp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cipp",
-  "version": "0.1.2",
-  "description": "Claude plugins for CIPP (CyberDrain Improved Partner Portal) — Microsoft 365 multi-tenant management for MSPs: tenants, users, mailboxes, conditional access, standards, BPA, licensing, GDAP, and alerts",
+  "version": "0.1.3",
+  "description": "Claude plugins for CIPP (CyberDrain Improved Partner Portal) \u2014 Microsoft 365 multi-tenant management for MSPs: tenants, users, mailboxes, conditional access, standards, BPA, licensing, GDAP, and alerts",
   "author": {
     "name": "MSP Claude Plugins Community"
   },

--- a/msp-claude-plugins/cipp/cipp/GOVERNANCE.md
+++ b/msp-claude-plugins/cipp/cipp/GOVERNANCE.md
@@ -1,0 +1,179 @@
+# CIPP plugin — governance and safety model
+
+Unofficial. Community-built plugin for the CIPP (CyberDrain Improved
+Partner Portal) API. Not affiliated with, endorsed by, or sponsored by
+the vendor.
+
+**Read this one carefully.** CIPP is the highest-blast-radius connector
+in this marketplace. It acts through a CSP/GDAP delegation, which means
+a single tool call reaches into a customer's production Microsoft 365
+tenant with partner-level privilege — and `tenantFilter='allTenants'`
+reaches into every one of them at once.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches CIPP through the WYRE
+Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the tenants the
+operator is authorised for.
+
+- No CIPP API client ID or secret is stored on the technician's machine,
+  in this repo, or in the model's context.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers
+  "who reset this user's MFA" — CIPP's own log records the API client,
+  and the customer's M365 audit log records the delegated partner
+  principal. Neither names the technician.
+- Revoking gateway access revokes CIPP access with it, immediately.
+
+## Tool permission tiers
+
+Classified by blast radius in the **customer's** tenant, not by HTTP
+verb. Several tools whose names read like reads or routine updates sit
+in the destructive tier; the justifications follow the table.
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change tenant or CIPP state. Safe for autonomous agents. | `cipp_ping`, `cipp_get_version`, `cipp_list_logs`, `cipp_list_tenants`, `cipp_get_tenant_details`, `cipp_get_tenant_alignment`, `cipp_get_tenant_drift`, `cipp_list_users`, `cipp_list_mfa_users`, `cipp_list_user_devices`, `cipp_list_user_groups`, `cipp_list_groups`, `cipp_list_mailboxes`, `cipp_list_mailbox_permissions`, `cipp_list_licenses`, `cipp_list_csp_licenses`, `cipp_list_conditional_access_policies`, `cipp_list_named_locations`, `cipp_list_standards`, `cipp_list_standard_templates`, `cipp_list_bpa`, `cipp_list_domain_health`, `cipp_list_alert_queue`, `cipp_list_audit_logs`, `cipp_list_enterprise_apps`, `cipp_list_gdap_roles`, `cipp_list_gdap_invites`, `cipp_list_scheduled_items`, `cipp_bec_check` |
+| **Write** | Creates or modifies records. Reversible, but visible to the customer. | `cipp_create_user`, `cipp_edit_user`, `cipp_create_group`, `cipp_set_out_of_office`, `cipp_create_standard_template` |
+| **Destructive** | Locks users out, revokes access, rewrites tenant configuration, or schedules unattended execution. Requires explicit per-call human approval. | `cipp_disable_user`, `cipp_offboard_user`, `cipp_reset_password`, `cipp_reset_mfa`, `cipp_revoke_sessions`, `cipp_set_email_forwarding`, `cipp_run_standards_check`, `cipp_add_scheduled_item`, `cipp_delete_standard_template` |
+
+`cipp_get_tenant_alignment`, `cipp_get_tenant_drift`,
+`cipp_list_enterprise_apps`, `cipp_list_standard_templates`,
+`cipp_create_standard_template`, and `cipp_delete_standard_template` are
+registered by the MCP server but not yet covered by a skill. They are
+tiered here because a gateway allowlist has to account for everything
+the server exposes, not just what the plugin documents.
+
+### Why these sit in the destructive tier
+
+The account-lockout group is the obvious half. `cipp_disable_user`,
+`cipp_reset_password`, `cipp_reset_mfa`, and `cipp_revoke_sessions` all
+read like routine updates and all end with a real person unable to sign
+in to a production tenant. `cipp_reset_mfa` clears **every** registered
+method — under a Conditional Access policy that requires MFA, the user
+cannot authenticate at all until they re-enrol, and they usually cannot
+re-enrol without signing in. `cipp_offboard_user` bundles the whole
+sequence behind one call.
+
+The other four are the ones a reviewer is most likely to challenge:
+
+- **`cipp_run_standards_check`** — the name says "check" and the skill
+  describes it as an on-demand evaluation. But any standard configured
+  in `Remediate` mode **auto-fixes tenant configuration when the
+  evaluation runs**, with no further confirmation. Against
+  `tenantFilter='allTenants'` this is a portfolio-wide configuration
+  push triggered by a call that looks like a read. This is the closest
+  analogue in CIPP to Huntress's `huntress_incidents_bulk_approve`: a
+  bookkeeping-shaped verb whose real effect lands on production.
+- **`cipp_add_scheduled_item`** — takes an arbitrary CIPP `command` and
+  a recurrence. Scheduling a job defers execution past every approval
+  gate: whatever a human declined to approve now runs unattended later.
+  CIPP does not validate the command against known job types and does
+  not dedupe by name, so a typo creates a silently-failing job and a
+  repeat call creates a duplicate that fires twice.
+- **`cipp_set_email_forwarding`** — destructive in both directions.
+  Setting a forwarding address routes a user's mail to a third party,
+  which is the exact shape of a BEC exfiltration rule. Setting
+  `disable=true` removes **all** forwarding including legitimate
+  business rules, and the prior configuration is not recoverable through
+  this API.
+- **`cipp_delete_standard_template`** — deletes a baseline definition
+  the MSP's tenants are measured against.
+
+`cipp_create_user` stays in Write. It is additive and reversible — but
+note that it consumes a licence, so it has a billing consequence, and
+`usageLocation` must be set at create time or no licence can be
+assigned later.
+
+`cipp_bec_check` stays in Read. It is a forensic report and changes
+nothing; its risk is what it returns, not what it does. See Data
+handling.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.**
+
+- Read tools: allow. Portfolio audits, MFA gap reports, licence
+  rightsizing, and BPA sweeps are the intended autonomous use.
+- Write tools: agent drafts the exact call — including the resolved
+  `tenantFilter` and `userId` — a human approves, then it runs.
+- Destructive tools: require a **named human approver per invocation**.
+  Do not grant these to scheduled or unattended agents. `cipp_offboard_user`
+  and `cipp_run_standards_check` in particular should never be reachable
+  by an agent running without a person watching.
+- **Treat `tenantFilter='allTenants'` as its own permission.** It turns
+  any tool into a portfolio-wide operation. Several read tools accept
+  it, and `cipp_run_standards_check` does too.
+- Require the agent to resolve and **state the tenant by display name**
+  before any write or destructive call. `cipp_list_tenants` returns
+  several tenants with similar names in most portfolios, and
+  `tenantFilter` accepts four different identifier formats.
+
+## What it cannot reach
+
+- Only the M365 tenants CIPP has onboarded **and** for which an active
+  GDAP relationship grants the required roles. A broken or expired GDAP
+  relationship silently narrows what any tool can do.
+- No filesystem, no shell, no other vendor's data.
+- **No Conditional Access writes.** CA policies are readable only. Policy
+  rollout happens through standards or the CIPP UI — which is precisely
+  why `cipp_run_standards_check` is tiered destructive.
+- No inbox-rule, transport-rule, mail-flow, or quarantine management —
+  those require the CIPP UI or Exchange Online PowerShell.
+- No group membership writes. Groups can be listed and created; adding
+  or removing a member is not in this surface.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session
+  and are not persisted by this plugin.
+- **`cipp_reset_password` returns a plaintext password** when called
+  without one — CIPP generates it. That credential lands in the model's
+  context and in the transcript. Treat any session that calls it as
+  containing a live secret, and deliver the password through a secure
+  channel rather than the chat surface.
+- **`cipp_bec_check` is the heaviest PII read here.** It returns a
+  user's recent sign-in locations and IPs, mailbox forwarding and inbox
+  rules, MFA changes, and app-consent grants — a complete behavioural
+  profile of one employee.
+- `cipp_list_users`, `cipp_list_mfa_users`, `cipp_list_mailboxes`,
+  `cipp_list_mailbox_permissions`, and `cipp_list_user_devices` return
+  customer-employee PII: names, UPNs, device identifiers, and who can
+  read whose mailbox.
+- `cipp_list_audit_logs` returns the customer's activity trail
+  attributable to named users.
+- `cipp_list_licenses` and `cipp_list_csp_licenses` return commercial
+  data — the MSP's CSP position across the portfolio. Do not let
+  portfolio-level licence output reach a single customer's report.
+- `cipp_list_tenants` returns the MSP's full client roster.
+
+## Known sharp edges
+
+- **Two near-identical log tools.** `cipp_list_logs` returns CIPP's own
+  application log; `cipp_list_audit_logs` returns the *customer's* M365
+  unified audit log. An investigation run against the wrong one produces
+  a confident, empty, wrong answer.
+- **Ordering matters in a BEC response.** Run `cipp_bec_check` **before**
+  revoking sessions or resetting credentials — it captures the forensic
+  snapshot while session telemetry is still live. An agent that disables
+  the account first destroys the evidence it was asked to gather.
+- **`enabledForReportingButNotEnforced` looks like coverage.** A CA
+  policy in that state enforces nothing. Any posture summary that counts
+  policies rather than checking `state == 'enabled'` overstates the
+  tenant's security.
+- **Standards `Remediate` mode changes tenants without asking.** The
+  progression `Report` → `Alert` → `Remediate` exists so a human
+  validates auto-remediation before it is live. An agent must never
+  promote a standard's mode, and should treat any tenant with
+  `Remediate` standards as one where evaluation is a write.
+- **Audit retention is licence-dependent.** 90 days on E3, a year on E5.
+  An investigation window that predates retention returns empty results
+  that look like "nothing happened."
+- **Stale GDAP is the number one cause of partial failures.** Bulk
+  operations against a tenant with a broken relationship fail silently
+  or apply to only some users. Run the `cipp-ops` pre-flight check
+  before any bulk run.
+- **`consumedUnits` lags the live tenant.** Do not let an agent make
+  licence-reclaim decisions from a number that is minutes stale.

--- a/msp-claude-plugins/cipp/cipp/skills/alerts/SKILL.md
+++ b/msp-claude-plugins/cipp/cipp/skills/alerts/SKILL.md
@@ -11,6 +11,22 @@ when_to_use: >-
 
 CIPP raises alerts based on standards violations, anomaly detection, and configured thresholds. The two tools in this skill let you triage the alert queue and pull underlying audit log evidence.
 
+## Anti-triggers
+
+- **A CIPP tool is erroring or a background job failed** — that is
+  CIPP's own application log, `cipp_list_logs`, in `cipp-ops`. It is not
+  `cipp_list_audit_logs`, which reads the customer tenant's M365
+  unified audit log.
+- **An endpoint or SIEM detection** — a CIPP alert is a configuration
+  or threshold alert about a tenant, never an EDR finding. Use
+  `huntress-incidents`, `blumira-findings`, `sentinelone-alerts`, or
+  `blackpoint-incident-response` depending on which product raised it.
+- **The forensic snapshot for one compromised user** — `cipp_bec_check`
+  is in `cipp-users`; the audit-log queries here supplement it rather
+  than replace it.
+- **Why an alert fired at all** — the standard that raised it, and its
+  Report/Alert/Remediate mode, live in `cipp-standards`.
+
 ## Tools
 
 ### `cipp_list_alert_queue`

--- a/msp-claude-plugins/cipp/cipp/skills/groups/SKILL.md
+++ b/msp-claude-plugins/cipp/cipp/skills/groups/SKILL.md
@@ -10,6 +10,20 @@ when_to_use: >-
 
 Groups in CIPP cover all four Entra/M365 group types: Security, Microsoft 365 (unified), Distribution List, and Mail-Enabled Security. Most groups are managed through CIPP for delegation simplicity, but membership changes for individual users typically flow through `cipp_list_user_groups` (read) and the M365 plugin or graph-API for write operations.
 
+## Anti-triggers
+
+- **Adding or removing a member of an existing group** — CIPP exposes
+  create and list only; there is no membership-write tool. Use the
+  `m365` plugin or `microsoft-graph-querying`.
+- **Which groups one user belongs to** — `cipp_list_user_groups` is in
+  `cipp-users`, and `cipp_offboard_user` strips memberships as part of
+  the offboard.
+- **Reviewing group and role assignments for a governance report** —
+  read-only identity inventory across a baseline is
+  `inforcer-identity-governance`.
+- **A shared mailbox** — a Microsoft 365 group is not a shared mailbox;
+  mailbox objects and their delegates are `cipp-mailboxes`.
+
 ## Tools
 
 ### `cipp_list_groups`

--- a/msp-claude-plugins/cipp/cipp/skills/licenses/SKILL.md
+++ b/msp-claude-plugins/cipp/cipp/skills/licenses/SKILL.md
@@ -11,6 +11,19 @@ when_to_use: >-
 
 License visibility across managed tenants. Two tools cover the read surface: per-tenant assignment + usage, and portfolio CSP inventory. License *changes* (assigning, removing) flow through `cipp_create_user`, `cipp_offboard_user`, or the M365 plugin — this skill is read-only.
 
+## Anti-triggers
+
+- **Assigning or removing a licence** — no write tool exists here. Use
+  `cipp-users` (`cipp_create_user` assigns at create time,
+  `cipp_offboard_user` reclaims) or the `m365` plugin's
+  `Microsoft 365 Licensing`.
+- **Buying, provisioning, or cancelling a subscription** — CSP
+  *commitments* are visible here, but procurement is the distributor;
+  use `Pax8 Subscriptions` or `Pax8 Orders`.
+- **Why a standard reports a failure that is really a licensing gap** —
+  the standard and its findings are in `cipp-standards`; come here only
+  to confirm the SKU.
+
 ## Tools
 
 ### `cipp_list_licenses`

--- a/msp-claude-plugins/cipp/cipp/skills/mailboxes/SKILL.md
+++ b/msp-claude-plugins/cipp/cipp/skills/mailboxes/SKILL.md
@@ -12,6 +12,20 @@ when_to_use: >-
 
 Exchange Online mailbox operations through CIPP. The four supported tools cover the highest-frequency MSP mailbox tasks: listing mailboxes for inventory, auditing permissions during BEC investigations, setting OOO for leave/offboarding, and configuring forwarding for transition periods.
 
+## Anti-triggers
+
+- **The BEC investigation report itself** — `cipp_bec_check` is in
+  `cipp-users`. This skill covers the mailbox layer of the remediation
+  that follows it.
+- **A whole offboard** — `cipp_offboard_user` in `cipp-users` sets OOO,
+  forwarding, and shared-mailbox conversion in one call; reach for the
+  individual tools here only when you need step-by-step control.
+- **Inbox rules, transport rules, mail flow, or quarantine** — none are
+  in CIPP's MCP surface. Use the `m365` plugin
+  (`Microsoft 365 Mailboxes`) or Exchange Online PowerShell.
+- **Who signed in to or accessed a mailbox** — that is unified audit
+  log territory; use `cipp-alerts`.
+
 ## Tools
 
 ### `cipp_list_mailboxes`

--- a/msp-claude-plugins/cipp/cipp/skills/ops/SKILL.md
+++ b/msp-claude-plugins/cipp/cipp/skills/ops/SKILL.md
@@ -11,6 +11,20 @@ when_to_use: >-
 
 The meta-layer — tools for managing CIPP itself rather than the tenants it manages. GDAP for the delegation chain, scheduler for recurring jobs, and health/version/log endpoints for verifying CIPP is reachable and functioning.
 
+## Anti-triggers
+
+- **"Who did what" inside a customer tenant** — `cipp_list_logs` here
+  is CIPP's own application log, not the M365 unified audit log. The
+  near-identically named `cipp_list_audit_logs` lives in `cipp-alerts`;
+  loading the wrong one is the most common CIPP mis-route.
+- **Entra role assignments inside a tenant** — GDAP roles are what the
+  *partner* may delegate, a different object from the roles a tenant's
+  own users hold; use `inforcer-identity-governance` or the `m365`
+  plugin.
+- **Forcing a standards evaluation now** — the CIPP scheduler runs it
+  on a recurrence, but the on-demand call is
+  `cipp_run_standards_check` in `cipp-standards`.
+
 ## GDAP
 
 ### `cipp_list_gdap_roles`

--- a/msp-claude-plugins/cipp/cipp/skills/security/SKILL.md
+++ b/msp-claude-plugins/cipp/cipp/skills/security/SKILL.md
@@ -11,6 +11,21 @@ when_to_use: >-
 
 Read-only access to a tenant's Conditional Access policy graph and named-location list. Use as input to security posture reviews and to detect tenants drifting from MSP baseline policies. CIPP doesn't expose CA write operations through MCP — apply policy changes via CIPP standards or the CIPP UI.
 
+## Anti-triggers
+
+- **Creating, editing, or deploying a CA policy** — there is no CA
+  write tool here; policy rollout goes through `cipp-standards` or the
+  CIPP UI.
+- **Who has actually registered MFA** — CA tells you what is *required*,
+  not what users have *enrolled*; `cipp_list_mfa_users` in `cipp-users`
+  answers the enrolment question.
+- **Defender, secure score, or threat policies for one tenant you hold
+  credentials for** — that is the `m365` plugin's
+  `Microsoft 365 Security`; this skill is CSP-delegated and CA-only.
+- **Portfolio-wide posture scoring** — comparing tenants against a
+  baseline template is `cipp-standards` or
+  `inforcer-compliance-reporting`.
+
 ## Tools
 
 ### `cipp_list_conditional_access_policies`

--- a/msp-claude-plugins/cipp/cipp/skills/standards/SKILL.md
+++ b/msp-claude-plugins/cipp/cipp/skills/standards/SKILL.md
@@ -12,6 +12,17 @@ when_to_use: >-
 
 Standards are CIPP's mechanism for declaring "this is what every tenant we manage should look like" and continuously enforcing it. The Best Practice Analyser (BPA) is the read side — it shows you where current tenant state diverges from CIPP's recommended baseline. Domain health is a complementary check focused on email authentication.
 
+## Anti-triggers
+
+- **Drift against an Inforcer baseline** — Inforcer and CIPP both say
+  "baseline", "drift", and "secure score" but measure different things
+  against different templates; a tenant can be CIPP-compliant and
+  Inforcer-drifted at once. Use `inforcer-baseline-alignment`.
+- **Inspecting Conditional Access policies** — CA policies are not CIPP
+  standards and do not appear in BPA output; use `cipp-security`.
+- **Triaging what an `Alert`-mode standard actually raised** — the
+  queue those alerts land in is `cipp-alerts`.
+
 ## Tools
 
 ### `cipp_list_standards`

--- a/msp-claude-plugins/cipp/cipp/skills/tenants/SKILL.md
+++ b/msp-claude-plugins/cipp/cipp/skills/tenants/SKILL.md
@@ -11,6 +11,18 @@ when_to_use: >-
 
 Tenants are the top-level scope in CIPP. Every operational tool — users, mailboxes, standards, security — takes a `tenantFilter` parameter that scopes the call to one tenant or to `allTenants`. Knowing how to enumerate tenants and resolve a friendly name to its tenant ID is the first step in almost every CIPP workflow.
 
+## Anti-triggers
+
+- **Inforcer's tenant list** — Inforcer manages the same M365 tenants
+  but keys them by an *integer* Client Tenant ID, not a domain or GUID.
+  A `tenantFilter` value from here will not work there; use
+  `inforcer-tenant-management`.
+- **Why a tenant is missing, stale, or failing** — that is usually the
+  GDAP delegation chain, not the tenant record; use `cipp-ops`.
+- **A tenant's licence, standards, or CA posture** — this skill only
+  resolves and describes the tenant itself; use `cipp-licenses`,
+  `cipp-standards`, or `cipp-security`.
+
 ## Tools
 
 ### `cipp_list_tenants`

--- a/msp-claude-plugins/cipp/cipp/skills/users/SKILL.md
+++ b/msp-claude-plugins/cipp/cipp/skills/users/SKILL.md
@@ -13,6 +13,23 @@ when_to_use: >-
 
 User management is the highest-volume MSP workflow against CIPP. Every step of the M365 user lifecycle — onboarding, role changes, security incidents, offboarding — has a dedicated tool. Most calls require `tenantFilter`; resolve it via `cipp_list_tenants` before you start.
 
+## Anti-triggers
+
+- **Mailbox-side work during an offboard** — delegate/full-access
+  audits, out-of-office, and forwarding are Exchange operations with
+  their own tools; use `cipp-mailboxes`. (`cipp_offboard_user` bundles
+  OOO and forwarding, but only as offboarding parameters.)
+- **A single tenant you hold direct credentials for** — CIPP routes
+  through a CSP/GDAP delegation and needs `tenantFilter` on every call.
+  Direct Graph work against one tenant is the `m365` plugin
+  (`Microsoft 365 Users`) or `microsoft-graph-querying`.
+- **Reading who exists for a governance or baseline review** — that is
+  read-only identity inventory, not administration; use
+  `inforcer-identity-governance`.
+- **Creating or auditing the groups themselves** — this skill only
+  reads a user's memberships (`cipp_list_user_groups`); use
+  `cipp-groups`.
+
 ## Tool surface
 
 ### Listing & lookup

--- a/msp-claude-plugins/inforcer/inforcer/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/inforcer/inforcer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "inforcer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Inforcer - read-only Microsoft 365 security baseline governance for MSPs: tenants, baselines, alignment/drift, secure scores, identity inventory, audit events, and assessments",
   "author": {
     "name": "WYRE AI"

--- a/msp-claude-plugins/inforcer/inforcer/GOVERNANCE.md
+++ b/msp-claude-plugins/inforcer/inforcer/GOVERNANCE.md
@@ -1,0 +1,116 @@
+# Inforcer plugin — governance and safety model
+
+Unofficial. Community-built plugin for the Inforcer Microsoft 365
+baseline governance platform. Not affiliated with, endorsed by, or
+sponsored by the vendor. Inforcer publishes no official public API
+documentation; the surface modelled here is community-sourced from
+[`royklo/InforcerCommunity`](https://github.com/royklo/InforcerCommunity)
+and may change without notice.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches Inforcer through the
+WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the managed tenants
+the operator is authorised for.
+
+- No Inforcer API key is stored on the technician's machine, in this
+  repo, or in the model's context. The gateway supplies
+  `X-Inforcer-Api-Key` and `X-Inforcer-Region` and forwards the key
+  upstream as `Inf-Api-Key`.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers
+  "who triggered an assessment against this tenant" — Inforcer's own log
+  records only the API account.
+- Revoking gateway access revokes Inforcer access with it, immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change Inforcer or tenant state. Safe for autonomous agents. | `inforcer_status`, `inforcer_navigate`, `inforcer_tenants_list`, `inforcer_tenants_get`, `inforcer_tenants_resolve`, `inforcer_baselines_list`, `inforcer_alignment_scores`, `inforcer_alignment_details`, `inforcer_policies_list`, `inforcer_secure_scores_get`, `inforcer_users_list`, `inforcer_users_get`, `inforcer_groups_list`, `inforcer_groups_get`, `inforcer_roles_list`, `inforcer_audit_event_types`, `inforcer_audit_search`, `inforcer_assessments_list` |
+| **Write** | Starts a tenant evaluation. Consumes vendor-side work; changes no customer configuration. | `inforcer_assessments_run` |
+| **Destructive** | — | *Empty.* |
+
+**One write, no destructive tier.** `inforcer_assessments_run` is the
+only tool in the entire Inforcer surface that changes anything, and what
+it changes is Inforcer's own evaluation data. The API cannot deploy a
+policy, remediate drift, back up, or restore configuration — those exist
+only in the Inforcer product UI.
+
+`inforcer_assessments_run` is deliberately **not** destructive, and a
+reviewer may push back on that. The skill documentation flags it as a
+"HIGH-IMPACT ACTION" and requires per-tenant confirmation, which reads
+like a destructive-tier control. The tiering here follows blast radius
+rather than ceremony: a run re-measures a tenant and writes no
+configuration to Microsoft 365. Its real cost is vendor-side compute and
+a misleading audit entry against the wrong customer. The confirmation
+discipline is right; the tier is Write.
+
+> **Tool-name drift.** Three skill documents refer to
+> `inforcer_secure_scores`, `inforcer_audit_events_search`, and
+> `inforcer_tenant_policies_list`. The MCP server registers those
+> handlers as `inforcer_secure_scores_get`, `inforcer_audit_search`, and
+> `inforcer_policies_list`. Build gateway allow/deny rules against the
+> names in the table above — a rule written against a name the server
+> does not register silently permits nothing and blocks nothing.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.**
+
+- Read tools: allow. Portfolio drift sweeps, posture roll-ups, and
+  privileged-access reviews are the intended autonomous use.
+- Write tool: the agent states the resolved tenant display name **and**
+  the integer Client Tenant ID, a human approves, then it runs. Never
+  grant `inforcer_assessments_run` to a scheduled or unattended agent,
+  and never let one batch-run the portfolio "to refresh data."
+- Destructive tools: none exist.
+
+## What it cannot reach
+
+- Only the Inforcer-managed tenants mapped to the operator's gateway
+  identity, and only in the configured region — Inforcer's base URL is
+  region-derived, so a US operator cannot reach an EU instance.
+- No filesystem, no shell, no other vendor's data.
+- **No remediation path.** Inforcer shows drift in full per-policy
+  detail and can change nothing about it. Every fix this plugin
+  surfaces is a recommendation for a human to action in the Inforcer UI,
+  CIPP, or the Microsoft 365 admin centre. An agent that reports drift
+  as "resolved" has misread its own capability.
+- No identity administration. Users, groups, and roles are readable
+  only; nothing here creates, disables, or de-privileges an account.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session
+  and are not persisted by this plugin.
+- `inforcer_users_list` / `inforcer_users_get` return tenant user PII —
+  display names, UPNs and email addresses, enabled state, and licensing
+  hints for the *customer's* staff, not the MSP's.
+- `inforcer_roles_list` returns the privileged-role map for a tenant:
+  who holds Global Admin and equivalents. Useful for review, and a
+  target list if it leaks. Restrict it from unattended agents.
+- `inforcer_audit_search` returns change history attributable to named
+  identities.
+- `inforcer_tenants_list` returns the MSP's full managed-tenant roster.
+
+## Known sharp edges
+
+- **Integer Client Tenant ID, not a GUID or a domain.** Every
+  tenant-scoped call takes an integer. A GUID or domain that reaches the
+  path unresolved returns an *empty result*, not an error — so a report
+  can read "no drift" when it means "wrong identifier." On
+  `inforcer_assessments_run` the same mistake has a side effect instead
+  of a silent blank: it runs against a real, different customer.
+- **Pagination understates everything.** `continuationToken` must be
+  paged to exhaustion. A partial page silently drops tenants from a
+  portfolio sweep or events from an audit window, and the truncated
+  answer looks complete.
+- **Inforcer and CIPP both say "baseline", "drift", and "secure
+  score".** They measure different templates and are not comparable. A
+  report that blends the two produces a number that describes nothing.
+- **Community-sourced field shapes.** Response field names are
+  best-effort, not a vendor contract. Verify shapes on first use rather
+  than trusting a field that a workflow depends on.

--- a/msp-claude-plugins/inforcer/inforcer/skills/assessments/SKILL.md
+++ b/msp-claude-plugins/inforcer/inforcer/skills/assessments/SKILL.md
@@ -28,6 +28,20 @@ headers, the region requirement, the envelope, and pagination, and
 its **integer Client Tenant ID**. Assessment calls are tenant-scoped by
 that integer id.
 
+## Anti-triggers
+
+- **"Run a compliance check on this tenant"** — if the intent is CIPP's
+  standards evaluation, that is `cipp_run_standards_check` in
+  `cipp-standards`. The two are different products with different
+  baselines; running the wrong one produces a report against a template
+  nobody asked about.
+- **Reading the results** — a run only refreshes data. Scores and drift
+  are read in `inforcer-compliance-reporting` and
+  `inforcer-baseline-alignment`.
+- **Changing the tenant** — a run re-measures; it never deploys policy,
+  remediates drift, or restores configuration. Those M365 changes are
+  `cipp-standards`, `cipp-security`, or the Inforcer UI.
+
 ## Tools
 
 ### `inforcer_assessments_list` (read-only)

--- a/msp-claude-plugins/inforcer/inforcer/skills/audit-events/SKILL.md
+++ b/msp-claude-plugins/inforcer/inforcer/skills/audit-events/SKILL.md
@@ -26,6 +26,18 @@ many pages — paging to completion matters more here than almost anywhere
 else, because a partial page silently drops events from the window you
 think you searched.
 
+## Anti-triggers
+
+- **The Microsoft 365 unified audit log** — this is Inforcer's own
+  record of what *it* observed, a much narrower feed than M365's. For
+  sign-ins, inbox-rule creation, app consents, or admin operations in
+  the tenant, use `cipp-alerts` (`cipp_list_audit_logs`).
+- **A security detection or alert to triage** — an audit event is
+  history, not a finding. Use `blumira-findings`,
+  `huntress-incidents`, or `cipp-alerts`.
+- **The current state that drifted** — audit answers *when and by
+  whom*; the state itself is `inforcer-baseline-alignment`.
+
 ## Tools
 
 ### `inforcer_audit_event_types`

--- a/msp-claude-plugins/inforcer/inforcer/skills/baseline-alignment/SKILL.md
+++ b/msp-claude-plugins/inforcer/inforcer/skills/baseline-alignment/SKILL.md
@@ -26,6 +26,22 @@ envelope, and pagination, and [tenant-management](../tenant-management/SKILL.md)
 for resolving a tenant to its integer Client Tenant ID. Every
 alignment/policy call is tenant-scoped by that integer id.
 
+## Anti-triggers
+
+- **Fixing the drift** — Inforcer's API cannot deploy a policy,
+  remediate, or restore configuration; those exist only in the Inforcer
+  UI. The M365 changes themselves are `cipp-users`, `cipp-security`, or
+  `cipp-standards`, and CIPP's `Remediate`-mode standards are the
+  auto-fix mechanism Inforcer lacks.
+- **CIPP's version of "baseline" and "drift"** — CIPP standards and
+  BPA measure a different template with different findings; the two
+  scores are not comparable. Use `cipp-standards`.
+- **The threshold that turns a score into aligned / semi-aligned /
+  drifted** — that classification lives in
+  `inforcer-compliance-reporting`.
+- **What change caused a drift** — the alignment surface shows state,
+  not history; use `inforcer-audit-events`.
+
 ## Tools
 
 ### `inforcer_baselines_list`

--- a/msp-claude-plugins/inforcer/inforcer/skills/compliance-reporting/SKILL.md
+++ b/msp-claude-plugins/inforcer/inforcer/skills/compliance-reporting/SKILL.md
@@ -25,6 +25,19 @@ envelope, and pagination, and [tenant-management](../tenant-management/SKILL.md)
 for resolving tenants to integer Client Tenant IDs. Alignment mechanics
 live in [baseline-alignment](../baseline-alignment/SKILL.md).
 
+## Anti-triggers
+
+- **Per-policy drift detail** — this skill produces the classification
+  and the roll-up; *which* controls diverged is
+  `inforcer-baseline-alignment`.
+- **CIPP's compliance view** — BPA reports, standards compliance, and
+  domain health are a separate baseline with separate findings; use
+  `cipp-standards`. Do not blend CIPP and Inforcer scores into one
+  number.
+- **Stale scores before a report** — refreshing the underlying data
+  means triggering an assessment run, the one write in this plugin; use
+  `inforcer-assessments`.
+
 ## Tools
 
 ### `inforcer_secure_scores`

--- a/msp-claude-plugins/inforcer/inforcer/skills/identity-governance/SKILL.md
+++ b/msp-claude-plugins/inforcer/inforcer/skills/identity-governance/SKILL.md
@@ -28,6 +28,18 @@ headers, the region requirement, the envelope, and pagination, and
 to its **integer Client Tenant ID**. Every identity call is tenant-scoped
 by that integer id.
 
+## Anti-triggers
+
+- **Any change to a user, group, or role** — create, edit, disable,
+  reset MFA, revoke sessions, offboard, or strip a privileged role are
+  all absent here. Use `cipp-users` and `cipp-groups`, or the `m365`
+  plugin.
+- **The word "governance" meaning policy configuration** — this skill
+  inventories identity *objects*; policy state and its drift are
+  `inforcer-baseline-alignment`.
+- **Who did what, and when** — role membership is a snapshot, not a
+  history; use `inforcer-audit-events`.
+
 ## Tools
 
 ### `inforcer_users_list`

--- a/msp-claude-plugins/inforcer/inforcer/skills/tenant-management/SKILL.md
+++ b/msp-claude-plugins/inforcer/inforcer/skills/tenant-management/SKILL.md
@@ -23,6 +23,19 @@ almost every Inforcer workflow.
 Read [api-patterns](../api-patterns/SKILL.md) first for the gateway
 headers, the region requirement, the envelope, and pagination.
 
+## Anti-triggers
+
+- **CIPP's tenant list** — CIPP manages the same M365 tenants but keys
+  them by domain or GUID in `tenantFilter`. An identifier from one will
+  not work in the other, and the two portfolios can legitimately
+  differ. Use `cipp-tenants`.
+- **Onboarding, offboarding, or changing a tenant** — Inforcer's tenant
+  surface is read-only; there is no tenant CRUD here.
+- **A "tenant" in an MDR or SIEM product** — Blackpoint and Blumira use
+  the same word for a customer scope that has nothing to do with M365
+  baselines. Use `blackpoint-multi-tenant-operations` or
+  `blumira-msp`.
+
 ## Tools
 
 ### `inforcer_tenants_list`


### PR DESCRIPTION
Applies the connector-quality standard to the first security batch: **blackpoint, blumira, cipp, inforcer**. Follows the huntress exemplar and the contract in `_standards/skill-quality-checklist.md` + `_templates/governance-template.md`.

Branched from `feat/skill-anti-triggers-governance`, not `main`. Additive only — **333 lines added, 0 deleted**. No `triggers:` frontmatter (#158). Nothing outside the four vendor directories is touched; `_standards/`, `_templates/`, `marketplace.json` and `plugins.ts` are untouched and `npm run generate` was not run.

## Task A — `## Anti-triggers`

**24 added, 3 skipped.**

| Plugin | Added | Skipped |
|---|---|---|
| cipp | 9 / 9 | — |
| inforcer | 6 / 7 | `api-patterns` |
| blumira | 5 / 6 | `api-patterns` |
| blackpoint | 4 / 5 | `api-patterns` |

**Why the three skips.** Nothing routes *into* an `api-patterns` skill by mistake — an operator reaches it deliberately, for auth and pagination mechanics. A section there could only have said "do not use this for non-vendor questions", which is the filler the checklist explicitly tells us to cut. The one genuinely confusable thing in each (Inforcer's integer Client Tenant ID vs GUID) is already covered where the mis-route actually happens, in `inforcer-tenant-management`.

**Why cipp got 9/9.** Not mechanical completeness — CIPP genuinely overlaps `m365`, `microsoft-graph` and `inforcer` on nearly every entity it exposes (users, groups, mailboxes, licences, security, tenants), and each of those boundaries has a named destination skill. Every bullet routes somewhere real.

## Task B — `GOVERNANCE.md`

One per plugin, from the template, tiered by **blast radius rather than HTTP verb**, with Conduit-gateway framing (centralised auth, no local secrets, per-operator audit identity) and PII-returning tools flagged.

| Plugin | Read | Write | Destructive |
|---|---|---|---|
| blackpoint | 15 | 0 | 0 |
| blumira | 24 | 6 | 0 |
| inforcer | 18 | 1 | 0 |
| cipp | 29 | 5 | 9 |

Tool names were derived from each plugin's own skills and then cross-checked against the MCP server sources. **CIPP 43/43 and Blumira 30/30 match the server exactly** — no invented names.

## Judgement calls a reviewer should look at

**1. `cipp_run_standards_check` → destructive.** The most likely challenge. The name says "check" and the skill calls it an on-demand evaluation. But any standard in `Remediate` mode auto-fixes tenant configuration when the evaluation runs, with no further confirmation — and against `tenantFilter='allTenants'` that is a portfolio-wide config push triggered by a read-shaped call. This is CIPP's analogue of `huntress_incidents_bulk_approve`.

**2. `cipp_add_scheduled_item` → destructive.** Takes an arbitrary CIPP `command` plus a recurrence. Scheduling defers execution past every approval gate: whatever a human declined now runs unattended later. CIPP neither validates the command nor dedupes by name.

**3. `cipp_set_email_forwarding` → destructive in both directions.** Setting an address is the exact shape of a BEC exfiltration rule; `disable=true` clears *all* forwarding including legitimate business rules, and the prior config is not recoverable through this API.

**4. The account-lockout group → destructive.** `cipp_disable_user`, `cipp_reset_password`, `cipp_reset_mfa`, `cipp_revoke_sessions`. All read like routine updates; all end with a real person locked out of a production tenant. `cipp_reset_mfa` is the sharpest — it clears every registered method, so under a CA policy requiring MFA the user cannot authenticate to re-enrol.

**5. `inforcer_assessments_run` → Write, *not* destructive.** Argued the other way in the doc, because the skill flags it "HIGH-IMPACT ACTION" with per-tenant confirmation, which reads like destructive-tier ceremony. Tiering follows blast radius: a run re-measures a tenant and writes no configuration to M365. Confirmation discipline is right; the tier is Write. Flagging it explicitly in case reviewers disagree.

**6. `blumira_findings_resolve` → Write, not destructive.** Deliberately diverges from Huntress. Approving a Huntress remediation instructs software to act on an endpoint; resolving a Blumira finding closes a record. Noted in the doc that resolution code `30` (False Positive) feeds detection tuning, so batch-closing a noisy rule trains the platform to stop detecting it — the real risk is a silenced detection, not a broken endpoint.

**7. `cipp_bec_check` → Read, but flagged as the heaviest PII call.** Changes nothing; returns a complete behavioural profile of one employee (sign-in geo and IPs, inbox and forwarding rules, MFA changes, app consents). Risk is what it returns, not what it does.

**8. Blumira agent keys stay in Read.** `blumira_agents_keys_get` / `_list` / the `msp_keys_*` pair return deployment tokens — credential material emitted by a read tool. Correct tier, called out under Data handling as the plugin's sharpest exposure.

**9. `cipp_reset_password` returns a plaintext password** when called without one. Documented under Data handling: any session invoking it contains a live secret.

## Pre-existing issue found, not fixed

Three Inforcer skills reference tool names the MCP server does not register:

| Skill doc says | Server registers |
|---|---|
| `inforcer_secure_scores` | `inforcer_secure_scores_get` |
| `inforcer_audit_events_search` | `inforcer_audit_search` |
| `inforcer_tenant_policies_list` | `inforcer_policies_list` |

Also in `inforcer/README.md`, `agents/inforcer-drift-reporter.md`, and both `commands/*.md`. Out of scope for an additive PR, so `GOVERNANCE.md` uses the server's real names and carries a callout — a gateway rule written against a name the server does not register silently permits nothing and blocks nothing. Worth a follow-up issue.

Separately, six CIPP tools are registered by the server but not covered by any skill: `cipp_get_tenant_alignment`, `cipp_get_tenant_drift`, `cipp_list_enterprise_apps`, `cipp_list_standard_templates`, `cipp_create_standard_template`, `cipp_delete_standard_template`. They are tiered in `GOVERNANCE.md` anyway, since an allowlist has to cover everything the server exposes.

## Note on the changelog

Repo convention is to keep `CHANGELOG.md` updated, but the root changelog is outside this batch's allowed paths and parallel agents are working the other plugin groups. Left untouched to avoid a conflict — worth a single consolidated entry once all batches land.
