### PR TITLE
feat: anti-triggers and governance for network/monitoring plugins (auvik, domotz, meraki, azure-mcp, betterstack)

### DIFF
--- a/msp-claude-plugins/auvik/auvik/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/auvik/auvik/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "auvik",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Claude plugins for Auvik - network monitoring, device inventory, alert triage, configuration audit, and capacity planning for MSPs",
   "author": {
     "name": "MSP Claude Plugins Community"
@@ -8,5 +8,11 @@
   "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
   "repository": "https://github.com/wyre-technology/msp-claude-plugins",
   "license": "Apache-2.0",
-  "keywords": ["auvik", "msp", "network-monitoring", "mcp", "rmm"]
+  "keywords": [
+    "auvik",
+    "msp",
+    "network-monitoring",
+    "mcp",
+    "rmm"
+  ]
 }

--- a/msp-claude-plugins/auvik/auvik/GOVERNANCE.md
+++ b/msp-claude-plugins/auvik/auvik/GOVERNANCE.md
@@ -1,0 +1,105 @@
+# Auvik plugin — governance and safety model
+
+Unofficial. Community-built plugin for the Auvik API. Not affiliated
+with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches Auvik through the
+WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the tenant the
+operator is authorised for.
+
+- No Auvik username or API key is stored on the technician's machine,
+  in this repo, or in the model's context.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log
+  answers "who dismissed that alert" — Auvik's own audit trail records
+  only the API user.
+- Revoking gateway access revokes Auvik access with it, immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change Auvik or device state. Safe for autonomous agents. | `auvik_status`, `auvik_navigate`, `auvik_tenants_list`, `auvik_tenants_get`, `auvik_tenants_detail`, `auvik_devices_list`, `auvik_devices_get`, `auvik_devices_get_details`, `auvik_devices_get_lifecycle`, `auvik_devices_get_warranty`, `auvik_networks_list`, `auvik_networks_get`, `auvik_interfaces_list`, `auvik_configurations_list`, `auvik_configurations_get`, `auvik_alerts_list`, `auvik_alerts_get`, `auvik_statistics_device`, `auvik_statistics_interface`, `auvik_statistics_service`, `auvik_statistics_snmp_poller`, `auvik_billing_client_usage`, `auvik_billing_device_usage`, `auvik_entities_list_audits`, `auvik_entities_list_notes` |
+| **Write** | Changes Auvik-side state. Reversible in effect, permanent in the audit log. | `auvik_alerts_dismiss` |
+| **Destructive** | Nothing in the curated surface deletes data, revokes access, or changes device configuration. | — (see `auvik_raw_request` below) |
+
+**Auvik cannot configure network devices.** It polls them over SNMP and
+reads their saved configurations; there is no tool that pushes a change
+to a switch, router, or firewall. For an MSP evaluating agent risk this
+is the single most reassuring fact about this plugin: a mistake here
+produces a wrong answer, not an outage.
+
+`auvik_raw_request` is the exception and is deliberately left out of
+the tiers above, because its blast radius is whatever endpoint it is
+pointed at. It reaches the Auvik REST API directly and is not bounded
+by the curated tool set. Treat it as destructive-tier by default: the
+gateway cannot tell a read from a write once the call is inside the
+passthrough. If your agent policy does not need it, do not grant it.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.**
+
+- Read tools: allow. Fleet inventory, lifecycle risk reporting, and
+  cross-tenant triage sweeps are the intended autonomous use.
+- Write tools: `auvik_alerts_dismiss` should be drafted by the agent
+  and approved by a human. It is one call, but see the sharp edges.
+- `auvik_raw_request`: require a named human approver per invocation,
+  or withhold it entirely.
+
+## What it cannot reach
+
+- Only the Auvik tenants mapped to the operator's gateway identity. A
+  single MSP credential typically sees every client tenant the MSP
+  manages, so scope is broad by design — see the cross-tenant note in
+  the sharp edges.
+- Only the Auvik region cluster the credential belongs to. Auvik is
+  region-pinned; a credential for `us1` cannot see `eu1` data.
+- No filesystem, no shell, no other vendor's data.
+- No device CLI. Auvik reads configuration; it does not offer a shell
+  onto the monitored hardware.
+- No live event stream. Every tool is point-in-time.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the
+  session and are not persisted by this plugin.
+- **`auvik_configurations_get` returns device running configurations.**
+  On real network gear those routinely contain SNMP community strings,
+  VPN pre-shared keys, RADIUS secrets, and hashed local credentials.
+  This is the most sensitive tool in the plugin and the one most worth
+  restricting — a config diff pulled into a chat transcript is a
+  credential disclosure.
+- `auvik_billing_client_usage` and `auvik_billing_device_usage` return
+  commercial data. Restrict these if your agents run unattended.
+- Device and interface records include IP addressing and topology for
+  customer networks — useful to an attacker, and worth treating as
+  confidential rather than merely technical.
+
+## Known sharp edges
+
+- **Dismissal is not resolution.** `auvik_alerts_dismiss` hides an
+  alert; it does not clear the condition. Auvik re-evaluates on a
+  schedule, so if the condition still holds a *new* alert with a *new
+  ID* appears minutes later. An agent told to "clear the alert queue"
+  will loop, generate audit noise, and mask a genuine outage behind
+  repeated dismissals. Dismissal is appropriate only for confirmed
+  noise, already-ticketed conditions, and transients that have
+  cleared.
+- **Cross-tenant leakage is a formatting failure, not a permissions
+  failure.** One credential sees every tenant, and several list tools
+  return across all of them unless a tenant is passed explicitly. An
+  agent building a per-client report must scope every call, or it will
+  put one customer's devices in another customer's document.
+- **Rate limits degrade mid-task.** The `auvik_statistics_*` tools are
+  far heavier than entity listings and hit the per-key limit first. A
+  fleet-wide statistics sweep tends to fail partway, leaving a report
+  that looks complete but silently covers only the tenants processed
+  before the 429.
+- **Stale entities outlive their alerts.** An alert can reference a
+  device already deleted in Auvik; enriching it returns 404. That is
+  evidence the alert is stale, not evidence of a broken credential.

--- a/msp-claude-plugins/auvik/auvik/skills/alerts/SKILL.md
+++ b/msp-claude-plugins/auvik/auvik/skills/alerts/SKILL.md
@@ -12,6 +12,19 @@ when_to_use: >-
 
 Auvik alerts are condition-based notifications generated when a monitored entity (device, interface, network, service) crosses a threshold or changes state. This skill covers the severity model, the status lifecycle, and the dismissal semantics that confuse new users.
 
+## Anti-triggers
+
+- **An alert raised by an endpoint's RMM agent** — Auvik alerts come
+  from SNMP and ICMP polling of network infrastructure, never from
+  software running on a workstation or server; use `atera` or
+  `ncentral`.
+- **A public website or endpoint being down** — that is external
+  uptime checking, not internal polling; use `betterstack-monitors`.
+- **Conditions a site collector raised about LAN devices** — different
+  product, different alert engine; use `domotz-alerts`.
+- **Who gets paged, and when it escalates** — Auvik has no on-call
+  model; use `pagerduty-oncall` or `rootly-oncall`.
+
 ## Tools
 
 | Tool | Use For |

--- a/msp-claude-plugins/auvik/auvik/skills/devices/SKILL.md
+++ b/msp-claude-plugins/auvik/auvik/skills/devices/SKILL.md
@@ -15,6 +15,22 @@ when_to_use: >-
 
 Devices are the unit of inventory in Auvik. Every discovered piece of network gear or endpoint - whether actively monitored or just seen on a discovery scan - has a device record. This skill covers the device type taxonomy, the manage-status model, lifecycle fields, and which tool to call for which question.
 
