### PR TITLE
feat(plugins): anti-triggers + governance for crewhu, m365, microsoft-graph, scalepad, timezest

### DIFF
--- a/msp-claude-plugins/crewhu/crewhu/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/crewhu/crewhu/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "crewhu",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Crewhu - CSAT/NPS surveys, employee recognition, badges, and prize/redemption gamification for MSPs",
   "author": {
     "name": "WYRE AI"

--- a/msp-claude-plugins/crewhu/crewhu/GOVERNANCE.md
+++ b/msp-claude-plugins/crewhu/crewhu/GOVERNANCE.md
@@ -1,0 +1,92 @@
+# Crewhu plugin — governance and safety model
+
+Unofficial. Community-built plugin for the Crewhu API. Not affiliated
+with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches Crewhu through the
+WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the Crewhu account the
+operator is authorised for.
+
+- No Crewhu API token is stored on the technician's machine, in this
+  repo, or in the model's context.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers
+  "who pulled this manager's scorecard" — Crewhu's own log records only
+  the API account.
+- Revoking gateway access revokes Crewhu access with it, immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change Crewhu state. Safe for autonomous agents. | `crewhu_surveys_list`, `crewhu_surveys_get`, `crewhu_surveys_search`, `crewhu_surveys_detractors`, `crewhu_surveys_promoters`, `crewhu_users_list`, `crewhu_users_get`, `crewhu_users_search`, `crewhu_badges_list`, `crewhu_badges_get`, `crewhu_badges_history_list`, `crewhu_badges_user_recognition`, `crewhu_prizes_list`, `crewhu_prizes_get`, `crewhu_prizes_history_list`, `crewhu_prizes_user_redemptions`, `crewhu_prizes_pending_redemptions` |
+| **Write** | Creates or modifies records. Reversible, but visible to staff. | `crewhu_badges_update_contest` |
+| **Destructive** | — | None. |
+
+**This plugin is read-only except for one tool.** Seventeen of the
+eighteen tools cannot change anything; `crewhu_badges_update_contest` is
+the sole write, and nothing here deletes data, revokes access, or moves
+money.
+
+That single write still deserves a human. A recognition contest is
+staff-facing gamification: changing its parameters mid-run alters who is
+seen to be winning, and the change is visible to the whole team the next
+time they open Crewhu. It is trivially reversible in the data and not at
+all reversible in the room.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose the one write, never
+grant it unattended.**
+
+- Read tools: allow. Trend reporting, detractor queues, and per-tech
+  roll-ups are the intended autonomous use.
+- `crewhu_badges_update_contest`: agent drafts the exact call, a human
+  approves, then it runs.
+- Destructive tools: none exist, so there is nothing to withhold.
+
+## What it cannot reach
+
+- Only the Crewhu account mapped to the operator's gateway identity.
+- No filesystem, no shell, no other vendor's data.
+- No PSA. Crewhu records the feedback; it cannot raise the follow-up
+  ticket, log the call-back, or credit the account.
+- No live feed. Every tool is point-in-time.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session
+  and are not persisted by this plugin.
+- **This plugin returns employee performance data.** `crewhu_users_*`
+  returns named MSP staff (names, email addresses). `crewhu_surveys_*`
+  ties a score and a free-text customer comment to the technician who
+  handled the ticket — and detractor comments frequently name and
+  criticise that person directly. `crewhu_badges_user_recognition` and
+  `crewhu_prizes_user_redemptions` add a per-employee recognition and
+  reward history.
+- Survey comments are customer verbatims and routinely contain the
+  customer contact's name, their company, and details of their issue.
+- Treat the combination as HR-adjacent. In several jurisdictions,
+  automated processing of employee performance data carries consultation
+  or notification obligations. Restrict these tools if your agents run
+  unattended, and do not pipe detractor comments into a channel the
+  named technician has not been told about.
+
+## Known sharp edges
+
+- **Small denominators mislead.** Technicians with a handful of
+  responses swing wildly. An agent that ranks staff without showing
+  response counts will manufacture a performance problem that does not
+  exist; treat anything under ~10 responses as low-confidence, not as a
+  score.
+- **Comment-only responses have no score.** Coercing them into an
+  average silently biases the result. Report them separately.
+- **Timestamps are tenant-local.** Comparing periods across tenants
+  without normalising produces wrong week boundaries and wrong trends.
+- **The contest write is the only rollback you own.** There is no
+  vendor-side undo tool — restoring a contest means calling
+  `crewhu_badges_update_contest` again with the previous values, so
+  capture them before changing anything.

--- a/msp-claude-plugins/crewhu/crewhu/skills/surveys/SKILL.md
+++ b/msp-claude-plugins/crewhu/crewhu/skills/surveys/SKILL.md
@@ -19,6 +19,20 @@ to a ticket close, a specific tech, or a project milestone. This skill
 covers listing surveys, finding a specific one, and isolating the two
 ends of the curve (detractors and promoters) so MSP managers can react.
 
+## Anti-triggers
+
+- **"User" here is an MSP technician, not an end user.**
+  `crewhu_users_*` returns the staff being scored. A customer's staff
+  account in a tenant is `m365-users` or `cipp-users`; the customer's
+  billing or ticket contact is a PSA contact (`connectwise`,
+  `halopsa`, `kaseya/autotask`).
+- **Acting on a detractor** — Crewhu records the feedback and stops
+  there. Raising the follow-up ticket, logging the call-back, or
+  crediting the account happens in the PSA.
+- **Compliance or insurance questionnaires** — those are also
+  "surveys" in MSP conversation but share nothing with CSAT; use the
+  `compliance-pack` or `scalepad` (`scalepad-controlmap`).
+
 ## API Tools
 
 ### List & Search

--- a/msp-claude-plugins/m365/m365/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/m365/m365/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "m365",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Claude plugins for Microsoft 365 - users, mailboxes, Teams, OneDrive, licensing, and security posture",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/m365/m365/GOVERNANCE.md
+++ b/msp-claude-plugins/m365/m365/GOVERNANCE.md
@@ -1,0 +1,183 @@
+# Microsoft 365 plugin — governance and safety model
+
+Unofficial. Community-built plugin for Microsoft 365 administration via
+Microsoft Graph. Not affiliated with, endorsed by, or sponsored by the
+vendor.
+
+This is the most dangerous plugin an MSP can point at a customer. It
+reaches mailboxes, identities, licences, and files in a live production
+tenant, and several of its routine operations are irreversible in ways
+that are not obvious from the HTTP verb. Read the tiers before granting
+anything.
+
+## What it connects as
+
+This plugin should hold no credentials. It reaches Microsoft Graph
+through the WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`),
+which brokers authentication centrally and scopes every call to the
+tenant the operator is authorised for.
+
+- No client secret is stored on the technician's machine, in this repo,
+  or in the model's context.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers
+  "who disabled that account" — the Microsoft 365 unified audit log
+  records only the app registration, and cannot tell you which
+  technician was behind it.
+- Revoking gateway access revokes Graph access with it, immediately.
+
+**One exception you must know about.** This plugin's `README.md` and
+`.env.example` still document a direct-to-Microsoft path: an Entra app
+registration whose `MICROSOFT_CLIENT_SECRET` sits in a local `.env`
+file. That path puts a tenant-wide, admin-consented credential on a
+technician's laptop and produces no per-operator attribution — every
+action in the customer's audit log appears as the app. Do not use it
+against production tenants. It is documentation drift, not a supported
+deployment model.
+
+## Tool permission tiers
+
+This plugin's skills teach Graph calls directly rather than wrapping
+them in named MCP tools, so the tiers below are keyed to the **Graph
+operation**, which is what actually determines blast radius. Grant
+against the operation, not the endpoint path — several tenant-destroying
+calls are `POST` and several harmless ones are not.
+
+| Tier | What it can do | Operations |
+|---|---|---|
+| **Read** | Cannot change tenant state. Safe for autonomous agents — but see the confidentiality warning below. | `GET /users`, `GET /users/{id}`, `GET /users/{id}/memberOf`, `GET /users/{id}/authentication/methods`, `GET /subscribedSkus`, `GET /reports/authenticationMethods/userRegistrationDetails`, `GET /reports/getMailboxUsageDetail`, `GET /auditLogs/signIns`, `GET /auditLogs/directoryAudits`, `GET /identityProtection/riskyUsers`, `GET /identity/conditionalAccess/policies`, `GET /security/secureScores`, `GET /teams`, `GET /teams/{id}/channels`, `GET /teams/{id}/members`, `GET /users/{id}/joinedTeams`, `GET /users/{id}/drive`, `GET /drives/{id}/items/{id}/permissions`, `GET /users/{id}/calendar/events`, `GET /users/{id}/calendarView`, `POST /users/{id}/calendar/getSchedule`, `GET /sites`, `GET /places/microsoft.graph.room` |
+| **Read (confidential)** | Changes nothing, but returns the contents of a customer's private communications. | `GET /users/{id}/messages`, `GET /users/{id}/messages/{id}` (message body and attachments), `GET /users/{id}/mailboxSettings`, `GET /users/{id}/mailFolders/inbox/messageRules`, `GET /teams/{id}/channels/{id}/messages`, `GET /users/{id}/drive/root/search`, `GET /drives/{id}/root/children` |
+| **Write** | Creates or modifies records. Reversible, but visible to the customer. | `PATCH /users/{id}` (profile properties, `usageLocation`), `POST /users` (create user), `PATCH /users/{id}/mailboxSettings` (out-of-office), `POST /users/{id}/events`, `PATCH /users/{id}/events/{id}`, `POST /users/{id}/onlineMeetings`, `POST /teams`, `POST /teams/{id}/members`, `POST /drives/{id}/items/{id}/createLink`, `POST /drives/{id}/items/{id}/invite`, `POST /identityProtection/riskyUsers/dismiss` |
+| **Destructive** | Blocks a person's access, destroys data on a timer, or speaks to the outside world as someone else. Requires explicit human approval per call. | `PATCH /users/{id}` with `accountEnabled: false`, `POST /users/{id}/revokeSignInSessions`, `POST /users/{id}/assignLicense` with `removeLicenses`, `POST /users/{id}/sendMail`, `POST /users/{id}/events/{id}/cancel`, `DELETE /teams/{id}/members/{id}`, `POST /teams/{id}/archive`, `DELETE /drives/{id}/items/{id}/permissions/{id}`, `PATCH /users/{id}/mailboxSettings` when setting external forwarding |
+
+### Why these four sit in the destructive tier
+
+They are the calls most likely to be mis-tiered by an agent reasoning
+from the HTTP verb, and each one is routine MSP work.
+
+- **`POST /users/{id}/assignLicense` with `removeLicenses`** looks like
+  cost hygiene and is the single most common way an MSP destroys
+  customer data by accident. Removing an Exchange licence starts a
+  30-day clock, after which the mailbox is **permanently deleted**.
+  Nothing in the API response says so. An agent reclaiming "unused"
+  seats from accounts flagged inactive is one bad inactivity threshold
+  away from deleting a director's mail while they are on sabbatical.
+  Convert the mailbox to shared, or confirm the retention path, before
+  the licence comes off.
+- **`POST /users/{id}/sendMail`** changes no directory object at all —
+  and is destructive anyway. It sends mail **as the user**, to
+  recipients who may be outside the organisation, with no indication it
+  was automated. It cannot be recalled, it lands in the customer's Sent
+  Items as if they wrote it, and it is indistinguishable from business
+  email compromise to anyone reviewing the mailbox afterwards. Never
+  grant it to an unattended agent.
+- **`PATCH /users/{id}` with `accountEnabled: false` and
+  `POST /users/{id}/revokeSignInSessions`** block a real person from
+  working, across every device, immediately. Technically reversible;
+  operationally an incident if the target was wrong.
+- **`PATCH /users/{id}/mailboxSettings` setting external forwarding**
+  is the same API shape as setting an out-of-office reply, but silently
+  routes a copy of the customer's mail to an outside address. It is
+  also, verbatim, the persistence mechanism this plugin's own
+  `m365-security` skill teaches you to hunt for. Any agent that can
+  write it can install the exact artefact you audit for.
+
+`POST /teams/{id}/archive` and `DELETE /teams/{id}/members/{id}` are
+tiered up for a narrower reason: archiving sets the backing SharePoint
+site read-only for members, and removing the sole owner of a team
+orphans it — a security finding the same skills tell you to report.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.**
+
+- Read tools: allow — with the exception of the confidential-read row.
+  Licence audits, MFA-coverage reports, sign-in reviews, and Secure
+  Score reporting are the intended autonomous use.
+- Confidential reads: restrict deliberately. Reading a customer's mail
+  changes nothing, so a verb-based policy will wave it through; decide
+  separately whether an agent should ever see message bodies, and log it
+  when it does.
+- Write tools: agent drafts the exact call, human approves, then it
+  runs.
+- Destructive tools: require a named human approver per invocation. Do
+  not grant these to scheduled or unattended agents under any
+  circumstances.
+- Prefer the read-only route for questions. If the task is "how many",
+  "who has no MFA", or "which licences are unused", the `microsoft-graph`
+  plugin answers it with a structurally read-only tool surface and no
+  write path to mis-fire. Use this plugin when you intend to change
+  something.
+
+## What it cannot reach
+
+- Only the Microsoft 365 tenants mapped to the operator's gateway
+  identity, and within them only what the granted Graph scopes and the
+  caller's Entra roles permit.
+- No filesystem, no shell, no other vendor's data.
+- **One tenant at a time.** There is no fleet view here; "across all our
+  customers" is a `cipp` question.
+- **Not everything is in Graph.** Shared-mailbox full-access
+  permissions, mailbox-to-shared conversion, SharePoint site ownership
+  transfer, and message trace need Exchange or SharePoint PowerShell, or
+  the admin centre. An offboarding run through this plugin alone leaves
+  those steps undone — say so rather than reporting the offboarding
+  complete.
+- No push feed. Every call is point-in-time; sign-in logs lag.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session
+  and are not persisted by this plugin.
+- **This plugin returns message content.** `GET /users/{id}/messages`
+  with `$select=body` places the customer's private correspondence —
+  including anything a third party sent them in confidence — into the
+  model context. This is the single most sensitive capability in the
+  fleet. Restrict it, and treat any transcript containing it
+  accordingly.
+- **Sign-in telemetry is personal data.** `GET /auditLogs/signIns`
+  returns IP addresses and geolocation per named user. In several
+  jurisdictions this attracts employee-monitoring obligations
+  independent of the customer's consent to IT support.
+- **Directory and licence reads carry PII throughout**: names, UPNs,
+  email addresses, job titles, managers, group membership, device
+  names, guest/external account details.
+- **File and mailbox search results leak by title.** A search across
+  OneDrive or SharePoint returns file names — "Redundancy plan Q3",
+  "Acquisition — Project Falcon" — which disclose sensitive facts even
+  when the content is never opened.
+- **Credentials in flight.** `POST /users` includes a `passwordProfile`
+  with a plaintext temporary password. It will appear in the model
+  context and in any transcript of the session. Do not paste it into a
+  ticket note or a chat channel.
+
+## Known sharp edges
+
+- **Licence removal is a delayed delete.** Repeated because it is the
+  one that ends in data loss: 30 days after the Exchange licence comes
+  off, the mailbox goes. Nothing surfaces this at call time.
+- **`signInActivity` requires Entra ID P1/P2 and returns null
+  otherwise** — indistinguishable from "never signed in". An inactivity
+  sweep on an unlicensed tenant will class the entire directory as
+  dormant and recommend reclaiming every seat. Confirm the licence tier
+  before trusting an inactivity report.
+- **Advanced queries fail silently without the right header.** Filters
+  such as `assignedLicenses/$count eq 0` need `ConsistencyLevel:
+  eventual` and `$count=true`. Missing them yields an error or a wrong
+  result set — and a wrong result set here is the input to a licence
+  reclamation.
+- **Throttling degrades mid-task.** Graph returns 429 with `Retry-After`
+  at roughly 10,000 requests per 10 minutes per app per tenant. A
+  tenant-wide per-user loop — MFA methods, mailbox rules — will hit it
+  partway through and produce a partial audit that looks complete.
+  Paginate to exhaustion and check for truncation before reporting
+  totals.
+- **`Authorization_RequestDenied` is usually consent, not a bug.** The
+  scope was never admin-consented in that tenant. Fix consent; do not
+  retry.
+- **Removing the sole team owner orphans the team.** Check ownership
+  before any offboarding removal, and assign a replacement first.
+- **Soft-delete is a 30-day window, not a safety net.** A deleted user is
+  recoverable for 30 days and then is not. Do not describe deletion as
+  reversible without saying when it stops being so.

--- a/msp-claude-plugins/m365/m365/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/m365/m365/skills/api-patterns/SKILL.md
@@ -17,6 +17,30 @@ when_to_use: >-
 
 Microsoft Graph is the unified REST API surface for all M365 services (users, mail, calendar, Teams, OneDrive, security). All M365 MCP tools ultimately make Graph calls. Understanding Graph's OData query syntax, pagination model, throttling behavior, and auth patterns is essential for building reliable M365 workflows.
 
+## Anti-triggers
+
+This skill teaches you to compose Graph calls by hand. Two neighbouring
+plugins cover the same tenant with almost identical vocabulary, and
+choosing the wrong one is the most common routing mistake in the
+Microsoft estate:
+
+- **A read-only question about one tenant** — "how many users", "who
+  has no MFA registered", "which licences are unassigned". The Graph
+  Enterprise MCP answers these from a vetted query catalogue, so nobody
+  hand-writes a `$filter`; use the `microsoft-graph` plugin's
+  `microsoft-graph-querying` skill. Hand-writing a Graph URL when that
+  server is connected is the exact error pattern it exists to prevent.
+- **Anything spanning more than one customer tenant** — fleet-wide
+  standards, BPA drift, GDAP, or a packaged action such as offboard /
+  reset MFA / revoke sessions. Use the `cipp` plugin, which carries the
+  multi-tenant scope and per-tenant audit trail this plugin does not.
+- **A tenant that authenticates but returns nothing** — that is an app
+  registration and admin-consent problem, not a query-syntax problem;
+  use `microsoft-graph-connection`.
+
+The short rule: **ask one tenant → `microsoft-graph`; change one tenant
+→ this plugin; do either across the fleet → `cipp`.**
+
 ## Authentication
 
 ### Token Scope for MSP Operations

--- a/msp-claude-plugins/m365/m365/skills/calendar/SKILL.md
+++ b/msp-claude-plugins/m365/m365/skills/calendar/SKILL.md
@@ -18,6 +18,27 @@ when_to_use: >-
 
 Microsoft 365 calendar is powered by Exchange Online and surfaced through Microsoft Graph. For MSPs, calendar tasks include troubleshooting scheduling issues, creating meetings on behalf of users, managing room resources, and checking user availability during support incidents.
 
+## Anti-triggers
+
+"Schedule a meeting" routes three different ways depending on who picks
+the time. Here, *you* pick it and write the event straight into a
+mailbox:
+
+- **The customer picks the slot from a booking link** — a self-service
+  scheduling request tied to a PSA ticket is what TimeZest is for; use
+  the `timezest` plugin (`timezest-scheduling`). Writing the event
+  directly here bypasses the PSA workflow and the customer's choice.
+- **Dispatching a technician to a job** — an onsite visit or service
+  window is a PSA service call, which carries the billing and dispatch
+  record a calendar event does not; use the `autotask` plugin
+  (`autotask-service-calls`) or the equivalent PSA plugin.
+- **The same calendar work across many tenants** — use the `cipp`
+  plugin.
+
+Note also that a TimeZest "resource" is a technician or team, while a
+resource here is a room or equipment mailbox — they are not the same
+object.
+
 ## Graph API Patterns
 
 ### Get a User's Calendar Events

--- a/msp-claude-plugins/m365/m365/skills/files/SKILL.md
+++ b/msp-claude-plugins/m365/m365/skills/files/SKILL.md
@@ -18,6 +18,23 @@ when_to_use: >-
 
 Microsoft 365 provides two file storage surfaces: OneDrive (personal, per-user) and SharePoint (team/department libraries). Both are accessible through the same Microsoft Graph `/drives` endpoint. MSP support tasks include investigating access issues, checking storage quotas, managing sharing permissions, and transferring file access during offboarding.
 
+## Anti-triggers
+
+- **Files on the machine this session is running on** — "read the
+  file", "find the config", "list the directory" almost always mean the
+  local filesystem, which Claude Code's own file tools handle. This
+  skill only reaches a customer's cloud storage through Graph, and
+  loading it for local work wastes the call.
+- **Restoring a deleted or ransomware-encrypted file** — past the
+  recycle bin and retention window, Graph has nothing to return; use
+  the `backup-pack` or `kaseya/datto-saas-protection`.
+- **MSP documentation, runbooks, and stored credentials** — those live
+  in the documentation platform, not the customer's OneDrive; use
+  `kaseya/it-glue` or `hudu`.
+- **A tenant-wide external-sharing posture review** — this skill
+  inspects one item's permissions; the policy question across the
+  tenant or the fleet is `m365-security` or `cipp`.
+
 ## Core Concepts
 
 | Surface | Use | Graph Resource |

--- a/msp-claude-plugins/m365/m365/skills/licensing/SKILL.md
+++ b/msp-claude-plugins/m365/m365/skills/licensing/SKILL.md
@@ -18,6 +18,24 @@ when_to_use: >-
 
 M365 licensing is a top billing concern for MSPs. Licenses are purchased as SKU subscriptions, each containing bundles of service plans (Exchange, Teams, SharePoint, etc.). Efficient license management — finding unused seats, rightsizing SKUs, ensuring all users have what they need — directly impacts both the MSP's margin and the customer's costs.
 
+## Anti-triggers
+
+Assigning a seat and buying a seat are different systems, and the word
+"license" covers both:
+
+- **Buying, cancelling, or repricing subscriptions** — changing what
+  the tenant *owns* happens at the distributor, not in Graph.
+  `subscribedSkus` only reports what was already purchased. Use `pax8`
+  (`pax8-subscriptions`), `sherweb`, or `cipp` for CSP licences.
+- **License cost, margin, or invoice reconciliation** — commercial data
+  lives with the distributor and in the PSA contract, not in Entra; use
+  `pax8` (`pax8-invoices`) or the `finance-pack`.
+- **A licence audit across every customer tenant** — use the `cipp`
+  plugin (`cipp-licenses`).
+- **Reading seat utilisation without changing assignments** — the
+  vetted query catalogue answers this without composing a `$filter`;
+  use the `microsoft-graph` plugin's `microsoft-graph-querying` skill.
+
 ## Core Concepts
 
 ### Subscription → SKU → Service Plans

--- a/msp-claude-plugins/m365/m365/skills/mailboxes/SKILL.md
+++ b/msp-claude-plugins/m365/m365/skills/mailboxes/SKILL.md
@@ -18,6 +18,23 @@ when_to_use: >-
 
 Microsoft 365 mailboxes are managed through Exchange Online, accessible via Microsoft Graph. For MSPs, mailbox tasks range from diagnosing delivery failures and searching for lost emails to managing shared mailboxes and offboarding users. Graph provides a unified API across all mailbox types.
 
+## Anti-triggers
+
+- **"The email never arrived"** — most often the message was
+  quarantined or blocked before Exchange, so nothing here will find it.
+  Check the mail-security gateway first: `mimecast`, `spamtitan`,
+  `abnormal`, `ironscales`, or the `email-security` pack. Come back
+  here only once you know the message reached the tenant.
+- **Mailbox permissions and forwarding across tenants** — full-access
+  delegation and forwarding rules are CIPP primitives with proper
+  multi-tenant scope; use the `cipp` plugin (`cipp-mailboxes`).
+- **A suspicious forwarding rule as an active compromise** — this skill
+  reads rules; interpreting them as an indicator, plus session
+  revocation and the rest of the response, is `m365-security`.
+- **Recovering a permanently deleted mailbox or item** — past the
+  retention window this is a backup restore, not a Graph read; use the
+  `backup-pack` or `kaseya/datto-saas-protection`.
+
 ## Mailbox Types
 
 | Type | Description | Common MSP Tasks |

--- a/msp-claude-plugins/m365/m365/skills/security/SKILL.md
+++ b/msp-claude-plugins/m365/m365/skills/security/SKILL.md
@@ -19,6 +19,26 @@ when_to_use: >-
 
 Security checks are among the most high-value tasks an MSP can perform in a customer's M365 tenant. Account compromises, inadequate MFA coverage, and misconfigured mail rules are the leading causes of M365 security incidents. This skill covers the key checks and indicators that separate a secure tenant from a vulnerable one.
 
+## Anti-triggers
+
+"Security" is the most overloaded word in the MSP stack. This skill is
+identity posture inside **one** M365 tenant, read via Graph:
+
+- **A detection or alert on an endpoint** — malware, ransomware,
+  suspicious process, isolate-the-host. That is EDR/MDR, not Entra; use
+  `huntress`, `sentinelone`, `blackpoint`, or `blumira`.
+- **Enforcing a baseline rather than reporting on it** — this skill
+  tells you conditional access is missing; deploying and holding the
+  standard across tenants is `cipp` (`cipp-standards`) or `inforcer`
+  (`inforcer-baseline-alignment`).
+- **The same posture check across every tenant** — use `cipp`
+  (`cipp-security`). One tenant at a time is what this skill does.
+- **Phishing, quarantine, and mail-flow threat verdicts** — those
+  belong to the mail-security gateway: `mimecast`, `abnormal`,
+  `ironscales`, or the `email-security` pack.
+- **Evidence for an audit or insurance questionnaire** — a control
+  attestation is not a Graph query; use the `compliance-pack`.
+
 ## MFA Status Audit
 
 ### Check All Users' Authentication Methods

--- a/msp-claude-plugins/m365/m365/skills/teams/SKILL.md
+++ b/msp-claude-plugins/m365/m365/skills/teams/SKILL.md
@@ -17,6 +17,24 @@ when_to_use: >-
 
 Microsoft Teams is the collaboration hub for most M365 customers. MSP support tasks include troubleshooting access issues, managing team membership, reviewing channel structure, and investigating meeting problems. All Teams data is accessible through Microsoft Graph.
 
+## Anti-triggers
+
+"Team" means something different in four of the plugins an MSP has
+installed. Here it is a Microsoft 365 collaboration workspace backed by
+an Entra group:
+
+- **A scheduling pool of technicians** — TimeZest teams are round-robin
+  availability groups with no Microsoft Teams involvement at all; use
+  the `timezest` plugin (`timezest-agents-and-teams`).
+- **A PSA dispatch queue or technician group** — use the PSA plugins
+  (`halopsa`, `connectwise`, `kaseya/autotask`).
+- **Booking or rescheduling a meeting** — creating the calendar event
+  is `m365-calendar`; this skill covers the Teams objects the meeting
+  hangs off.
+- **Reading Teams chat for an investigation** — message retrieval for
+  compromise or eDiscovery work is a security and retention question,
+  not a membership one; start at `m365-security`.
+
 ## Core Teams Objects
 
 | Object | Description | API Resource |

--- a/msp-claude-plugins/m365/m365/skills/users/SKILL.md
+++ b/msp-claude-plugins/m365/m365/skills/users/SKILL.md
@@ -17,6 +17,20 @@ when_to_use: >-
 
 Users in Microsoft 365 (Entra ID) are the central identity object for your tenant. Every licensed service — Exchange, Teams, OneDrive, SharePoint — flows through the user object. For MSPs, user management spans onboarding new staff, offboarding leavers, license optimization, and security posture checks across customer tenants.
 
+## Anti-triggers
+
+- **Counting, listing, or auditing users without changing them** — a
+  read-only question is cheaper and safer through the vetted query
+  catalogue; use the `microsoft-graph` plugin's
+  `microsoft-graph-querying` skill.
+- **Offboarding as one packaged action, or any user work across more
+  than one tenant** — the multi-step sequence below is a CIPP primitive
+  with its own audit record; use the `cipp` plugin (`cipp-users`).
+- **"User" meaning a PSA contact or an MSP technician** — an Entra user
+  is neither. The customer's billing/ticket contact lives in the PSA
+  (`connectwise`, `halopsa`, `kaseya/autotask`); the technician being
+  scored on a CSAT survey is a `crewhu` user.
+
 ## User Object Key Properties
 
 | Property | Description | MSP Relevance |

--- a/msp-claude-plugins/microsoft-graph/microsoft-graph/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/microsoft-graph/microsoft-graph/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "microsoft-graph",
-  "version": "1.0.2",
-  "description": "Claude plugins for the Microsoft Graph MCP Server for Enterprise (public preview) — query a client's Microsoft Entra identity and directory data (users, groups, applications, devices, admin reporting) in natural language. Read-only, RBAC-honoring access via a RAG-backed suggest-queries workflow.",
+  "version": "1.0.3",
+  "description": "Claude plugins for the Microsoft Graph MCP Server for Enterprise (public preview) \u2014 query a client's Microsoft Entra identity and directory data (users, groups, applications, devices, admin reporting) in natural language. Read-only, RBAC-honoring access via a RAG-backed suggest-queries workflow.",
   "author": {
     "name": "MSP Claude Plugins Community"
   },

--- a/msp-claude-plugins/microsoft-graph/microsoft-graph/GOVERNANCE.md
+++ b/msp-claude-plugins/microsoft-graph/microsoft-graph/GOVERNANCE.md
@@ -1,0 +1,118 @@
+# Microsoft Graph plugin — governance and safety model
+
+Unofficial. Community-built plugin for Microsoft's Graph MCP Server for
+Enterprise. Not affiliated with, endorsed by, or sponsored by the
+vendor.
+
+> The upstream service is a Microsoft **public preview** hosted at
+> `https://mcp.svc.cloud.microsoft/enterprise`. Its tool surface, query
+> catalogue, and scopes may change before general availability.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches the Graph Enterprise
+MCP through the WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`),
+which brokers authentication centrally and scopes every call to the
+tenant the operator is authorised for.
+
+This vendor uses **BYOC** (bring-your-own-credentials): the MSP
+registers its own multi-tenant Entra app and supplies `tenantId`,
+`clientId`, and `clientSecret` **to the gateway**, not to the
+technician. Consequences worth stating plainly:
+
+- No client secret is stored on the technician's machine, in this repo,
+  or in the model's context. It lives at the gateway and rotates there
+  once, not per technician.
+- The token minted is **delegated** — every call executes *as the
+  signed-in user*, not as a service principal. Operator identity is
+  therefore enforced by Entra itself, not merely logged: a technician
+  cannot read what their own Entra roles do not permit.
+- Revoking gateway access revokes Graph access with it, immediately.
+- Separately, a Global Administrator in **each customer tenant** must
+  grant admin consent out of band before that tenant returns any data.
+  Consent is per tenant and revocable by the customer at any time, from
+  their side, without involving you.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change any tenant state. Safe for autonomous agents. | `microsoft_graph_suggest_queries`, `microsoft_graph_list_properties`, `microsoft_graph_get` |
+| **Write** | — | None. |
+| **Destructive** | — | None. |
+
+**This plugin is read-only, structurally and not just by convention.**
+The server exposes exactly three tools, and the only one that reaches a
+tenant — `microsoft_graph_get` — issues HTTP `GET` requests to Microsoft
+Graph. There is no create, update, delete, or action endpoint to
+withhold, no admin-consent scope that would add one, and no parameter
+that turns a read into a write.
+
+This is the strongest safety property in the Microsoft part of the
+fleet, and it is the reason to prefer this plugin for questions. If an
+operator asks for a change, the correct answer is to route to a
+write-capable tool — the `m365` plugin for one tenant, the `cipp`
+plugin for the fleet — not to look for a way to do it here.
+
+## Recommended agent policy
+
+**Allow all three tools to autonomous agents.** Unattended audits,
+scheduled reporting, and cross-tenant question-answering are the
+intended use, and the read-only ceiling makes them safe.
+
+The residual risk is not damage — it is **disclosure and wrong
+conclusions**. See Data handling and Known sharp edges.
+
+## What it cannot reach
+
+- Only the Entra tenants that have granted admin consent to your BYOC
+  app **and** that the signed-in caller's roles permit. Both gates must
+  pass.
+- Nothing outside the consented `MCP.*` delegated scopes.
+- No writes to any tenant, by design.
+- No filesystem, no shell, no other vendor's data.
+- No live event stream. Every call is point-in-time.
+- No fleet view. One delegated token sees one signed-in user in the
+  tenants they are consented into; "across all our tenants" is a `cipp`
+  question.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session
+  and are not persisted by this plugin.
+- **`microsoft_graph_get` returns directory PII by design.** In normal
+  use that includes user names, user principal names and email
+  addresses, job titles, managers, group memberships, device names,
+  licence assignments, and guest/external account details.
+- It also returns **sign-in telemetry**: last sign-in timestamps, source
+  IP addresses, and geolocation. IP and location data about a named
+  individual is personal data in most jurisdictions and is more
+  sensitive than the directory record it attaches to.
+- Everything returned is bounded by the caller's Entra roles and the
+  consented scopes — but within that boundary the model sees the raw
+  records, so the presentation guidance in
+  `microsoft-graph-querying` (answer in plain language; do not surface
+  GUIDs and JSON unasked) is a privacy control, not a style preference.
+
+## Known sharp edges
+
+- **A permissions boundary looks exactly like a clean result.** If
+  admin consent is missing, or the caller's roles are narrower than the
+  question, the tenant returns nothing — and an audit reports "no
+  findings". Confirm consent and scope before treating an empty result
+  as good news. This is the single most dangerous failure mode here and
+  the reason a read-only plugin still needs governance.
+- **Preview service.** Behaviour and the query catalogue may change
+  without notice. Verify anything material in the Entra admin center
+  before acting on it; do not build hard automation dependencies yet.
+- **Rate limit: 100 calls/min/user**, on top of Graph's own throttling.
+  Fanning out speculative `get` calls degrades the tenant for the
+  signed-in user, not just for the agent. Route through
+  `suggest_queries` — one good call beats ten guesses.
+- **Delegated means per-caller, so results are not reproducible across
+  technicians.** The same question asked by two operators with different
+  Entra roles legitimately returns different answers. Record who ran a
+  report on the report.
+- **Licence-gated data returns empty rather than erroring.** PIM and
+  some sign-in reporting need Entra ID P2; without it the field is
+  simply absent, which reads as "nothing to see".

--- a/msp-claude-plugins/microsoft-graph/microsoft-graph/skills/connection/SKILL.md
+++ b/msp-claude-plugins/microsoft-graph/microsoft-graph/skills/connection/SKILL.md
@@ -21,6 +21,18 @@ The Microsoft Graph MCP Server for Enterprise is a Microsoft-hosted MCP server (
 
 Read this whole skill before connecting. The admin-consent requirement is non-obvious and the failure mode (a connection that authenticates fine but returns nothing) looks like a different bug.
 
+## Anti-triggers
+
+- **Actual directory or identity questions** once the connection works —
+  use `microsoft-graph-querying`.
+- **The `m365` plugin's Entra app registration** — it is a *different*
+  app with different (Graph `User.Read.All`-style) permissions and its
+  own consent. Consenting one does not consent the other, and the
+  troubleshooting below does not apply to it; use the `m365` plugin.
+- **GDAP relationships and tenant onboarding across the fleet** — a
+  different consent model entirely, managed per customer relationship
+  rather than per app; use the `cipp` plugin (`cipp-tenants`).
+
 ## How the connection works
 
 - The gateway exposes a `microsoft-graph` vendor that proxies to `https://mcp.svc.cloud.microsoft/enterprise`.

--- a/msp-claude-plugins/microsoft-graph/microsoft-graph/skills/querying/SKILL.md
+++ b/msp-claude-plugins/microsoft-graph/microsoft-graph/skills/querying/SKILL.md
@@ -20,6 +20,27 @@ when_to_use: >-
 
 The Microsoft Graph MCP Server for Enterprise is **not** a raw Graph API passthrough. It is built around a Retrieval-Augmented-Generation (RAG) workflow: you describe what you want, the server hands you vetted candidate API calls from a curated catalog, and you execute the one that fits. Following this loop is the difference between correct answers and made-up endpoints.
 
+## Anti-triggers
+
+Three plugins reach the same Microsoft 365 tenant with near-identical
+vocabulary. This one answers questions; it cannot change anything.
+
+- **Any change to the tenant** — this server issues `GET` only, so
+  there is no write path to fall back on. A single-tenant change
+  (disable an account, assign a licence, set out-of-office) belongs to
+  the `m365` plugin; a packaged multi-tenant action (offboard, reset
+  MFA, revoke sessions) belongs to the `cipp` plugin.
+- **Fleet-wide questions** — "across all our tenants" needs a
+  multi-tenant control plane, not one delegated token scoped to one
+  signed-in user in one consented tenant; use the `cipp` plugin
+  (`cipp-tenants`, `cipp-standards`).
+- **A tenant that authenticates but returns nothing** — that is
+  per-tenant admin consent, not a bad query; use
+  `microsoft-graph-connection`.
+
+The short rule: **ask one tenant → this skill; change one tenant →
+`m365`; do either across the fleet → `cipp`.**
+
 ## The core rule
 
 **Always start with `microsoft_graph_suggest_queries`. Do not invent raw Graph endpoints.**

--- a/msp-claude-plugins/scalepad/scalepad/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/scalepad/scalepad/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "scalepad",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "ScalePad - asset lifecycle management, warranty services, client engagement roadmaps (Lifecycle Manager), compliance (ControlMap), backup monitoring (Backup Radar), and quoting (Quoter) for MSPs",
   "author": {
     "name": "WYRE AI"

--- a/msp-claude-plugins/scalepad/scalepad/GOVERNANCE.md
+++ b/msp-claude-plugins/scalepad/scalepad/GOVERNANCE.md
@@ -1,0 +1,145 @@
+# ScalePad plugin — governance and safety model
+
+Unofficial. Community-built plugin for the ScalePad API. Not affiliated
+with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches ScalePad through the
+WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the ScalePad account
+the operator is authorised for.
+
+- No ScalePad API key — and no Quoter OAuth client secret — is stored on
+  the technician's machine, in this repo, or in the model's context.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers
+  "who published that quote" — ScalePad's own log records only the API
+  account.
+- Revoking gateway access revokes ScalePad access with it, immediately.
+
+One credential, five products. A single ScalePad API key covers Core,
+Lifecycle Manager, ControlMap, Backup Radar, and the hosted Quoter path.
+There is no per-product key, so **you cannot grant an agent Core without
+also granting it Quoter** at the credential layer. Separation has to come
+from the tool tiers below, which is why they matter more here than for a
+single-product vendor.
+
+## Tool permission tiers
+
+The surface is roughly 400 tools across five domains, named
+`scalepad_<domain>_<resource>_<action>` with domain prefixes `core`,
+`lm`, `cm`, `br`, and `quoter`. Tiering by suffix is reliable; the named
+exceptions below are not.
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change ScalePad state. Safe for autonomous agents. | Every `scalepad_core_*` tool (the whole domain is read-only) and every `scalepad_br_*` tool (likewise); across `lm`, `cm`, and `quoter`: `*_list`, `*_get`, `*_search`, `*_list_summaries`, `*_lookup`; plus `scalepad_status` and `scalepad_navigate` |
+| **Write** | Creates or modifies records. Reversible, but often customer-visible. | `*_create`, `*_update`, `*_map` / `*_unmap`, `*_attach` / `*_detach`, `*_upload_document`, and the targeted field updates (`scalepad_lm_initiatives_status_update`, `scalepad_lm_goals_status_update`, `scalepad_lm_action_items_completion_status_update`, and similar) |
+| **Destructive** | Destroys records, exposes client data outside the tenant, or commits commercially. Requires explicit human approval per call. | Every `*_delete` across `lm`, `cm`, and `quoter` — including `scalepad_cm_evidence_delete`, `scalepad_cm_documents_delete`, `scalepad_cm_policies_delete_section`, `scalepad_lm_initiatives_delete`, `scalepad_quoter_items_delete`; plus `scalepad_quoter_quotes_publish`, `scalepad_lm_deliverables_share_link_create`, `scalepad_lm_deliverables_share_link_regenerate`, `scalepad_lm_deliverables_share_link_revoke` |
+
+Three of those destructive entries are not deletes, and the
+classification is deliberate:
+
+- **`scalepad_quoter_quotes_publish`** makes a quote customer-visible.
+  Publishing is not a status flag — it puts your pricing, margin
+  structure, and product selection in front of the client. You can void
+  the quote afterwards; you cannot unsee it, and a wrong number that has
+  been seen becomes a commercial negotiation. Review totals with
+  `scalepad_quoter_quotes_get` first.
+- **`scalepad_lm_deliverables_share_link_create`** mints a link that
+  exposes a client deliverable to whoever holds the URL. It is a
+  `create`, but its blast radius is data leaving the tenant boundary.
+  `_regenerate` compounds this by silently breaking every link already
+  distributed, and `_revoke` removes access someone is currently
+  relying on — the template's own definition of destructive.
+- **`scalepad_cm_evidence_delete` and `scalepad_cm_documents_delete`**
+  destroy compliance evidence. That is not an ordinary record delete:
+  the artefact existed to prove a control was satisfied at a point in
+  time, and an auditor asking for it later cannot be told it was tidied
+  up by an agent.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.**
+
+- Read tools: allow. Because Core and Backup Radar are read-only in
+  their entirety, an agent restricted to those two domains is
+  structurally incapable of changing anything — that is the right shape
+  for asset reporting, warranty review, and backup sweeps.
+- Write tools: agent drafts the exact call, human approves, then it
+  runs. Pay particular attention to `_create` calls in ControlMap; a
+  fabricated control or risk pollutes a compliance record other people
+  will later rely on.
+- Destructive tools: require a named human approver per invocation. Do
+  not grant these to scheduled or unattended agents.
+
+## What it cannot reach
+
+- Only the ScalePad account mapped to the operator's gateway identity.
+- No filesystem, no shell, no other vendor's data.
+- **Only the products the account subscribes to.** Endpoints for
+  unsubscribed products return HTTP 402 — a licensing boundary, not a
+  permissions failure.
+- **Only one data-residency region per call.** ControlMap partitions
+  across `us`/`eu`/`ca`/`au` and Backup Radar across `us`/`eu`; Core and
+  Lifecycle Manager are US-only. Records in another region are invisible,
+  not absent.
+- No live device state. ScalePad asset rows are lifecycle records synced
+  from RMM and PSA integrations, not telemetry — the RMM is the source
+  of truth for what a machine is doing right now.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session
+  and are not persisted by this plugin.
+- **End-customer PII.** `scalepad_core_contacts_*`,
+  `scalepad_lm_contacts_*`, and `scalepad_quoter_contacts_*` return
+  client contact names and email addresses.
+  `scalepad_core_saas_users_*` is more sensitive still: it maps named
+  individuals to the SaaS seats they hold, which is an employee-level
+  inventory of a customer's staff and their tooling.
+- **MSP staff PII.** `scalepad_core_members_*` and
+  `scalepad_lm_active_users_list` return your own team's records.
+- **Commercial data.** `scalepad_quoter_*` exposes cost, margin, and
+  supplier pricing; `scalepad_lm_budget_*` and
+  `scalepad_lm_warranty_pricing_list` expose client budgets and
+  forecasts. Restrict these if agents post output into shared channels.
+- **Signed URLs behave like credentials.**
+  `scalepad_cm_documents_get_signed_url`,
+  `scalepad_cm_reports_get_signed_url`,
+  `scalepad_cm_action_items_generate_signed_urls`,
+  `scalepad_cm_evidence_requests_signed_urls`, and the
+  `scalepad_lm_*_pdf_get` / `_csv_get` exports return artefacts that
+  grant access to anyone holding them for their lifetime. Treat a signed
+  URL in a transcript the way you would treat a password in a
+  transcript.
+- **Compliance content is regulated content.** ControlMap holds risk
+  registers, audit evidence, and policy documents. Its confidentiality
+  obligations usually exceed those of the surrounding MSP tooling.
+
+## Known sharp edges
+
+- **402 is not an auth failure.** It means the account has no
+  subscription for that product. An agent that retries with different
+  credentials, or reports "authentication problem", sends the operator
+  down the wrong path. Surface it as a licensing answer and stop.
+- **A 404 on a known-good ID is usually the wrong region.** Verify
+  `X-ScalePad-Region` before concluding a record was deleted — and
+  before *re-creating* it, which is how duplicates get made.
+- **Deletes are irreversible; attach/detach is not.** Detaching an asset
+  from an initiative is a relationship change you can redo. `*_delete`
+  removes the record. Prefer detach when the intent is "not this one".
+- **Core IDs and Lifecycle Manager keys are different namespaces.** LM
+  addresses hardware by opaque `hardware_key` and clients by
+  `client_key`; these are not the Core asset and client IDs. Carrying an
+  ID across domains fails, or worse, resolves to the wrong record.
+- **One rate limit for everything: 50 requests per 5 seconds per key.**
+  Every domain shares it, so a compliance sweep can throttle the quoting
+  agent working alongside it. Honour `Retry-After`.
+- **Two Quoter access paths.** The hosted ScalePad path is the default.
+  The standalone `api.quoter.com` path uses separate OAuth client
+  credentials — a second secret with its own rotation and its own blast
+  radius. Only configure it if the tenant genuinely uses standalone
+  Quoter.

--- a/msp-claude-plugins/scalepad/scalepad/skills/backup-radar/SKILL.md
+++ b/msp-claude-plugins/scalepad/scalepad/skills/backup-radar/SKILL.md
@@ -21,6 +21,23 @@ via `X-ScalePad-Region`. Discover this domain's tools with
 Backup Radar subscription
 (402 otherwise).
 
+## Anti-triggers
+
+Backup Radar reports on jobs other products ran. It never touches the
+backups themselves:
+
+- **Restoring data, browsing recovery points, or running a restore
+  test** — none of that exists here; go to the backup product itself
+  (`kaseya/datto-bcdr`, `kaseya/datto-saas-protection`,
+  `kaseya/spanning`, `kaseya/unitrends`) or the `backup-pack`
+  (`restore-test-verification`).
+- **Retention and RPO policy questions** — Backup Radar reports
+  outcomes, not schedules or retention configuration; use the
+  `backup-pack` (`retention-rpo-compliance`) or the backup vendor.
+- **Assets with no backup at all** — a device missing from Backup Radar
+  is invisible here by definition. Start from the asset inventory in
+  `scalepad-core` or the RMM and compare inward.
+
 ## API Tools
 
 | Tool | Purpose |

--- a/msp-claude-plugins/scalepad/scalepad/skills/controlmap/SKILL.md
+++ b/msp-claude-plugins/scalepad/scalepad/skills/controlmap/SKILL.md
@@ -25,6 +25,25 @@ Search endpoints are
 POST with filter bodies upstream — the tools accept normal filter
 arguments.
 
+## Anti-triggers
+
+- **Assessments and action items on a vCIO roadmap** — Lifecycle
+  Manager has identically named objects under `scalepad_lm_*`. An LM
+  assessment scores a client's IT maturity for a QBR; a ControlMap
+  assessment answers a framework questionnaire. Use
+  `scalepad-lifecycle-manager` for the roadmap side.
+- **A misconfigured tenant setting rather than a control** —
+  "conditional access is off", "MFA is not enforced" is a
+  configuration baseline, not a framework control. Use `cipp`
+  (`cipp-standards`), `inforcer`
+  (`inforcer-baseline-alignment`), or `m365-security`.
+- **Vendor-agnostic evidence-mapping and questionnaire workflow** — the
+  cross-platform method lives in the `compliance-pack`
+  (`evidence-mapping`, `insurance-questionnaires`); this skill is the
+  ControlMap tool calls behind it.
+- **Backup evidence** — proving backups run is `scalepad-backup-radar`
+  or the `backup-pack`; attach the result here as evidence afterwards.
+
 ## API Tools (~100; the high-value subset)
 
 ### Health & Reports

--- a/msp-claude-plugins/scalepad/scalepad/skills/core/SKILL.md
+++ b/msp-claude-plugins/scalepad/scalepad/skills/core/SKILL.md
@@ -21,6 +21,26 @@ IDs, and serial numbers here before touching Lifecycle Manager,
 ControlMap, or Quoter. Discover this domain's tools with
 `scalepad_navigate` (domain `core`).
 
+## Anti-triggers
+
+Core holds *lifecycle records* about assets — what was bought, when the
+warranty ends, which contract covers it. It is not a live view of the
+machine:
+
+- **Live device state** — is it online, patched, low on disk, alerting
+  right now? Core's asset rows are synced snapshots. Use the RMM:
+  `kaseya/datto-rmm` (`datto-rmm-devices`), `ncentral`, `ninjaone`,
+  `atera`, or `connectwise/automate`.
+- **Changing anything** — Core is entirely read-only. Once you have the
+  client or asset ID, the write surface is
+  `scalepad-lifecycle-manager`, `scalepad-controlmap`, or
+  `scalepad-quoter`.
+- **Hardware in Lifecycle Manager** — LM keeps its own asset list under
+  opaque `hardware_key` values that are *not* the Core asset IDs; do
+  not carry one across. Use `scalepad-lifecycle-manager`.
+- **Documented configurations, passwords, and runbooks** — use
+  `kaseya/it-glue` or `hudu`.
+
 ## API Tools
 
 ### Clients & People

--- a/msp-claude-plugins/scalepad/scalepad/skills/lifecycle-manager/SKILL.md
+++ b/msp-claude-plugins/scalepad/scalepad/skills/lifecycle-manager/SKILL.md
@@ -22,6 +22,28 @@ forecasting. It is full CRUD — most write tools exist alongside the
 reads. Discover this domain's tools with `scalepad_navigate` (domain `lifecycle-manager`).
 US-only.
 
+## Anti-triggers
+
+LM shares three nouns with its sibling domains and with the wider
+stack, and each pair is a different object:
+
+- **Assessments and action items in ControlMap** — `scalepad_cm_*` and
+  `scalepad_lm_*` both have them. LM's are vCIO engagement items on a
+  roadmap; ControlMap's are compliance findings against a framework
+  control. They are separate records with separate tools; use
+  `scalepad-controlmap` for the compliance side.
+- **Contracts** — an LM contract is the vCIO agreement backing a
+  roadmap, not the billing contract that drives invoicing. For the
+  agreement you bill against, use the PSA (`kaseya/autotask`,
+  `connectwise`, `halopsa`).
+- **Live device state** — LM hardware rows are lifecycle records, not
+  RMM telemetry; use `kaseya/datto-rmm`, `ncentral`, or `ninjaone`.
+- **Vendor-agnostic warranty or refresh methodology** — the
+  cross-vendor "how do we run refresh planning" workflow is the
+  `assets-pack` (`warranty-tracking`, `refresh-cycle-planning`); this
+  skill is the ScalePad tool calls that execute it.
+- **Quoting the refresh you roadmapped** — use `scalepad-quoter`.
+
 ## API Tools (~190; the high-value subset)
 
 ### Clients & Contacts

--- a/msp-claude-plugins/scalepad/scalepad/skills/quoter/SKILL.md
+++ b/msp-claude-plugins/scalepad/scalepad/skills/quoter/SKILL.md
@@ -29,6 +29,23 @@ the same product:
 
 Discover this domain's tools with `scalepad_navigate` (domain `quoter`).
 
+## Anti-triggers
+
+Most MSPs run more than one quoting system, and "build a quote" does
+not name which. This skill only speaks to Quoter:
+
+- **A ConnectWise quote** — use the `connectwise/cpq` plugin
+  (`connectwise-cpq-quotes`).
+- **An Autotask quote or opportunity** — use the `autotask` plugin
+  (`autotask-quotes`); Kaseya's standalone quoting product is
+  `kaseya-quote-manager`.
+- **Sending a document for signature** — publishing a quote here is not
+  an e-signature flow; use `pandadoc`.
+- **Invoicing and payment collection** — a published quote is not an
+  invoice; use `quickbooks`, `xero`, `stripe`, or the `finance-pack`.
+- **Distributor purchasing** — buying what you quoted happens at the
+  distributor; use `pax8` or `sherweb`.
+
 ## API Tools (~60; the high-value subset)
 
 ### Quotes

--- a/msp-claude-plugins/timezest/timezest/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/timezest/timezest/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "timezest",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "TimeZest - tech scheduling and appointment booking against ConnectWise / Autotask / Halo PSA tickets for MSPs",
   "author": {
     "name": "WYRE AI"

--- a/msp-claude-plugins/timezest/timezest/GOVERNANCE.md
+++ b/msp-claude-plugins/timezest/timezest/GOVERNANCE.md
@@ -1,0 +1,109 @@
+# TimeZest plugin — governance and safety model
+
+Unofficial. Community-built plugin for the TimeZest API. Not affiliated
+with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches TimeZest through the
+WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the TimeZest account
+the operator is authorised for.
+
+- No TimeZest API token is stored on the technician's machine, in this
+  repo, or in the model's context.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers
+  "who sent the customer that booking link" — TimeZest's own log records
+  only the API account.
+- Revoking gateway access revokes TimeZest access with it, immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change TimeZest state or reach the customer. Safe for autonomous agents. | `timezest_agents_list`, `timezest_agents_get`, `timezest_teams_list`, `timezest_teams_get`, `timezest_appointment_types_list`, `timezest_appointment_types_get`, `timezest_resources_list`, `timezest_scheduling_list`, `timezest_scheduling_get`, `timezest_navigate`, `timezest_back`, `timezest_status` |
+| **Write** | Creates a record — and sends the customer an email that cannot be recalled. | `timezest_scheduling_create_request` |
+| **Destructive** | Revokes a booking link or cancels a confirmed appointment. Requires explicit per-call human approval. | `timezest_scheduling_cancel` |
+
+`timezest_scheduling_create_request` is the tool to watch. It is a
+create, but its blast radius is not a database row: it emails the
+**customer** a self-service booking link and, in the default `pod`
+trigger mode, fires the PSA workflow that updates the ticket and
+notifies whoever the integration is configured to notify. None of that
+can be un-sent. Nine of the twelve read tools exist precisely so an
+agent can resolve the agent, team, and appointment type *before*
+reaching a real person.
+
+`timezest_scheduling_cancel` sits in the destructive tier deliberately.
+Against a pending request it revokes the customer's link; against a
+booked one it cancels a confirmed appointment, which removes the slot
+from the technician's calendar and sends the customer a cancellation.
+There is no uncancel — recovery means creating a new request and asking
+the customer to book again.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.**
+
+- Read tools: allow. Roster surveys, pipeline queues, stale-request
+  sweeps, and PSA-association audits are the intended autonomous use.
+- `timezest_scheduling_create_request`: agent drafts the exact call —
+  resolved agent or team, appointment type, `associatedEntities`,
+  trigger mode — a human approves, then it runs. Do not grant it to
+  scheduled or unattended agents; a loop that re-sends booking links is
+  visible to the customer as harassment.
+- `timezest_scheduling_cancel`: require a named human approver per
+  invocation.
+
+## What it cannot reach
+
+- Only the TimeZest account mapped to the operator's gateway identity.
+- No filesystem, no shell, no other vendor's data.
+- **No PSA credentials.** TimeZest attaches a booking to a ticket and
+  triggers the PSA's own configured workflow; it cannot read, update, or
+  close that ticket. Anything that changes the ticket is PSA work.
+- No calendar credentials of its own. It reflects availability the
+  TimeZest tenant has already been configured to see; it cannot read a
+  technician's mailbox.
+- No push feed. The surface is poll-only.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session
+  and are not persisted by this plugin.
+- `timezest_agents_list` / `timezest_agents_get` and
+  `timezest_teams_list` / `timezest_teams_get` return MSP staff PII —
+  technician names, email addresses, and in some tenants department and
+  working-hours detail.
+- **Scheduling requests carry end-customer PII.**
+  `timezest_scheduling_list` and `timezest_scheduling_get` return the
+  customer contact's name and email address alongside the PSA ticket
+  reference — which links a named individual to the IT problem they
+  reported. Restrict these if your agents run unattended or post output
+  into shared channels.
+- `timezest_scheduling_create_request` **transmits** PII outward: the
+  recipient address you pass is who receives the booking link. A wrong
+  address discloses the ticket context to the wrong person and cannot be
+  undone.
+
+## Known sharp edges
+
+- **No webhooks — polling only.** Booking state changes arrive only when
+  you ask. An agent that reports "not booked yet" is reporting the last
+  poll, not the present. Re-fetch before acting on state.
+- **Cancellation race.** A customer can book in the same second a
+  dispatcher cancels. Always re-fetch with `timezest_scheduling_get`
+  after a cancel and reconcile, rather than assuming the cancel won.
+- **`generate_url` silently skips the PSA.** A request created in
+  `generate_url` trigger mode produces a working booking link but never
+  fires the PSA workflow, so the ticket is never updated. It looks like
+  a successful booking and reads later as a sync bug.
+- **Orphan requests are unfindable.** A request created without an
+  `associatedEntities` entry cannot be traced from the PSA side. Treat a
+  missing PSA association as a validation failure, not an optional
+  field.
+- **Wrong appointment type is customer-visible.** Booking a 15-minute
+  type for a half-day onsite offers the customer a slot that is far too
+  short. Confirm the `duration`, not just the name.

--- a/msp-claude-plugins/timezest/timezest/skills/agents-and-teams/SKILL.md
+++ b/msp-claude-plugins/timezest/timezest/skills/agents-and-teams/SKILL.md
@@ -18,6 +18,28 @@ individual agent or a team. Picking the right one is the first step of
 any booking, and TimeZest treats agents and teams differently enough
 that the choice matters.
 
+## Anti-triggers
+
+Both nouns in this skill's name are heavily overloaded. Here an
+**agent** is a bookable human technician and a **team** is a
+round-robin pool of them:
+
+- **Claude subagents** — an "agent" defined under `agents/*.md` is an
+  AI configuration, not a TimeZest technician. Nothing in this skill
+  applies.
+- **An endpoint sensor** — Huntress, RocketCyber, and Liongard all call
+  their installed software an "agent"; use `huntress`
+  (`huntress-agents`), `kaseya/rocketcyber`, or `liongard`.
+- **A PSA technician record** — hours, permissions, ticket assignment,
+  and utilisation live in the PSA; use `halopsa` (`halopsa-agents`),
+  `connectwise`, or `kaseya/autotask`. TimeZest only knows who is
+  bookable.
+- **Microsoft Teams** — a TimeZest team is a scheduling pool with no
+  channels, chat, or membership sync; use `m365-teams`.
+- **Onboarding, deactivating, or permissioning a technician** — this
+  skill is read-only lookup; identity changes happen in the PSA or in
+  Entra (`m365-users`).
+
 ## Domains & Tools
 
 TimeZest's MCP server is navigation-based. Enter a domain with

--- a/msp-claude-plugins/timezest/timezest/skills/psa-integration/SKILL.md
+++ b/msp-claude-plugins/timezest/timezest/skills/psa-integration/SKILL.md
@@ -21,6 +21,23 @@ calendar, and in the billing record. Two parts of the scheduling
 request payload carry that coupling: `associatedEntities` and
 `triggerMode`.
 
+## Anti-triggers
+
+This skill shapes the TimeZest side of the link. It has no PSA
+credentials and cannot read or write a ticket:
+
+- **Reading, updating, or closing the ticket** — status, notes, time
+  entries, assignment; use `connectwise`, `halopsa`, or the `autotask`
+  plugin.
+- **Finding the ticket to book against** — ticket search and triage
+  happen in the PSA; arrive here with the ID already resolved.
+- **Configuring the PSA-side integration** — the `pod` workflow, its
+  notification templates, and the TimeZest app install are configured
+  in the PSA and in the TimeZest web UI, not through these tools.
+- **A booking that never sent, as opposed to one that never synced** —
+  a request stuck before delivery is a scheduling-request state
+  question; use `timezest-scheduling`.
+
 ## `associatedEntities` — the PSA link
 
 Every `timezest_scheduling_create_request` call should carry an

--- a/msp-claude-plugins/timezest/timezest/skills/resources/SKILL.md
+++ b/msp-claude-plugins/timezest/timezest/skills/resources/SKILL.md
@@ -17,6 +17,22 @@ bookable — agents and teams together in one list. It is the right
 starting point when a dispatcher has not named a specific technician
 or team and you need to survey the pool first.
 
+## Anti-triggers
+
+A TimeZest resource is always a **person or a pool of people**. Every
+other plugin means something else by the word:
+
+- **A room or equipment mailbox** — meeting rooms and projectors are
+  Exchange resource mailboxes, and TimeZest does not list them; use
+  `m365-calendar`.
+- **A PSA resource** — in Autotask a "resource" is an employee record
+  carrying rates, hours, and permissions; use the `autotask` plugin.
+- **An Azure resource** — VMs, storage accounts, resource groups; use
+  `azure-mcp` or the `cloudops-pack`.
+- **A managed device or configuration item** — use the RMM
+  (`kaseya/datto-rmm`, `ncentral`, `ninjaone`) or
+  `kaseya/it-glue`.
+
 ## Domain & Tools
 
 Enter the domain with `timezest_navigate` to `resources`.

--- a/msp-claude-plugins/timezest/timezest/skills/scheduling/SKILL.md
+++ b/msp-claude-plugins/timezest/timezest/skills/scheduling/SKILL.md
@@ -18,6 +18,26 @@ exists for. This skill walks the canonical flow: resolve the agent,
 resolve the appointment type, create the scheduling request with the
 PSA association, then poll for the customer's response.
 
+## Anti-triggers
+
+TimeZest schedules by sending the *customer* a link and letting them
+pick. Three neighbouring systems schedule by someone else picking:
+
+- **You already know the time and just need it on a calendar** — write
+  the event straight into the mailbox with `m365-calendar`. Creating a
+  TimeZest request for a time already agreed sends the customer a
+  pointless booking link.
+- **Dispatching a technician to a service window** — the PSA service
+  call is the record that carries dispatch and billing; use the
+  `autotask` plugin (`autotask-service-calls`) or the equivalent PSA
+  plugin. TimeZest links to that ticket, it does not replace it.
+- **Changing the ticket itself** — status, notes, time entries, and
+  assignment are PSA work (`connectwise`, `halopsa`,
+  `kaseya/autotask`); TimeZest only attaches a booking to it.
+- **Configuring which slots are bookable** — availability rules and
+  durations live on the appointment type, not the request; use
+  `timezest-appointment-types`.
+
 ## API Tools
 
 ### Resolve the actors


### PR DESCRIPTION
Applies the repo-wide connector-quality standard (`_standards/skill-quality-checklist.md`, `_templates/governance-template.md`) to the productivity batch, matching the `huntress` exemplar.

Branched from `feat/skill-anti-triggers-governance`, which carries the standard. **Retarget the base to that branch if it has not merged yet** — this PR is against `main` per instruction, so the diff will show the standard's commits until it lands.

## Per-plugin counts

| Plugin | Skills | Anti-triggers added | Skipped | GOVERNANCE.md |
|---|---|---|---|---|
| `crewhu` | 2 | 1 | 1 | ✅ |
| `m365` | 8 | 8 | 0 | ✅ |
| `microsoft-graph` | 2 | 2 | 0 | ✅ |
| `scalepad` | 6 | 5 | 1 | ✅ |
| `timezest` | 6 | 4 | 2 | ✅ |
| **Total** | **24** | **20** | **4** | **5** |

Additive only: 366 insertions, 0 deletions, 0 lines removed. No `triggers:` frontmatter (#158). `_standards/`, `_templates/`, `marketplace.json`, and `docs/src/data/plugins.ts` untouched; `npm run generate` not run.

## Why the four skips

Anti-triggers route work *out*; a bullet that only negates `when_to_use` is filler the checklist explicitly omits.

- **`crewhu-api-patterns`, `scalepad-api-patterns`, `timezest-api-patterns`** — auth/pagination/error skills whose names fully disambiguate them from their sibling domain skills. Nothing routes to them by mistake. (`m365-api-patterns` is the exception and *did* get a section — it is where the Microsoft three-way boundary belongs, because it is the skill that teaches hand-composing Graph URLs.)
- **`timezest-appointment-types`** — "appointment type" is TimeZest-specific vocabulary with no competing claimant in the fleet. The skill already cross-links `scheduling` and `agents-and-teams` in-body; an anti-trigger would restate it.

## The m365 / microsoft-graph / cipp boundary

The highest-value item in the batch. Three plugins touch the same tenant with near-identical vocabulary. The boundary is stated on three axes — **what you're doing** (ask vs change) × **how many tenants** (one vs fleet) — and reduced to one memorable rule repeated verbatim in both load-bearing skills:

> **Ask one tenant → `microsoft-graph`; change one tenant → `m365`; do either across the fleet → `cipp`.**

Placed in `m365-api-patterns` (with the "hand-writing a Graph URL when the Graph Enterprise MCP is connected is the exact error pattern it exists to prevent" framing), `microsoft-graph-querying` (mirrored), and `microsoft-graph-connection` (which adds the trap that the `m365` plugin uses a *different* Entra app registration — consenting one does not consent the other).

Per-entity skills then carry the axis locally: `m365-users` → `cipp-users` for packaged offboarding, `m365-licensing` → `cipp-licenses` for fleet audits, `m365-security` → `cipp-standards`/`inforcer` for enforcing rather than reporting a baseline.

`cipp` is referenced by name only — no files under `cipp/` were touched.

## Other collisions resolved

- **"teams"** — M365 workspace vs TimeZest round-robin pool vs PSA dispatch queue
- **"resources"** — TimeZest people vs Exchange room/equipment mailboxes vs Autotask employee records vs Azure resources
- **"agents"** — TimeZest technicians vs Claude subagents (`agents/*.md`) vs endpoint sensors (Huntress/RocketCyber/Liongard) vs PSA technician records
- **"assessments" / "action items"** — ScalePad Lifecycle Manager (`scalepad_lm_*`, vCIO roadmap) vs ControlMap (`scalepad_cm_*`, framework findings); identically named, separate tools, separate records
- **"files"** — customer OneDrive/SharePoint vs the local filesystem Claude Code's own tools handle
- **"users"** — Entra account vs PSA contact vs Crewhu technician being scored
- **assets** — ScalePad lifecycle records vs RMM live device state; also flags that Core asset IDs and LM `hardware_key` values are different namespaces
- **quoting** — ScalePad Quoter vs `connectwise/cpq` vs `autotask-quotes` vs `kaseya-quote-manager` vs PandaDoc e-sign
- **backup** — Backup Radar reports on jobs it cannot restore; restore/RPO work goes to `backup-pack` and the backup vendors

## GOVERNANCE.md — judgement calls

Tools classified by blast radius, not HTTP verb. Real tool names throughout, derived from each plugin's own skills and cross-checked against `/Users/asachs/mcp/{crewhu,scalepad,timezest}-mcp/src/`. Nothing invented.

**Disputable destructive-tier calls — please review these specifically:**

1. **`POST /users/{id}/assignLicense` with `removeLicenses` (m365) → Destructive.** Reads as routine cost hygiene, but removing an Exchange licence starts a 30-day clock ending in permanent mailbox deletion, and nothing in the response says so. An agent reclaiming "unused" seats on a bad inactivity threshold destroys customer data.
2. **`POST /users/{id}/sendMail` (m365) → Destructive.** Changes no directory object at all. Tiered up because it sends mail *as the user* to external recipients, cannot be recalled, lands in their Sent Items, and is indistinguishable from BEC to anyone reviewing afterwards. Same reasoning shape as the exemplar's `incidents_bulk_approve`.
3. **`PATCH /users/{id}/mailboxSettings` setting external forwarding (m365) → Destructive.** Identical API shape to setting an out-of-office, but it is verbatim the persistence mechanism `m365-security` teaches you to hunt for.
4. **`scalepad_quoter_quotes_publish` → Destructive.** A publish, not a delete — but it puts pricing and margin in front of the client irreversibly.
5. **`scalepad_lm_deliverables_share_link_create` → Destructive.** A `create` whose blast radius is client data leaving the tenant boundary. `_regenerate` silently breaks distributed links; `_revoke` removes access in use.
6. **`scalepad_cm_evidence_delete` / `_documents_delete` → Destructive.** Destroying audit evidence is not an ordinary record delete.
7. **`timezest_scheduling_create_request` → Write, not Destructive** (flagged hard instead). It emails a customer irreversibly and fires the PSA workflow, but does not delete, revoke, or change billing. Kept in Write with an explicit "never grant unattended" note. Argue me up if you disagree.

**Read-only statements** (the template calls these strong and useful): `microsoft-graph` is read-only *structurally* — three tools, one reaches the tenant, it issues `GET`. `crewhu` has exactly one write (`crewhu_badges_update_contest`) and no destructive tier. ScalePad's `core` and `br` domains are read-only in their entirety, which makes an agent scoped to those two incapable of changing anything.

**A fourth m365 tier — "Read (confidential)".** Message bodies, mailbox rules, and file-name searches change nothing, so a verb-based policy waves them through, yet they expose private correspondence. Split out so operators decide on them separately.

**PII / mail-content flags** are extensive in this batch as expected: m365 message bodies and sign-in IP/geolocation; `microsoft_graph_get` directory PII plus sign-in telemetry; ScalePad `saas_users` (named individuals mapped to SaaS seats), budget/margin data, and signed URLs that behave like credentials; TimeZest scheduling requests linking a named customer to their reported IT problem; Crewhu employee-performance data (HR-adjacent — customer verbatims naming and criticising a specific technician).

## Pre-existing gap found, not fixed

`m365` has **no `.mcp.json`**, but its README documents one and ships a `.env.example` containing `MICROSOFT_CLIENT_SECRET` for a direct-to-Microsoft Softeria server path. That path puts a tenant-wide admin-consented credential on a technician's laptop with no per-operator attribution. Out of scope here (additive changes only), so `GOVERNANCE.md` keeps the standard Conduit framing and calls the local-secret path out explicitly as documentation drift that must not be used against production tenants. Worth a follow-up issue.

Its skills also document raw Graph endpoints rather than named MCP tools, so the m365 tier table is keyed to the **Graph operation** — which is what actually determines blast radius — rather than inventing tool names that do not exist.