+## Anti-triggers
+
+- **Changing the device, not just reading it** — Auvik is a monitoring
+  and documentation layer and never pushes configuration. On Meraki
+  hardware use `meraki-devices`; for MX firewall or VPN changes,
+  `meraki-security-appliance`.
+- **A per-site sweep of everything with an IP** — Auvik indexes
+  infrastructure it can poll. The collector that fingerprints every
+  host on a local subnet, including phones and IoT gear, is
+  `domotz-devices`.
+- **Hunting unknown assets as a security exercise** — Auvik's
+  `unmanaged` means "discovered but not polled", not "unaccounted
+  for". Attack-surface and rogue-asset discovery is `runzero`.
+- **Whether a device is alerting right now** — the device record
+  carries status, not the alert queue; use `auvik-alerts`.
+
 ## Tools
 
 | Tool | Use For |

--- a/msp-claude-plugins/auvik/auvik/skills/networks/SKILL.md
+++ b/msp-claude-plugins/auvik/auvik/skills/networks/SKILL.md
@@ -14,6 +14,18 @@ when_to_use: >-
 
 A `network` in Auvik is an IP scope - typically a subnet that Auvik has discovered devices on. An `interface` is a port on a device. Both are distinct entity types with their own list endpoints. This skill clarifies the data model and the relationships.
 
+## Anti-triggers
+
+- **A Meraki "network"** — in the Meraki Dashboard a network is a site
+  container holding devices, not an IP scope. The word collides
+  completely; use `meraki-devices`.
+- **Scanning a subnet, mapping topology, or chasing an IP conflict** —
+  those run from a collector inside the LAN, not from Auvik's polled
+  read model; use `domotz-network`.
+- **Changing a VLAN or shutting a port** — Auvik reads `adminStatus`
+  and never sets it. On Meraki switches that write lives in
+  `meraki-devices`.
+
 ## Tools
 
 | Tool | Use For |

--- a/msp-claude-plugins/azure-mcp/azure-mcp/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/azure-mcp/azure-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "azure-mcp",
-  "version": "1.0.2",
-  "description": "Claude plugins for the Azure MCP Server — read-only Azure observability, cost, and resource health in natural language: Monitor metrics and Log Analytics KQL, retail pricing, quotas, Advisor recommendations, Resource Health, AppLens diagnostics, and subscription/resource-group inventory across tenants",
+  "version": "1.0.3",
+  "description": "Claude plugins for the Azure MCP Server \u2014 read-only Azure observability, cost, and resource health in natural language: Monitor metrics and Log Analytics KQL, retail pricing, quotas, Advisor recommendations, Resource Health, AppLens diagnostics, and subscription/resource-group inventory across tenants",
   "author": {
     "name": "MSP Claude Plugins Community"
   },

--- a/msp-claude-plugins/azure-mcp/azure-mcp/GOVERNANCE.md
+++ b/msp-claude-plugins/azure-mcp/azure-mcp/GOVERNANCE.md
@@ -1,0 +1,113 @@
+# azure-mcp plugin — governance and safety model
+
+Unofficial. Community-built plugin wrapping Microsoft's official Azure
+MCP Server. Not affiliated with, endorsed by, or sponsored by
+Microsoft.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches Azure through the
+WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the tenant the
+operator is authorised for.
+
+- No Azure tenant ID, client ID, or client secret is stored on the
+  technician's machine, in this repo, or in the model's context. The
+  service principal you register lives at the gateway.
+- Credential rotation happens once at the gateway, not per technician.
+  This matters more here than elsewhere: Azure client secrets expire on
+  a fixed date, and rotating one place beats chasing every workstation.
+- Every call carries operator identity, so the gateway audit log
+  answers "who ran that KQL query". Azure's activity log records only
+  the service principal.
+- Revoking gateway access revokes Azure access with it, immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change any Azure resource. Safe for autonomous agents. | `subscription_list`, `group_list`, `group_resource_list`, `monitor`, `resourcehealth`, `applens`, `advisor`, `pricing`, `quota` |
+| **Write** | Nothing. No tool in this connector creates or modifies an Azure resource. | — |
+| **Destructive** | Nothing. | — |
+
+**This plugin is read-only, and that is enforced in two independent
+places.** The gateway runs the Azure MCP Server with the `--read-only`
+flag, and it applies a namespace allowlist that admits only the eight
+observability, cost, and inventory namespaces. Write- and
+delete-capable namespaces (`storage`, `keyvault`, `compute`, `role`,
+`aks`, and others) are not enabled, so even an over-privileged service
+principal has no mutating call to route.
+
+For an MSP assessing agent risk, this is the strongest statement in
+the batch: nothing this connector does can change a customer's Azure
+infrastructure. A mistake produces a wrong answer or a wasted query,
+never an outage.
+
+## Recommended agent policy
+
+The safe default for most plugins is "read autonomously, propose
+writes". Here there are no writes to propose, so:
+
+- Read tools: allow, including for scheduled and unattended agents.
+  Health triage, Advisor review, quota headroom checks, and inventory
+  reporting are all safe to automate.
+- The two controls worth applying anyway are on **data** and **cost**,
+  not on state changes — see below.
+- When a user asks for a write, provision, restart, or quota increase,
+  the correct response is to say it is out of scope and hand off. Do
+  not look for a workaround through another namespace.
+
+## What it cannot reach
+
+- Only the Azure subscriptions where the registered service principal
+  holds a role assignment. A "missing" subscription is almost always a
+  missing Reader assignment, not a deleted subscription.
+- Only Azure Resource Manager. **Microsoft 365, Exchange, SharePoint,
+  and Entra ID directory objects are not reachable here** — that is a
+  different API surface entirely, and the most common misconception
+  about this connector.
+- No filesystem, no shell, no other vendor's data.
+- No ability to raise a quota, apply an Advisor recommendation,
+  acknowledge an alert, or restart a resource.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the
+  session and are not persisted by this plugin.
+- **Read-only in the ARM sense is not read-limited in the data
+  sense.** The `monitor` namespace runs arbitrary KQL against Log
+  Analytics workspaces, and a workspace contains whatever the customer
+  ingested into it — application traces, request bodies, sign-in logs,
+  security events. This is by far the most sensitive capability here,
+  and the one to restrict if agents run unattended. Scope queries with
+  a time bound and an explicit column projection rather than
+  `SELECT *`-style pulls.
+- `applens` diagnostic output can include connection strings and
+  resource identifiers surfaced in dependency failures.
+- `pricing` and `quota` are commercial and capacity data. Harmless
+  individually; a full inventory plus cost profile is a useful
+  document for someone targeting the customer.
+
+## Known sharp edges
+
+- **A read can still cost money.** An unbounded KQL query over a large
+  workspace is billed on data scanned and can run for a long time.
+  "Read-only" is not "free" — an agent looping broad queries across
+  subscriptions produces a real line item.
+- **Retail price is not the customer's price.** The `pricing` namespace
+  returns public list rates. It knows nothing about EA/CSP discounts,
+  reservations, or actual consumption. An agent that presents a retail
+  estimate as "your Azure bill" has produced a commercially wrong
+  answer that reads as authoritative.
+- **Advisor lags reality.** Recommendations refresh periodically, not
+  in real time, so a recommendation may reference a change made hours
+  ago or a resource already remediated.
+- **The connector fails all at once when the secret expires.** Azure
+  client secrets have a hard expiry. The symptom is every tool
+  returning authorization errors or empty results simultaneously,
+  which reads like a permissions regression rather than a lapsed
+  credential.
+- **Empty results are ambiguous.** An empty subscription or resource
+  list can mean "nothing there" or "no role assignment at that scope".
+  These are not the same finding, and an agent reporting "the customer
+  has no resources" from an RBAC gap is reporting a falsehood.

--- a/msp-claude-plugins/azure-mcp/azure-mcp/skills/connection/SKILL.md
+++ b/msp-claude-plugins/azure-mcp/azure-mcp/skills/connection/SKILL.md
@@ -17,6 +17,16 @@ when_to_use: >-
 
 The `azure-mcp` vendor runs Microsoft's official Azure MCP Server (`mcr.microsoft.com/azure-sdk/azure-mcp`) as a WYRE-built sidecar inside the MCP gateway. Each connecting MSP supplies its own Azure **service principal**; the gateway isolates credentials per tenant and scopes every request to the principal you registered.
 
+## Anti-triggers
+
+- **Microsoft 365 or Entra ID tenant work** — in MSP conversation
+  "Azure tenant" almost always means the M365 tenant. This connector
+  reaches Azure Resource Manager only. Tenant onboarding, GDAP, and CSP
+  relationships are `cipp-tenants`; Graph app registrations are
+  `microsoft-graph-connection`.
+- **What to actually query once connected** — use
+  `azure-mcp-observability` or `azure-mcp-cost-and-capacity`.
+
 ## Read-only deployment — read this first
 
 The gateway runs the Azure MCP Server with the `--read-only` flag and a deliberately constrained namespace allowlist. Day-one the connector exposes exactly eight read-leaning namespaces:

--- a/msp-claude-plugins/azure-mcp/azure-mcp/skills/cost-and-capacity/SKILL.md
+++ b/msp-claude-plugins/azure-mcp/azure-mcp/skills/cost-and-capacity/SKILL.md
@@ -18,6 +18,15 @@ This skill covers the cost, capacity, and inventory side of the `azure-mcp` conn
 
 Tool names follow the Azure MCP Server's namespace convention (`azmcp` / `azure_mcp` prefixes, grouped under `pricing`, `quota`, `subscription`, `group`). Invoke them by capability.
 
+## Anti-triggers
+
+- **What the customer was actually billed** — `pricing` returns public
+  retail rates, never invoiced consumption. CSP invoices and margin sit
+  in `pax8` or `sherweb`.
+- **Where the money is being wasted** — cost *optimisation* findings
+  come from Azure Advisor; use `azure-mcp-observability`.
+- **M365 seat counts and licence costs** — use `cipp-licenses`.
+
 ## Namespace surface
 
 ### `subscription` — subscription inventory

--- a/msp-claude-plugins/azure-mcp/azure-mcp/skills/observability/SKILL.md
+++ b/msp-claude-plugins/azure-mcp/azure-mcp/skills/observability/SKILL.md
@@ -18,6 +18,20 @@ This skill covers the monitoring, diagnostics, and health side of the `azure-mcp
 
 Tool names follow the Azure MCP Server's namespace convention (`azmcp` / `azure_mcp` prefixes, e.g. tools grouped under `monitor`, `resourcehealth`, `applens`, `advisor`). Describe and invoke them by capability — the connector exposes one or more tools per namespace.
 
+## Anti-triggers
+
+- **Estimating a price or checking quota headroom** — use
+  `azure-mcp-cost-and-capacity`. Advisor's *Cost* recommendations do
+  belong here; a meter rate or a usage limit does not.
+- **Application logs held outside Azure** — KQL reaches Log Analytics
+  workspaces only. Better Stack log search is `betterstack-logging`.
+- **Microsoft 365 sign-in, mailbox, or licensing signals** — unless
+  they are ingested into a workspace, use `microsoft-graph-querying` or
+  `cipp-security`.
+- **Alerting an MSP NOC rather than Azure** — an Azure Monitor alert
+  rule is not the RMM alert queue (`atera`, `ncentral`) or an uptime
+  incident (`betterstack-incidents`).
+
 ## Namespace surface
 
 ### `monitor` — Azure Monitor

--- a/msp-claude-plugins/betterstack/betterstack/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/betterstack/betterstack/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "betterstack",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Claude plugins for Better Stack - uptime monitoring, incident management, status pages, on-call schedules, and log management (Logtail) for MSPs",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/betterstack/betterstack/GOVERNANCE.md
+++ b/msp-claude-plugins/betterstack/betterstack/GOVERNANCE.md
@@ -1,0 +1,121 @@
+# Better Stack plugin — governance and safety model
+
+Unofficial. Community-built plugin for the Better Stack API. Not
+affiliated with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches Better Stack through
+the WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which
+brokers authentication centrally and scopes every call to the tenant
+the operator is authorised for.
+
+- No Better Stack API token is stored on the technician's machine, in
+  this repo, or in the model's context.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log
+  answers "who paused that monitor" — Better Stack's own log records
+  only the token.
+- Revoking gateway access revokes Better Stack access with it,
+  immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change Better Stack state or notify anyone. Safe for autonomous agents. | `list_monitors`, `get_monitor`, `list_heartbeats`, `get_heartbeat`, `list_incidents`, `get_incident`, `list_on_call_schedules`, `get_on_call_schedule`, `list_schedule_policies`, `list_status_pages`, `get_status_page`, `list_status_page_sections`, `execute_query`, `list_saved_queries`, `get_saved_query`, `list_dashboards`, `get_dashboard`, `list_dashboard_panels`, `list_applications`, `get_application`, `list_releases` |
+| **Write** | Creates or modifies records. Reversible, but may page a human on the way. | `create_monitor`, `update_monitor`, `resume_monitor`, `create_heartbeat`, `update_heartbeat`, `create_incident`, `acknowledge_incident`, `resolve_incident`, `create_on_call_schedule`, `update_on_call_schedule`, `create_status_page`, `update_status_page`, `create_dashboard`, `create_release` |
+| **Destructive** | Removes monitoring coverage, breaks paging, or publishes to the public. Requires explicit per-call human approval. | `delete_monitor`, `delete_heartbeat`, `delete_on_call_schedule`, `pause_monitor`, `create_status_page_incident` |
+
+### Why two non-delete tools sit in the destructive tier
+
+- **`pause_monitor` silently removes detection.** It is a trivially
+  reversible one-field change, which is exactly what makes it
+  dangerous: a paused monitor raises no incident, pages nobody, and
+  produces no gap in a dashboard that anyone will notice. An agent
+  that pauses monitors for a maintenance window and does not resume
+  them leaves the customer unmonitored indefinitely, and the SLA
+  report for that period is quietly wrong. Loss of detection is the
+  characteristic failure mode of a monitoring product, and it deserves
+  destructive-tier handling even though the verb is harmless.
+- **`create_status_page_incident` publishes outside the MSP.** Status
+  pages are public, frequently on the customer's own branded domain,
+  and subscribers are notified. A wrongly posted outage cannot be
+  recalled — deleting the post does not unsend the email or un-tell
+  the customer's customers. That is a commercial and reputational
+  event, not a record edit.
+
+`delete_on_call_schedule` earns its tier for a second-order reason: a
+notification policy that referenced the deleted schedule is left with
+a step that resolves to nobody, so pages route into the void. The
+failure shows up at the worst possible moment.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.**
+
+- Read tools: allow. Monitor health sweeps, incident and MTTR
+  reporting, on-call lookups, and log investigation are the intended
+  autonomous use.
+- Write tools: agent drafts the exact call, human approves, then it
+  runs. Note that several of these can wake somebody up — see the
+  sharp edges.
+- Destructive tools: require a named human approver per invocation.
+  If you automate a maintenance window, pair every `pause_monitor`
+  with a scheduled, verified `resume_monitor` and alert on the pause
+  outliving its window.
+
+## What it cannot reach
+
+- Only the Better Stack teams the token is scoped to. An Uptime-scoped
+  token cannot see Telemetry or Error Tracking; a Global token sees
+  all three.
+- **Only what is reachable from the public internet.** Better Stack's
+  checks run from its own regions, so it cannot monitor an
+  RFC1918 address, an internal-only service, or anything behind a
+  customer firewall. That boundary is a capability limit, not a
+  permissions one — no token changes it.
+- No filesystem, no shell, no other vendor's data.
+- No access to the monitored systems themselves. It observes their
+  responses; it cannot log into them, restart them, or fix them.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the
+  session and are not persisted by this plugin.
+- **`execute_query` runs arbitrary ClickHouse SQL over ingested
+  logs.** Those logs contain whatever the customer's applications
+  chose to log — and applications routinely log more than intended:
+  session tokens, API keys in request headers, email addresses, and
+  full request bodies. This is the highest-exposure tool in the
+  plugin. Bound queries by time and source, and restrict the tool
+  entirely if agents run unattended.
+- `list_on_call_schedules` and `get_on_call_schedule` return staff
+  names and shift times — personal data about the MSP's own people.
+- Status page tools read and write **public** content. Anything an
+  agent writes there is world-readable.
+
+## Known sharp edges
+
+- **Writes can wake people up.** Incident creation and monitor state
+  changes feed the notification policy, which escalates to phone
+  calls and SMS. A page cannot be recalled and it does not care what
+  time it is. Treat any incident or monitor write during out-of-hours
+  as higher-risk than its tier alone suggests.
+- **Acknowledging stops the escalation chain.** `acknowledge_incident`
+  tells Better Stack a human has it. An agent that acknowledges an
+  incident to tidy the queue has told the paging system to stop
+  escalating a live outage that nobody is actually working.
+- **Auto-resolve makes incident history unreliable for SLA maths.**
+  Monitors close incidents on recovery, so `resolved_at` reflects
+  service recovery, not human intervention. Deriving MTTR from it
+  measures the outage, not the response.
+- **Deleting a monitor deletes its history.** Uptime history is the
+  evidence behind an SLA report. Removing a monitor to tidy an
+  account destroys the record you would need at renewal.
+- **Tool names are inconsistent across this plugin's own skills.** The
+  API-patterns skill and the on-call skill use the unprefixed names in
+  the table above, which match the hosted server at
+  `mcp.betterstack.com`; several other skills show a `betterstack_`
+  prefix. Prefer the names in the table.

--- a/msp-claude-plugins/betterstack/betterstack/skills/incidents/SKILL.md
+++ b/msp-claude-plugins/betterstack/betterstack/skills/incidents/SKILL.md
@@ -17,6 +17,19 @@ when_to_use: >-
 
 Incidents in Better Stack are triggered automatically when uptime monitors detect downtime, or created manually for ad-hoc issues. Each incident tracks the timeline from detection through acknowledgment to resolution, with associated monitors, status page updates, and on-call notifications.
 
+## Anti-triggers
+
+- **A security incident** — Better Stack incidents are uptime events
+  with no threat model, no indicators, and no remediation flow; use
+  `huntress-incidents`.
+- **The MSP's major-incident process** — if the question is about
+  incident commanders, customer comms, or postmortems rather than a
+  failing check, use `rootly-incidents` or `pagerduty-incidents`.
+- **Billable follow-up work** — an incident is not a PSA ticket; use
+  `autotask`, `halopsa`, or `connectwise-psa`.
+- **Telling end users about the outage** — use
+  `betterstack-status-pages`.
+
 ## Key Concepts
 
 ### Incident Lifecycle

--- a/msp-claude-plugins/betterstack/betterstack/skills/logging/SKILL.md
+++ b/msp-claude-plugins/betterstack/betterstack/skills/logging/SKILL.md
@@ -15,6 +15,15 @@ when_to_use: >-
 
 Better Stack Logs (formerly Logtail) provides centralized log management with structured log ingestion, real-time search, and log-based alerting. MSPs use it to aggregate logs from client infrastructure, investigate incidents, and set up proactive alerting on error patterns.
 
+## Anti-triggers
+
+- **Azure Log Analytics and KQL** — different store, different query
+  language; use `azure-mcp-observability`.
+- **Threat hunting or security event analysis** — these are
+  application logs, not a SIEM; use `huntress-signals` or `blumira`.
+- **Uptime history for a monitor** — check results are not log records;
+  use `betterstack-monitors`.
+
 ## Key Concepts
 
 ### Log Sources

--- a/msp-claude-plugins/betterstack/betterstack/skills/monitors/SKILL.md
+++ b/msp-claude-plugins/betterstack/betterstack/skills/monitors/SKILL.md
@@ -16,6 +16,19 @@ when_to_use: >-
 
 Uptime monitors are the core of Better Stack's monitoring platform. They periodically check URLs, ports, or heartbeats to detect downtime and performance degradation. Monitors can be grouped, paused, and configured with custom check intervals, expected status codes, and alerting thresholds.
 
+## Anti-triggers
+
+- **An internal or RFC1918 target** — checks run from Better Stack's
+  public regions and cannot reach a private LAN. Internal service
+  checks run from a collector inside the site; use `domotz-eyes`.
+- **Azure Monitor** — same word, different product. Azure metrics, KQL,
+  and alert rules are `azure-mcp-observability`.
+- **Whether a piece of infrastructure is up** — SNMP and ICMP polling
+  of switches, firewalls, and APs is `auvik-devices`; a workstation or
+  server under RMM is `atera` or `ncentral`.
+- **Who gets woken when a check fails** — the monitor holds the check;
+  the routing and rotation are `betterstack-oncall`.
+
 ## Key Concepts
 
 ### Monitor Types

--- a/msp-claude-plugins/betterstack/betterstack/skills/oncall/SKILL.md
+++ b/msp-claude-plugins/betterstack/betterstack/skills/oncall/SKILL.md
@@ -19,6 +19,19 @@ when_to_use: >-
 
 Better Stack Uptime includes integrated on-call scheduling that determines who gets paged when a monitor fails. Schedules define rotation patterns, and notification/escalation policies define how and when responders are alerted (via phone, SMS, email, or push). For MSPs, on-call is commonly configured per customer team, with separate schedules for each client's SLA requirements.
 
+## Anti-triggers
+
+- **Rotations that live in PagerDuty or Rootly** — "who is on call",
+  "escalation policy", and "paging" are shared vocabulary across all
+  three products, and nothing in the phrasing disambiguates them. If
+  the MSP's paging system is not Better Stack, use `pagerduty-oncall`
+  or `rootly-oncall`.
+- **Technician shifts, dispatch, or booked appointments** — an on-call
+  rotation is not a service schedule; that lives in the PSA
+  (`autotask`, `halopsa`, `connectwise-psa`).
+- **Changing what a monitor checks rather than who it wakes** — use
+  `betterstack-monitors`.
+
 ## Key Concepts
 
 ### Schedule Structure

--- a/msp-claude-plugins/betterstack/betterstack/skills/status-pages/SKILL.md
+++ b/msp-claude-plugins/betterstack/betterstack/skills/status-pages/SKILL.md
@@ -16,6 +16,16 @@ when_to_use: >-
 
 Status pages in Better Stack provide a public-facing view of your service health. They automatically reflect monitor statuses and allow manual incident and maintenance updates. MSPs use status pages to communicate service availability to clients without exposing internal monitoring details.
 
+## Anti-triggers
+
+- **"Is this service up right now?"** — a status page is outbound
+  communication, not the source of truth for health. Use
+  `betterstack-monitors` for the check and `betterstack-incidents` for
+  the event.
+- **Better Stack's own availability** — that is status.betterstack.com,
+  not a page you manage; for connection failures use
+  `betterstack-api-patterns`.
+
 ## Key Concepts
 
 ### Status Page Components

--- a/msp-claude-plugins/domotz/domotz/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/domotz/domotz/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "domotz",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Claude plugins for Domotz - network monitoring & management, device inventory, alert management, SNMP monitoring, and Domotz Eyes sensors for MSPs",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/domotz/domotz/GOVERNANCE.md
+++ b/msp-claude-plugins/domotz/domotz/GOVERNANCE.md
@@ -1,0 +1,110 @@
+# Domotz plugin — governance and safety model
+
+Unofficial. Community-built plugin for the Domotz API. Not affiliated
+with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches Domotz through the
+WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the tenant the
+operator is authorised for.
+
+- No Domotz API key is stored on the technician's machine, in this
+  repo, or in the model's context.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log
+  answers "who power-cycled that outlet" — Domotz's own log records
+  only the API account.
+- Revoking gateway access revokes Domotz access with it, immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change Domotz or customer-network state. Safe for autonomous agents. | `domotz_status`, `domotz_navigate`, `domotz_back`, `domotz_agents_list`, `domotz_agents_get`, `domotz_devices_list`, `domotz_devices_get`, `domotz_devices_inventory`, `domotz_devices_history`, `domotz_devices_uptime`, `domotz_alerts_device_list`, `domotz_alerts_profiles_list`, `domotz_metrics_snmp_sensors_list`, `domotz_metrics_sensor_history`, `domotz_metrics_variables_list`, `domotz_metrics_variable_history`, `domotz_network_interfaces`, `domotz_network_ip_conflicts`, `domotz_network_topology`, `domotz_power_outlets_list` |
+| **Write** | Nothing in this plugin creates or edits a Domotz record. | — |
+| **Destructive** | Physically interrupts power to customer hardware. Requires explicit per-call human approval. | `domotz_power_outlet_control` |
+
+This plugin is **read-only with a single exception**, and that
+exception is the sharpest tool in this batch.
+
+`domotz_power_outlet_control` switches an outlet on a monitored PDU
+`on`, `off`, or `cycle`. It does not change a monitoring record — it
+cuts mains power to whatever is plugged into that outlet. The blast
+radius is physical and immediate: an unplanned power cut to a server,
+a storage array, or a firewall risks filesystem corruption and an
+unattended site with nobody able to press the button back on. It sits
+in the destructive tier for that reason, and the vendor server agrees
+— the tool's own description is prefixed `DESTRUCTIVE ACTION` and it
+refuses to run unless `confirm: true` is passed explicitly.
+
+The remaining twenty tools are `GET` requests against the Domotz API.
+There is no tool that deletes an agent, edits a device, changes an
+alert profile, or reconfigures monitored hardware.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.**
+
+- Read tools: allow. Site inventory, topology mapping, IP-conflict
+  detection, and cross-site health reporting are the intended
+  autonomous use.
+- Write tools: none exist.
+- `domotz_power_outlet_control`: require a named human approver per
+  invocation, and confirm the specific outlet with the customer before
+  the call. Do not grant this to scheduled or unattended agents under
+  any circumstances — "cycle the outlet if the device stops
+  responding" is exactly the automation that takes a site down at 3am
+  with nobody on site.
+
+## What it cannot reach
+
+- Only the Domotz agents mapped to the operator's gateway identity.
+- Only the Domotz region cluster the credential belongs to
+  (`us-east-1` or `eu-central-1`); a credential for one cannot see the
+  other's data.
+- No filesystem, no shell, no other vendor's data.
+- Nothing beyond a site's own LAN. Every device query is scoped to one
+  agent, so there is no cross-site or fleet-wide query surface — a
+  fleet report means iterating agents explicitly.
+- No device configuration. Domotz observes the network and switches
+  outlets; it does not change device settings.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the
+  session and are not persisted by this plugin.
+- **`domotz_devices_list` and `domotz_devices_inventory` return a full
+  LAN census** — MAC addresses, hostnames, vendor, and IP for every
+  device that answered a scan. At a small business this includes
+  personal phones, laptops, and smart TVs belonging to staff, not just
+  managed assets. Treat it as premises data about people, not just an
+  equipment list.
+- **`domotz_network_topology` and `domotz_network_interfaces` describe
+  the internal shape of a customer network.** Combined with the device
+  census this is close to what an attacker would want for lateral
+  movement. Restrict it if your agents run unattended or if transcripts
+  are retained.
+- `domotz_agents_get` returns licence counts and site location
+  coordinates.
+
+## Known sharp edges
+
+- **The device inventory is only as fresh as the agent.** If a
+  collector is offline, device records persist and read as last-known
+  rather than current. An agent reporting "all devices online" from
+  stale data at a site whose collector died is worse than no report.
+  Check the agent's own status before trusting device status.
+- **Power control has no undo.** `cycle` is not a soft restart of a
+  service; it is a mains interruption. There is no confirmation that
+  the connected equipment came back, only that the outlet is on again.
+- **Every device query needs an agent ID.** Omitting it does not
+  return everything — it fails, or worse, an agent picks an arbitrary
+  site and reports one customer's devices under another's name.
+- **Documented tool names lag the server.** The skills in this plugin
+  describe some tools under older names (for example `domotz_list_devices`
+  or `domotz_scan_network`) that the current server does not expose. The
+  table above reflects what the server actually serves; prefer it when
+  the two disagree.

--- a/msp-claude-plugins/domotz/domotz/skills/agents/SKILL.md
+++ b/msp-claude-plugins/domotz/domotz/skills/agents/SKILL.md
@@ -18,6 +18,17 @@ when_to_use: >-
 
 Domotz agents (also called collectors or probes) are software or hardware appliances deployed at customer sites that perform network discovery, device monitoring, and data collection. Each agent represents a monitored site/location and is the entry point for all device and network operations.
 
+## Anti-triggers
+
+- **Claude subagents** — "agent" here is a site collector appliance,
+  never an AI subagent definition under `agents/*.md`.
+- **Software installed on a workstation or server** — Domotz agents are
+  one per site, not one per endpoint. RMM endpoint agents are `atera`
+  or `ncentral`; the Huntress endpoint sensor is `huntress-agents`.
+- **What the collector found** — this skill covers the collector's own
+  health, licensing, and connectivity; the devices it discovered are
+  `domotz-devices`.
+
 ## Key Concepts
 
 ### Agent Types

--- a/msp-claude-plugins/domotz/domotz/skills/alerts/SKILL.md
+++ b/msp-claude-plugins/domotz/domotz/skills/alerts/SKILL.md
@@ -17,6 +17,18 @@ when_to_use: >-
 
 Domotz provides a comprehensive alerting system that monitors device status, network conditions, and sensor results. Alerts are generated when monitored conditions meet configured thresholds and can be routed to various notification channels including email, webhooks, and PSA integrations.
 
+## Anti-triggers
+
+- **A security detection** — Domotz alerts are availability and
+  threshold conditions, never threat findings; use
+  `huntress-incidents`.
+- **An incident record with acknowledgement, escalation, and MTTR** —
+  Domotz alerts have no responder lifecycle; use
+  `betterstack-incidents`, `pagerduty-incidents`, or
+  `rootly-incidents`.
+- **The same condition seen across every client** — if the question
+  spans tenants rather than one site, use `auvik-alerts`.
+
 ## Key Concepts
 
 ### Alert Types

--- a/msp-claude-plugins/domotz/domotz/skills/devices/SKILL.md
+++ b/msp-claude-plugins/domotz/domotz/skills/devices/SKILL.md
@@ -18,6 +18,20 @@ when_to_use: >-
 
 Domotz automatically discovers and monitors devices on networks where agents are deployed. Devices include servers, workstations, network equipment, IoT devices, printers, and any IP-connected hardware. Each device is associated with a specific agent (site).
 
+## Anti-triggers
+
+- **A managed endpoint with software installed on it** — a Domotz
+  device is anything that answered a LAN scan, including unmanaged
+  phones, printers, and IoT gear. Managed-endpoint inventory is
+  `atera` or `ncentral`.
+- **Infrastructure across every client at once** — Domotz queries are
+  scoped to a single agent, so fleet-wide network inventory means
+  fanning out site by site; `auvik-devices` answers it directly.
+- **Meraki hardware you intend to act on** — reading it here is fine,
+  but reboot, removal, and config key off the Dashboard serial; use
+  `meraki-devices`.
+- **Attack-surface or rogue-asset discovery** — use `runzero`.
+
 ## Key Concepts
 
 ### Device Discovery

--- a/msp-claude-plugins/domotz/domotz/skills/eyes/SKILL.md
+++ b/msp-claude-plugins/domotz/domotz/skills/eyes/SKILL.md
@@ -17,6 +17,17 @@ when_to_use: >-
 
 Domotz Eyes are synthetic monitoring sensors that run from Domotz agents to actively test service availability and performance. Unlike passive SNMP monitoring, Eyes actively probe endpoints with TCP connections, HTTP requests, and custom checks to verify services are responding correctly.
 
+## Anti-triggers
+
+- **Checking a public URL from the internet** — Eyes probe from inside
+  the customer LAN, which is what makes them right for internal
+  targets and wrong for proving a public service is reachable. Use
+  `betterstack-monitors`.
+- **Passive polling of a device's own metrics** — Eyes actively probe a
+  service; SNMP counters and thresholds are `domotz-network`.
+- **The notification a failed check produced** — this skill covers the
+  sensor and its results; the alert lifecycle is `domotz-alerts`.
+
 ## Key Concepts
 
 ### Eye Types

--- a/msp-claude-plugins/domotz/domotz/skills/network/SKILL.md
+++ b/msp-claude-plugins/domotz/domotz/skills/network/SKILL.md
@@ -17,6 +17,17 @@ when_to_use: >-
 
 Domotz provides comprehensive network monitoring capabilities through its agents. This includes network device discovery, SNMP polling for hardware metrics, TCP port monitoring, speed tests for bandwidth measurement, and network topology mapping.
 
+## Anti-triggers
+
+- **A switch port's VLAN, PoE, or link state** — the ports here are TCP
+  service ports on a host, not physical switch ports. Meraki switch
+  ports are `meraki-devices`.
+- **Interface counters across a whole MSP fleet** — Domotz polls one
+  site at a time; fleet-wide interface and utilisation history is
+  `auvik-networks`.
+- **Scanning to enumerate an attack surface** — Domotz discovery feeds
+  monitoring, not security assessment; use `runzero`.
+
 ## Key Concepts
 
 ### Network Scanning

--- a/msp-claude-plugins/meraki/meraki/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/meraki/meraki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "meraki",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Claude plugins for Cisco Meraki - Dashboard API v1 network management, organization/network/device inventory, wireless (MR), switching (MS), security appliance (MX) firewall & VPN, camera/sensor (MV/MT) access, live troubleshooting tools, and client policy management for MSPs",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/meraki/meraki/GOVERNANCE.md
+++ b/msp-claude-plugins/meraki/meraki/GOVERNANCE.md
@@ -1,0 +1,168 @@
+# Meraki plugin — governance and safety model
+
+Unofficial. Community-built plugin for the Cisco Meraki Dashboard API.
+Not affiliated with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches Meraki through the
+WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the tenant the
+operator is authorised for.
+
+- No Meraki Dashboard API key is stored on the technician's machine, in
+  this repo, or in the model's context.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log
+  answers "who replaced that firewall ruleset". The Meraki change log
+  records only the Dashboard account that owns the API key, which for
+  an MSP is usually a shared service account.
+- Revoking gateway access revokes Meraki access with it, immediately.
+
+## Tool permission tiers
+
+Meraki is the plugin in this batch that can actually change a
+customer's network, so the tiering below is driven by blast radius
+rather than by HTTP verb.
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change Meraki or device state. Safe for autonomous agents. | `meraki_status`, `meraki_navigate`, `meraki_organizations_list`, `meraki_organizations_get`, `meraki_organizations_inventory_list`, `meraki_networks_list`, `meraki_networks_get`, `meraki_devices_list`, `meraki_devices_get`, `meraki_clients_list`, `meraki_clients_get`, `meraki_clients_get_policy`, `meraki_wireless_ssids_list`, `meraki_wireless_rf_profiles_list`, `meraki_switch_ports_list`, `meraki_switch_port_statuses_list`, `meraki_appliance_firewall_l3_get`, `meraki_appliance_vpn_status_get` |
+| **Write** | Changes Dashboard records. Reversible, bounded to one object, no site-wide effect. | `meraki_networks_update`, `meraki_clients_update_policy` |
+| **Destructive** | Can interrupt connectivity for a whole site, or delete Dashboard objects. Requires explicit per-call human approval. | `meraki_appliance_firewall_l3_update`, `meraki_switch_ports_update`, `meraki_wireless_ssids_update`, `meraki_devices_reboot`, `meraki_devices_remove`, `meraki_networks_delete`, `meraki_raw_request` |
+
+### Why four non-delete tools sit in the destructive tier
+
+The four config-write tools below are `PUT`/`POST` calls that delete
+nothing. They are destructive because of a property peculiar to
+network management: **the operator applies the change over the link
+the change can break.**
+
+- **`meraki_appliance_firewall_l3_update` replaces the entire
+  ruleset.** It is not additive. Any rule omitted from the payload is
+  gone, and the new ruleset takes effect immediately. A mistake either
+  cuts the site off the internet or silently opens it up. If it cuts
+  the site off, the MX loses its Dashboard connection — and the
+  Dashboard is how you would push the fix. Recovery becomes a site
+  visit or an out-of-band line.
+- **`meraki_switch_ports_update` can partition a site.** Changing a
+  port's VLAN or disabling it is a single-port operation until the
+  port in question is the uplink to the rest of the building, or the
+  one the customer's server is on. Same lockout property as the
+  firewall.
+- **`meraki_wireless_ssids_update` can drop every wireless client at
+  once.** Changing auth mode, PSK, or VLAN on an SSID disconnects
+  every device using it, and they cannot rejoin with the old
+  credentials. At sites where wireless *is* the network — retail,
+  warehousing, clinical carts — that is a full outage, and a
+  technician working over that SSID has cut their own connection.
+- **`meraki_devices_reboot` drops the site when the target is an MX or
+  a core MS.** The vendor server's own description calls it
+  "HIGH-IMPACT", and a reboot is not selective about who was mid-call
+  or mid-transaction.
+
+`meraki_raw_request` is destructive-tier because it reaches **any**
+Dashboard API v1 endpoint with any method. It is not bounded by the
+curated tool set, so it can VLAN-delete, change VPN topology, or touch
+org administrators — surfaces that have no curated safety wrapper at
+all.
+
+`meraki_networks_update` stays in the write tier because its
+documented surface is name, tags, and timezone. Note the one caveat:
+Meraki tags can bind a network to a configuration template, so a tag
+change is not always cosmetic.
+
+### The confirmation flag does not cover what you would expect
+
+The server enforces two independent controls, and it is worth knowing
+exactly where each applies:
+
+1. **`READ_ONLY_MODE`** defaults to **true** and blocks every write
+   tool. While it is on, this plugin is effectively read-only and the
+   tiering above is advisory.
+2. **`confirm_destructive_action`** is required by only three tools:
+   `meraki_devices_remove`, `meraki_networks_delete`, and
+   `meraki_raw_request` when the method is mutating.
+
+So once `READ_ONLY_MODE` is off, the firewall replace, switch port
+update, SSID update, and device reboot execute **with no confirmation
+argument at all** — the four highest-blast-radius config changes are
+the ones the flag does not guard. The vendor server marks all of them
+`destructiveHint: true` in their tool annotations, but that hint is
+advice to the model, not an enforced gate. Human approval for these
+has to come from your agent policy; do not rely on the tool schema to
+stop them.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.**
+
+- Read tools: allow. Offline-device sweeps, firmware and lifecycle
+  audits, firewall rule *reviews*, and VPN health checks are the
+  intended autonomous use.
+- Write tools: agent drafts the exact call, human approves, then it
+  runs.
+- Destructive tools: require a named human approver per invocation.
+  For the config-write tools, the approval must include a
+  before/after diff — fetch current state with the matching `_get` or
+  `_list` tool and show it. Do not grant these to scheduled or
+  unattended agents.
+- Leave `READ_ONLY_MODE=true` unless a specific change window needs
+  otherwise.
+
+## What it cannot reach
+
+- Only the Meraki organizations the API key can see, and only the
+  tenants mapped to the operator's gateway identity.
+- **Only Meraki-branded hardware.** Anything else on the customer's
+  network is invisible here regardless of permissions.
+- Only the regional Meraki cloud the key belongs to; keys are not
+  shared between the global and China clouds.
+- No filesystem, no shell, no other vendor's data.
+- No device CLI or SSH. All changes go through the Dashboard cloud,
+  which is also why a change that breaks connectivity cannot be undone
+  remotely.
+- The key inherits the permissions of the Dashboard account that
+  generated it. A full-org admin key gives this plugin full-org admin
+  reach — prefer a least-privilege service account.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the
+  session and are not persisted by this plugin.
+- **`meraki_clients_list` and `meraki_clients_get` return end-user
+  device data** — hostnames, MAC addresses, IPs, and usage. Hostnames
+  routinely identify individuals ("sarahs-iphone"), which makes this
+  personal data in most jurisdictions, not just network telemetry.
+- `meraki_appliance_firewall_l3_get` exposes the customer's security
+  posture in full. A leaked ruleset tells an attacker exactly what is
+  and is not filtered.
+- `meraki_appliance_vpn_status_get` maps inter-site topology and
+  exported subnets.
+
+## Known sharp edges
+
+- **Read before every write, without exception.** The firewall update
+  replaces rather than merges. An agent that constructs a ruleset from
+  its own assumptions, rather than from a fresh
+  `meraki_appliance_firewall_l3_get`, will silently drop every rule it
+  did not think to include.
+- **You cannot fix a lockout through this plugin.** Every tool depends
+  on the device reaching the Meraki cloud. A change that breaks WAN
+  connectivity removes the only path you had to revert it. Treat MX
+  and core-switch changes as requiring someone reachable on site.
+- **The rate limit is shared with the customer.** Meraki allows roughly
+  10 requests/second per organization across *all* callers — this
+  plugin, the customer's own Dashboard users, and any other MSP
+  tooling. A fan-out sweep across devices can rate-limit the
+  customer's own admins out of their dashboard. Prefer the org-wide
+  aggregate endpoints over per-device loops.
+- **Reboot is idempotent, its consequences are not.** The tool is
+  marked idempotent because rebooting twice yields the same end state.
+  It does not mean the second reboot was free — it means another
+  outage.
+- **Removal returns hardware to inventory, it does not delete it.**
+  `meraki_devices_remove` unassigns from a network. Recovering from a
+  mistaken removal means re-adding and reconfiguring the device, since
+  network-level config does not follow it back.

--- a/msp-claude-plugins/meraki/meraki/skills/devices/SKILL.md
+++ b/msp-claude-plugins/meraki/meraki/skills/devices/SKILL.md
@@ -17,6 +17,21 @@ when_to_use: >-
 
 Meraki devices are cloud-managed hardware identified by an immutable **serial number** (format `Q2XX-XXXX-XXXX`). Devices are claimed into an organization's inventory, then assigned to a network. This skill covers listing, inspecting, rebooting, and removing devices, plus reading device and uplink status through the `meraki_raw_request` passthrough.
 
+## Anti-triggers
+
+- **Hardware that is not Meraki** — every tool here keys off a Meraki
+  serial and the Dashboard API. Mixed-vendor network inventory is
+  `auvik-devices`; per-site LAN discovery is `domotz-devices`.
+- **Power-cycling something the Dashboard does not manage** —
+  `meraki_devices_reboot` reboots Meraki hardware only. Cutting power
+  to anything else at the site needs a switched PDU, which the Domotz
+  plugin controls; start from `domotz-devices` to find it.
+- **Firewall rules, VPN peers, or MX uplink policy** — use
+  `meraki-security-appliance`.
+- **Proving a device is genuinely unreachable** — status fields are
+  point-in-time and go stale; run live diagnostics with
+  `meraki-troubleshooting`.
+
 ## Key Concepts
 
 ### The Serial Is the Identity

--- a/msp-claude-plugins/meraki/meraki/skills/security-appliance/SKILL.md
+++ b/msp-claude-plugins/meraki/meraki/skills/security-appliance/SKILL.md
@@ -17,6 +17,23 @@ when_to_use: >-
 
 The Meraki **MX** is a cloud-managed security appliance combining routing, stateful firewall, SD-WAN, and Auto VPN. This skill covers the two curated MX capabilities: reviewing and updating the **Layer 3 outbound firewall** ruleset, and checking **site-to-site VPN** status. Firewall changes are high-impact -- the update tool replaces the entire ruleset, so read before you write.
 
+## Anti-triggers
+
+- **A firewall that is not a Meraki MX** — these rules are MX L3
+  outbound only. A Fortinet, SonicWall, or Palo Alto ruleset is not
+  reachable from this plugin at all; `auvik-devices` can tell you what
+  the firewall is, not change it.
+- **Inbound port forwarding, content filtering, or L7 rules** — the
+  curated tools cover the L3 outbound list alone; everything else on
+  the MX goes through `meraki_raw_request`, documented in
+  `meraki-api-patterns`.
+- **Client VPN or a remote-access VPN user** —
+  `meraki_appliance_vpn_status_get` reports site-to-site Auto VPN peers
+  only.
+- **A tunnel that is down because the appliance is** — check the MX and
+  its uplinks before diagnosing VPN config; use
+  `meraki-troubleshooting`.
+
 ## L3 Outbound Firewall
 
 ### Rule Model

--- a/msp-claude-plugins/meraki/meraki/skills/troubleshooting/SKILL.md
+++ b/msp-claude-plugins/meraki/meraki/skills/troubleshooting/SKILL.md
@@ -18,6 +18,19 @@ when_to_use: >-
 
 Meraki's **live tools** run diagnostics on demand from a device against a target -- ping, cable test, throughput test, wake-on-LAN, ARP table, and more. These are **not curated MCP tools**; they ride the `meraki_raw_request` passthrough because they map to dozens of endpoints under `/devices/{serial}/liveTools/...`. This skill covers the async live-tools pattern, plus reboots (`meraki_devices_reboot`) and uplink checks for a complete connectivity-triage toolkit.
 
+## Anti-triggers
+
+- **"Is the customer's website up?"** — live tools probe outward from a
+  Meraki device on the customer LAN, which cannot tell you what the
+  internet sees. External uptime checking is `betterstack-monitors`.
+- **A workstation or server problem that is not a network problem** —
+  use `atera` or `ncentral`.
+- **Historical trend data** — a live tool returns one point-in-time
+  result; interface history and utilisation over time are
+  `auvik-networks`.
+- **Deciding whether a firewall rule is what is blocking the traffic**
+  — use `meraki-security-appliance`.
+
 ## Why Live Tools Use `meraki_raw_request`
 
 The 27 curated tools cover inventory, config, and status. Live tools are transient diagnostics with an async job lifecycle and a long tail of endpoint variants -- wrapping each one individually adds little value. Instead, invoke them through `meraki_raw_request`, which reaches any Dashboard API v1 path directly.


### PR DESCRIPTION
Applies the connector-quality standard (`_standards/skill-quality-checklist.md`, `_templates/skill-template/SKILL.md`, `_templates/governance-template.md`) to the network-monitoring / infrastructure-monitoring batch.

Branched from `feat/skill-anti-triggers-governance`. **Additive only** — 0 deletions across all 19 modified files. No `triggers:` frontmatter (#158). No changes to `_standards/`, `_templates/`, `marketplace.json`, or `plugins.ts`. `npm run generate` not run.

## Task A — Anti-triggers

| Plugin | Added | Skipped |
|---|---|---|
| `auvik` | 3 — devices, networks, alerts | 1 — api-patterns |
| `domotz` | 5 — agents, devices, network, eyes, alerts | 1 — api-patterns |
| `meraki` | 3 — devices, security-appliance, troubleshooting | 1 — api-patterns |
| `azure-mcp` | 3 — connection, observability, cost-and-capacity | 0 |
| `betterstack` | 5 — monitors, incidents, oncall, logging, status-pages | 1 — api-patterns |
| **Total** | **19** | **4** |

**Why all four `api-patterns` skills were skipped.** Each is vendor-scoped auth/pagination/rate-limit material whose `when_to_use` keywords are already vendor-prefixed (`auvik api`, `domotz pagination`, `meraki rate limit`, `betterstack token`). Per the checklist, "two skills whose names alone disambiguate them do not need it" — a section here would have only negated `when_to_use`.

**The collisions actually targeted:**

- **"device" / "network" / "alert"** across auvik + domotz + meraki + `runzero`. The sharpest is the *network* homonym: an Auvik network is an IP subnet, a Meraki network is a Dashboard site container. Same word, unrelated objects.
- **"agent"** in `domotz-agents` — a site collector appliance, not an endpoint sensor (`huntress-agents`, `atera`, `ncentral`), and not a Claude subagent under `agents/*.md`.
- **"monitor"** in `betterstack-monitors` vs the `monitor` namespace in `azure-mcp-observability`.
- **"on-call" / "escalation" / "paging"** in `betterstack-oncall` vs `pagerduty-oncall` and `rootly-oncall` — identical vocabulary, nothing in the phrasing disambiguates.
- **"Azure tenant"** in `azure-mcp-connection` — in MSP usage this usually means the M365 tenant, which is `cipp-tenants` / `microsoft-graph-connection`, not ARM.

**Judgement calls:**

- Meraki is a device *vendor* as well as a monitoring surface, so its anti-triggers route *inward* on Meraki hardware and *outward* on everything else, rather than pushing all "device" traffic away.
- `betterstack-status-pages` got only 2 bullets — status pages are genuinely distinctive; the one real mistake is treating the page as the source of truth for health.
- The capability boundary doubles as the routing rule in two places: Better Stack checks from public regions and cannot reach RFC1918, so internal checks are `domotz-eyes`; Domotz Eyes probe from inside the LAN and cannot prove public reachability, so public checks are `betterstack-monitors`.
- Every cross-plugin reference was verified against `plugin.json` (this caught `connectwise` → `connectwise-psa`).

## Task B — GOVERNANCE.md

One per plugin, from the template, Conduit-gateway framing retained. Tool names derived from each plugin's own skills and **cross-checked against `/Users/asachs/mcp/{auvik,domotz,meraki}-mcp/src/`**.

| Plugin | Read | Write | Destructive |
|---|---|---|---|
| `auvik` | 25 | 1 | 0 (+ `auvik_raw_request` held out of tiers) |
| `domotz` | 20 | 0 | 1 |
| `meraki` | 18 | 2 | 7 |
| `azure-mcp` | 9 | 0 | 0 |
| `betterstack` | 21 | 14 | 5 |

### Destructive-tier calls that are not deletes

**Meraki — four config writes, classified destructive because the operator applies the change over the link the change can break.** A bad ruleset cuts the site off the internet, the MX loses its Dashboard connection, and the Dashboard is the only path to push the fix. Recovery becomes a site visit.

- `meraki_appliance_firewall_l3_update` — replaces the entire ruleset; any omitted rule is deleted.
- `meraki_switch_ports_update` — one port until that port is the building uplink.
- `meraki_wireless_ssids_update` — drops every wireless client at once; they cannot rejoin with old credentials. At wireless-only sites that is a full outage.
- `meraki_devices_reboot` — server's own description says "HIGH-IMPACT".
- `meraki_raw_request` — any v1 endpoint, any method, no curated safety wrapper.

**Verified gap worth reviewer attention:** `confirm_destructive_action` is enforced by only `meraki_devices_remove`, `meraki_networks_delete`, and `meraki_raw_request` (mutating methods) — confirmed in `src/utils/safety.ts:guardWrite` and each domain's call site. The four highest-blast-radius config changes above call `guardWrite({ destructive: false })`, so once `READ_ONLY_MODE=false` they execute with **no confirmation argument**. The server marks all nine writes `destructiveHint: true`, but that is advice to the model, not an enforced gate. The GOVERNANCE.md says so explicitly.

**Better Stack — two non-deletes in the destructive tier:**

- `pause_monitor` — a trivially reversible one-field change that silently removes detection. A paused monitor raises no incident, pages nobody, and leaves no visible gap. A pause that outlives its maintenance window leaves the customer unmonitored and the SLA report wrong. Loss of detection is the characteristic failure mode of a monitoring product.
- `create_status_page_incident` — publishes to a public, often customer-branded page and notifies subscribers. Deleting the post does not unsend the email.

**Domotz — `domotz_power_outlet_control`.** Not a record change: it cuts mains power to whatever is plugged into the outlet. The vendor server agrees — its description is prefixed `DESTRUCTIVE ACTION` and it refuses without `confirm: true`.

## Findings for follow-up (not fixed here — out of scope for an additive PR)

1. **Domotz skill docs name tools that do not exist.** The skills document `domotz_list_devices`, `domotz_scan_network`, `domotz_run_speed_test`, `domotz_list_eyes`, etc. The server (`domotz-mcp/src`) actually serves `domotz_devices_list`, `domotz_devices_inventory`, `domotz_network_topology`, `domotz_network_ip_conflicts`, `domotz_metrics_*`, and `domotz_power_outlets_list` / `domotz_power_outlet_control`. There is no scan or speed-test tool, and the entire Eyes surface is absent from the server. GOVERNANCE.md reflects the server and flags the drift; the skills themselves need a separate correction pass.
2. **Domotz has an undocumented destructive tool.** `domotz_power_outlet_control` (PDU on/off/cycle) appears in no skill.
3. **Better Stack tool names are inconsistent within the plugin.** `api-patterns` and `oncall` use unprefixed names matching the hosted `mcp.betterstack.com` server; `monitors`, `incidents`, `logging`, and `status-pages` show a `betterstack_` prefix. GOVERNANCE.md uses the unprefixed set and notes the discrepancy.
4. **Auvik and Meraki verified clean** — documented tool names match their sources exactly (Meraki: all 27).
