### PR TITLE
feat(revenue): anti-triggers + GOVERNANCE.md for the quote-to-cash plugin batch

### DIFF
--- a/msp-claude-plugins/alternative-payments/alternative-payments/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/alternative-payments/alternative-payments/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "alternative-payments",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Claude plugins for Alternative Payments - customers, invoices, payment requests, transactions, payouts, and webhooks",
   "author": {
     "name": "WYRE AI"

--- a/msp-claude-plugins/alternative-payments/alternative-payments/GOVERNANCE.md
+++ b/msp-claude-plugins/alternative-payments/alternative-payments/GOVERNANCE.md
@@ -1,0 +1,131 @@
+# Alternative Payments plugin — governance and safety model
+
+Unofficial. Community-built plugin for the Alternative Payments API. Not
+affiliated with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches Alternative Payments through
+the WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the account the operator is
+authorised for.
+
+- No OAuth client id or client secret is stored on the technician's machine, in
+  this repo, or in the model's context. The gateway forwards credentials as
+  headers and the MCP server mints the short-lived bearer token internally.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers "who
+  raised this invoice" — the payment processor's own log records one API key.
+- Revoking gateway access revokes Alternative Payments access with it,
+  immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change vendor state. Safe for autonomous agents, but see Data handling. | `ap_list_customers`, `ap_get_customer`, `ap_list_customer_users`, `ap_list_invoices`, `ap_get_invoice`, `ap_get_invoice_payment_link`, `ap_get_invoice_pdf_link`, `ap_get_payment_request`, `ap_list_transactions`, `ap_get_transaction`, `ap_list_payouts`, `ap_get_payout`, `ap_list_payout_transactions`, `ap_list_webhooks`, `ap_list_webhook_events`, `ap_status`, `ap_navigate` |
+| **Write** | Creates records with no financial demand attached. | `ap_create_customer`, `ap_add_customer_user`, `ap_create_webhook`, `ap_retry_webhooks` |
+| **Destructive** | Asks a customer for money, or removes a billing record or event feed. Requires explicit per-call human approval. | `ap_create_invoice`, `ap_create_payment_request`, `ap_archive_invoice`, `ap_archive_customer`, `ap_delete_webhook` |
+
+Two of the destructive entries are `create_` calls, and that is the point of
+classifying by blast radius rather than verb:
+
+- **`ap_create_invoice`** does not produce a draft. The invoice is created at
+  status `open` — issued and awaiting payment. It is a live accounts-receivable
+  demand against a named client from the moment the call returns, with a
+  payment link attached. Getting the amount wrong is not a data-entry error an
+  operator quietly fixes; it is a bill your client received.
+- **`ap_create_payment_request`** creates a standalone hosted checkout link for
+  an arbitrary amount. The vendor's own tool description is careful that it
+  "does not charge anyone" — true, and not the risk. The risk is that anyone
+  holding the URL can pay it, for the amount the agent chose.
+
+`ap_archive_invoice` and `ap_archive_customer` are the vendor's own high-impact
+operations and prompt for confirmation server-side; archiving an open invoice
+removes the customer's ability to pay it, which reads as a resolved bill and is
+not. `ap_delete_webhook` is irreversible and stops payment-event delivery
+silently — reconciliation keeps running and keeps being wrong.
+
+**No direct-charge tool exists here at all.** `POST /payments` is excluded from
+this integration by design, so nothing in this plugin can debit a card or bank
+account. Money only moves when a customer chooses to pay a hosted link.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never self-approve
+destructive calls.**
+
+- Read tools: allow. Reconciliation, payout tracing, and overdue-invoice
+  reporting are the intended autonomous use.
+- Write tools: agent drafts the exact call, human approves, then it runs.
+- Destructive tools: require a named human approver per invocation, and the
+  approver must check the amount and the customer, not just the tool name. Do
+  not grant these to scheduled or unattended agents. An automated monthly
+  billing run that can call `ap_create_invoice` is a system that can invoice
+  every client twice.
+
+## What it cannot reach
+
+- Only the Alternative Payments account the operator's gateway identity maps
+  to, and only the environment (`production` or `demo`) the gateway header
+  selects.
+- No filesystem, no shell, no other vendor's data.
+- **No direct charge.** `POST /payments` and the Web-SDK checkout-auth
+  initialiser are not exposed. There is no path from this plugin to debiting a
+  customer.
+- No refund, chargeback, or payout-initiation surface. Payouts can be read, not
+  triggered or redirected.
+- No bank account or payment-method management. Stored payment credentials are
+  neither readable nor writable here.
+- No accounting ledger. Nothing here posts to a GL; that is `xero-payments` or
+  `quickbooks-online-payments`.
+
+## Data handling
+
+Responses pass through the gateway into model context for the session and are
+not persisted by this plugin. Nearly everything this plugin returns is
+financial or personal:
+
+- **Live payment URLs.** `ap_get_invoice_payment_link` and
+  `ap_create_payment_request` return hosted checkout URLs that require no
+  further authentication to use. Treat the URL itself as sensitive — anyone who
+  obtains it from a transcript, a log, or a shared artifact can act on it.
+- **Signed document URLs.** `ap_get_invoice_pdf_link` returns a signed download
+  link to the invoice PDF, which carries the client's name, addresses, and full
+  line-item detail.
+- **Transaction and payout data.** `ap_list_transactions`, `ap_get_transaction`,
+  `ap_list_payouts`, `ap_get_payout`, and `ap_list_payout_transactions` return
+  amounts, payment-method descriptors, statuses, and settlement detail across
+  your whole customer base.
+- **Customer PII.** `ap_list_customers`, `ap_get_customer`, and
+  `ap_list_customer_users` return client business details and the individual
+  billing contacts attached to them.
+- **Webhook configuration.** `ap_list_webhooks` returns your endpoint URLs,
+  which map your internal reconciliation architecture.
+
+Restrict the payment-link, PDF-link, and transaction tools if agents run
+unattended or render output anywhere it is retained.
+
+## Known sharp edges
+
+- **`create` is not `draft`.** Covered above. This is the most common wrong
+  assumption an agent brings from other billing systems, where creating an
+  invoice produces something a human still has to approve and send.
+- **Archive looks like delete but is not undo.** Archiving an invoice removes
+  it from active lists; it does not credit the customer, reverse a payment, or
+  cancel an obligation. An agent "cleaning up" overdue invoices by archiving
+  them destroys your AR position while appearing to tidy it.
+- **`ap_retry_webhooks` releases a backlog.** It resumes failed delivery of
+  queued events. If a downstream consumer is not idempotent, a large backlog
+  arriving at once can double-apply payments in whatever system consumes the
+  feed. Fix the consumer before retrying.
+- **Deleting a webhook fails silently downstream.** Payments keep succeeding;
+  nothing tells you they stopped being recorded. The failure surfaces weeks
+  later as an unexplained reconciliation gap.
+- **The transactions resource lives at `GET /payments`.** The path implies a
+  write surface that does not exist. An agent inferring `POST /payments` from
+  the read path will construct a call this integration deliberately does not
+  offer.
+- **Rate limit is 5 requests per second.** A reconciliation sweep that walks
+  payouts and then each payout's transactions will hit it, back off, and return
+  partial results that look complete.

--- a/msp-claude-plugins/alternative-payments/alternative-payments/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/alternative-payments/alternative-payments/skills/api-patterns/SKILL.md
@@ -27,6 +27,15 @@ The WYRE integration exposes a **read + safe-write** surface. It deliberately do
 **not** implement direct payment creation (`POST /payments`), which would charge a
 card or bank account. Money movement is out of scope.
 
+## Anti-triggers
+
+- **Transaction and payout data** — the transactions resource lives at
+  `GET /payments`, which makes this skill look like the destination; the
+  filters, statuses, and reconciliation workflows are
+  `alternative-payments-payments`.
+- **Invoice, line-item, and payment-link fields** — use
+  `alternative-payments-invoicing`.
+
 ## Base URLs
 
 | Environment | Base URL |

--- a/msp-claude-plugins/alternative-payments/alternative-payments/skills/customers/SKILL.md
+++ b/msp-claude-plugins/alternative-payments/alternative-payments/skills/customers/SKILL.md
@@ -25,6 +25,15 @@ This skill covers the read + safe-write customer surface: listing, retrieving,
 and creating customers, adding users, and archiving (a destructive operation).
 There is no direct money-movement operation here.
 
+## Anti-triggers
+
+- **The same client in the accounting ledger** — an Alternative Payments
+  customer is a billing target on the payment rail with no GL contact record;
+  use `xero-contacts` or `quickbooks-online-customers`.
+- **The same client in the CRM** — use `hubspot-companies` or
+  `salesbuildr-companies-contacts`.
+- **Billing that customer** — use `alternative-payments-invoicing`.
+
 ## Core Concepts
 
 ### Customers and Users

--- a/msp-claude-plugins/alternative-payments/alternative-payments/skills/invoicing/SKILL.md
+++ b/msp-claude-plugins/alternative-payments/alternative-payments/skills/invoicing/SKILL.md
@@ -31,6 +31,17 @@ simply produces a URL. This integration never executes a direct charge. See
 [Alternative Payments API Patterns](../api-patterns/SKILL.md) for why
 `POST /payments` (direct charge) is excluded by design.
 
+## Anti-triggers
+
+- **The invoice as an accounting document** — these invoices are collection
+  artefacts with no GL coding, tax treatment, or aging; use `xero-invoices` or
+  `quickbooks-online-invoices`.
+- **Whether the invoice was paid and where the money settled** — use
+  `alternative-payments-payments`.
+- **Charging a card or bank account directly** — no such tool exists here by
+  design; a hosted link is the only collection mechanism, and the reasoning is
+  in `alternative-payments-api-patterns`.
+
 ## Core Concepts
 
 ### Invoice Status

--- a/msp-claude-plugins/alternative-payments/alternative-payments/skills/payments/SKILL.md
+++ b/msp-claude-plugins/alternative-payments/alternative-payments/skills/payments/SKILL.md
@@ -28,6 +28,16 @@ or moves money (`POST /payments`, the direct charge, is excluded by design). To
 collect from a customer, generate a hosted payment link or payment request — see
 [Alternative Payments Invoicing](../invoicing/SKILL.md).
 
+## Anti-triggers
+
+- **Collecting money rather than reporting on it** — this surface is
+  read-only; hosted payment links and payment requests are
+  `alternative-payments-invoicing`.
+- **Recording a receipt against an invoice in the books** — use
+  `xero-payments` or `quickbooks-online-payments`.
+- **A payment captured against a Quote Manager sales order** — use
+  `kaseya-quote-manager-quotes`.
+
 ## Core Concepts
 
 ### Transactions

--- a/msp-claude-plugins/hubspot/hubspot/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/hubspot/hubspot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hubspot",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Claude plugins for HubSpot CRM - contacts, companies, deals, tickets, activities, and associations",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/hubspot/hubspot/GOVERNANCE.md
+++ b/msp-claude-plugins/hubspot/hubspot/GOVERNANCE.md
@@ -1,0 +1,100 @@
+# HubSpot plugin — governance and safety model
+
+Unofficial. Community-built plugin for the HubSpot API. Not affiliated with,
+endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches HubSpot through the WYRE
+Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the portal the operator is
+authorised for.
+
+- No HubSpot client ID, client secret, or access token is stored on the
+  technician's machine, in this repo, or in the model's context.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers "who
+  changed this record". HubSpot's own history attributes the change to the
+  integration's app user, not to a person.
+- Revoking gateway access revokes HubSpot access with it, immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change HubSpot state. Safe for autonomous agents. | `hubspot_retrieve_contact`, `hubspot_list_contacts`, `hubspot_list_contact_properties`, `hubspot_search_contacts`, `hubspot_retrieve_company`, `hubspot_list_company_properties`, `hubspot_search_companies`, `hubspot_retrieve_deal`, `hubspot_list_deal_properties`, `hubspot_search_deals`, `hubspot_retrieve_ticket`, `hubspot_access_associations`, `hubspot_get_user_details`, `hubspot_open_hubspot_ui` |
+| **Write** | Creates or modifies records. Reversible, internally visible. | `hubspot_create_company`, `hubspot_update_company`, `hubspot_create_deal`, `hubspot_update_deal`, `hubspot_create_ticket`, `hubspot_update_ticket`, `hubspot_create_task`, `hubspot_create_note`, `hubspot_create_association` |
+| **Destructive** | Can cause HubSpot to email a real person. Requires explicit per-call human approval. | `hubspot_create_contact`, `hubspot_update_contact` |
+
+There is no delete tool in this plugin, so the destructive tier is not defined
+by data loss — it is defined by outbound reach.
+
+`hubspot_create_contact` and `hubspot_update_contact` sit in the destructive
+tier deliberately. HubSpot workflows enrol on contact creation and on contact
+property changes. In a portal with any lifecycle-stage, lead-status, or
+list-membership workflow that has an email action, writing a contact property
+hands a real named prospect to a marketing sequence. The plugin sends nothing;
+HubSpot does, on the strength of the write — and a sent email cannot be
+recalled. Company, deal, and ticket objects carry no email address of their
+own, which is why they stay in the write tier.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never self-approve
+destructive calls.**
+
+- Read tools: allow. Pipeline reporting, contact lookup, and cross-object
+  audits are the intended autonomous use.
+- Write tools: agent drafts the exact call, human approves, then it runs.
+- Destructive tools: require a named human approver per invocation. Do not
+  grant contact writes to scheduled or unattended agents — a nightly enrichment
+  job is exactly the shape that mass-enrols prospects by accident.
+
+## What it cannot reach
+
+- Only the HubSpot portals mapped to the operator's gateway identity.
+- Only the objects the granted OAuth scopes cover. HubSpot derives scopes from
+  the tools in use; an unscoped object returns a permissions error rather than
+  partial data.
+- No filesystem, no shell, no other vendor's data.
+- No marketing email, workflow, sequence, form, or CMS surface. This plugin
+  reads and writes CRM objects only — it cannot author, inspect, or disable the
+  workflows that a contact write may trigger.
+- No sensitive-data (PHI) fields. HubSpot excludes them from the MCP surface
+  regardless of portal configuration.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session and are
+  not persisted by this plugin.
+- `hubspot_retrieve_contact`, `hubspot_list_contacts`, and
+  `hubspot_search_contacts` return customer and prospect PII — names, email
+  addresses, phone numbers, job titles.
+- `hubspot_retrieve_deal` and `hubspot_search_deals` return commercial data:
+  contract values, MRR, forecast category, and close dates across the whole
+  pipeline. A single unfiltered search can return the company's entire
+  forecast.
+- `hubspot_get_user_details` returns staff identity and the portal ID.
+- `hubspot_search_*` with a permissive `filterGroups` will page through the
+  entire object set. Restrict these if your agents run unattended.
+
+## Known sharp edges
+
+- **Writes fan out to workflows.** Covered above, and it is the single most
+  important thing to understand before granting write access. Audit the portal's
+  active workflows before letting an agent touch contact properties.
+- **`hubspot_update_*` is a partial update, but stage changes are not.** Moving
+  a deal to a closed stage can trigger internal notifications, revenue
+  recognition, and renewal automation that no longer key off the original
+  close date.
+- **Domain-based auto-association is silent.** Creating a contact whose email
+  domain matches an existing company attaches it to that company without a
+  separate association call — and to the wrong company if two clients share a
+  parent domain.
+- **Search is eventually consistent.** A record created through this plugin may
+  not appear in `hubspot_search_*` results for several seconds. An agent that
+  creates then immediately searches will conclude the write failed and retry,
+  producing duplicates.
+- **`hubspot_open_hubspot_ui` is read-tier but leaves the model's world.** It
+  hands a URL to the technician; it does not verify that the technician is
+  authorised to view what is behind it.

--- a/msp-claude-plugins/hubspot/hubspot/skills/activities/SKILL.md
+++ b/msp-claude-plugins/hubspot/hubspot/skills/activities/SKILL.md
@@ -17,6 +17,16 @@ when_to_use: >-
 
 Activities in HubSpot encompass tasks, notes, and other engagement records that track interactions with contacts, companies, deals, and tickets. Associations are the links that connect HubSpot CRM objects together -- a contact associated with a company, a deal associated with a contact, a note associated with a ticket. For MSPs, activities provide the service history and follow-up tracking that drives client satisfaction, while associations ensure that every interaction is visible from any related record.
 
+## Anti-triggers
+
+- **A customer-reported issue that needs resolving** — that is a ticket with a
+  pipeline and stage, not a task; use `hubspot-tickets`.
+- **The properties of the record being annotated** — this skill covers the
+  note, task, and association only; object fields live in `hubspot-contacts`,
+  `hubspot-companies`, `hubspot-deals`, or `hubspot-tickets`.
+- **Billable time against client work** — HubSpot tasks are not time entries;
+  the PSA is the system of record for those.
+
 ## MCP Tools
 
 ### Available Tools

--- a/msp-claude-plugins/hubspot/hubspot/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/hubspot/hubspot/skills/api-patterns/SKILL.md
@@ -19,6 +19,16 @@ when_to_use: >-
 
 HubSpot provides a first-party remote MCP server at `https://mcp.hubspot.com/` for AI tool integration. The MCP server uses OAuth 2.0 with PKCE for authentication and Streamable HTTP as its transport protocol. Tools are backed by the HubSpot CRM Search API and cover contacts, companies, deals, tickets, tasks, notes, and associations. This skill covers MCP server connection, the complete tool reference, search patterns, error handling, and best practices.
 
+## Anti-triggers
+
+- **What properties an object has and what its enum values mean** — the field,
+  lifecycle-stage, and pipeline tables live with the object; use
+  `hubspot-contacts`, `hubspot-companies`, `hubspot-deals`, or
+  `hubspot-tickets`.
+- **A different hosted OAuth MCP server** — the connection shape rhymes but
+  the tenant, scopes, session model, and tools do not; use
+  `warmly-api-patterns` or `pandadoc-api-patterns`.
+
 ## Connection & Authentication
 
 ### MCP Server

--- a/msp-claude-plugins/hubspot/hubspot/skills/companies/SKILL.md
+++ b/msp-claude-plugins/hubspot/hubspot/skills/companies/SKILL.md
@@ -17,6 +17,16 @@ when_to_use: >-
 
 Companies in HubSpot represent organizations -- MSP clients, prospects, vendors, or partners. Companies are a central entity in the CRM that ties together contacts (the people who work there), deals (sales opportunities), and tickets (support requests). For MSPs, companies typically represent managed clients, each with associated contacts, service agreements, and support history. HubSpot can automatically associate contacts with companies based on email domain matching.
 
+## Anti-triggers
+
+- **A named person at the organization** — use `hubspot-contacts`.
+- **The revenue opportunity with that organization** — amount, stage, and
+  close date live on a deal, not the company; use `hubspot-deals`.
+- **The organization as a billing entity** — HubSpot companies hold no AR
+  balance; use `xero-contacts` or `quickbooks-online-customers`.
+- **Companies seen visiting the website but not yet in the CRM** — use
+  `warmly-visitor-intelligence`.
+
 ## MCP Tools
 
 ### Available Tools

--- a/msp-claude-plugins/hubspot/hubspot/skills/contacts/SKILL.md
+++ b/msp-claude-plugins/hubspot/hubspot/skills/contacts/SKILL.md
@@ -17,6 +17,19 @@ when_to_use: >-
 
 Contacts in HubSpot represent individual people -- clients, prospects, vendors, or any person your MSP interacts with. Contacts are the foundational entity in HubSpot CRM. They can be associated with companies, deals, tickets, and activities to build a complete picture of every relationship. For MSPs, contacts typically represent client employees, decision-makers, technical contacts, and billing contacts at managed companies.
 
+## Anti-triggers
+
+- **The organization rather than the person** — "look up Acme Corp" wants a
+  company record; use `hubspot-companies`.
+- **The organization as an entity you invoice** — a HubSpot contact carries no
+  balance, terms, or tax details; the AR-side record is `xero-contacts` or
+  `quickbooks-online-customers`.
+- **A company or person detected on the website but not yet in the CRM** —
+  that is intent data, not a contact record; use
+  `warmly-visitor-intelligence`.
+- **`filterGroups`, sort, and pagination syntax** — the search grammar is
+  shared across every object type; use `hubspot-api-patterns`.
+
 ## MCP Tools
 
 ### Available Tools

--- a/msp-claude-plugins/hubspot/hubspot/skills/deals/SKILL.md
+++ b/msp-claude-plugins/hubspot/hubspot/skills/deals/SKILL.md
@@ -17,6 +17,17 @@ when_to_use: >-
 
 Deals in HubSpot represent sales opportunities -- potential or active revenue from clients. For MSPs, deals track managed services agreements, project engagements, hardware sales, or any revenue opportunity moving through the sales process. Each deal belongs to a pipeline (e.g., "Sales Pipeline" or "Renewals") and progresses through stages (e.g., "Discovery", "Proposal", "Closed Won"). Deals are associated with contacts and companies to provide full context on who is involved and which client the revenue belongs to.
 
+## Anti-triggers
+
+- **Building or pricing the quote behind the deal** — a deal records *that* an
+  opportunity exists and what it is worth; the line items, catalog, and margin
+  live in `salesbuildr-quotes` or `connectwise-cpq-quotes`.
+- **Sending the customer something to sign** — use `pandadoc-documents`.
+- **Billing a won deal** — moving a deal to Closed Won invoices nobody; use
+  `xero-invoices` or `quickbooks-online-invoices`.
+- **Salesbuildr opportunities** — a different vendor's pipeline object with
+  identical vocabulary; use `salesbuildr-opportunities`.
+
 ## MCP Tools
 
 ### Available Tools

--- a/msp-claude-plugins/hubspot/hubspot/skills/tickets/SKILL.md
+++ b/msp-claude-plugins/hubspot/hubspot/skills/tickets/SKILL.md
@@ -17,6 +17,15 @@ when_to_use: >-
 
 Tickets in HubSpot represent support requests, service issues, or tasks that need resolution. For MSPs, tickets are the backbone of client service delivery -- tracking everything from break-fix requests and password resets to complex infrastructure projects. Tickets belong to a pipeline (e.g., "Support Pipeline") and progress through stages (e.g., "New", "In Progress", "Resolved"). They can be associated with contacts (the person who reported the issue), companies (the client organization), and deals (if the ticket relates to a service agreement).
 
+## Anti-triggers
+
+- **The MSP's service desk** — HubSpot tickets are a CRM-side service
+  pipeline with no SLA clock, time entries, or billing; the PSA owns those, so
+  use the ConnectWise Manage, Autotask, HaloPSA, or Freshdesk ticket skills.
+- **A follow-up you are setting yourself rather than an issue the customer
+  raised** — use `hubspot-activities`.
+- **Revenue attached to the same account** — use `hubspot-deals`.
+
 ## MCP Tools
 
 ### Available Tools

--- a/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kaseya-quote-manager",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Kaseya Quote Manager (Datto Commerce) - read-only access to quotes, sales orders, purchasing, catalog, CRM, and org data",
   "author": {
     "name": "WYRE AI"

--- a/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/GOVERNANCE.md
+++ b/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/GOVERNANCE.md
@@ -1,0 +1,99 @@
+# Kaseya Quote Manager plugin — governance and safety model
+
+Unofficial. Community-built plugin for the Kaseya Quote Manager (formerly
+Datto Commerce) API. Not affiliated with, endorsed by, or sponsored by the
+vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches Kaseya Quote Manager through
+the WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the tenant the operator is
+authorised for.
+
+- No Quote Manager API key is stored on the technician's machine, in this repo,
+  or in the model's context. The gateway translates operator identity into the
+  upstream `apiKey` header.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers "who
+  pulled this cost data" — Quote Manager sees a single API key and cannot.
+- Revoking gateway access revokes Quote Manager access with it, immediately.
+
+## Tool permission tiers
+
+**This plugin is read-only.** Every tool is a `_list` or a `_get`. The write
+and destructive tiers are empty, and that is the whole safety story: no agent
+using this plugin can create, edit, send, cancel, or delete anything in Quote
+Manager.
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change Quote Manager state. Safe for autonomous agents. | Sales: `kqm_quote_list`, `kqm_quote_get`, `kqm_quote_section_list`, `kqm_quote_section_get`, `kqm_quote_line_list`, `kqm_quote_line_get`, `kqm_sales_order_list`, `kqm_sales_order_get`, `kqm_sales_order_line_list`, `kqm_sales_order_line_get`, `kqm_sales_order_payment_list`, `kqm_sales_order_payment_get`. Procurement: `kqm_purchase_order_list`, `kqm_purchase_order_get`, `kqm_purchase_order_line_list`, `kqm_purchase_order_line_get`, `kqm_purchase_order_cost_list`, `kqm_purchase_order_cost_get`, `kqm_supplier_list`, `kqm_supplier_get`, `kqm_product_supplier_list`, `kqm_product_supplier_get`. Catalog: `kqm_product_list`, `kqm_product_get`, `kqm_product_image_list`, `kqm_category_list`, `kqm_category_get`, `kqm_brand_list`, `kqm_brand_get`. CRM: `kqm_customer_list`, `kqm_customer_get`, `kqm_customer_address_list`, `kqm_customer_address_get`, `kqm_contact_list`, `kqm_contact_get`. Org: `kqm_employee_list`, `kqm_employee_get`, `kqm_warehouse_list`, `kqm_warehouse_get`. Diagnostics: `kqm_status`, `kqm_navigate` |
+| **Write** | — | None. |
+| **Destructive** | — | None. |
+
+The absence of write tools is a deliberate design choice, not an oversight. An
+agent cannot issue a quote, accept an order, place a purchase order with a
+distributor, or record a payment through this plugin.
+
+## Recommended agent policy
+
+Because there is no write surface, **read tools can be granted to autonomous
+and scheduled agents** — margin analysis, procurement reporting, and quote
+pipeline review are the intended unattended uses.
+
+The remaining control is not about state change, it is about disclosure. The
+data this plugin returns is among the most commercially sensitive an MSP holds
+(see below), so scope agent access by *what an operator may see*, not by what
+it may break.
+
+## What it cannot reach
+
+- Only the Quote Manager tenant the operator's gateway identity maps to.
+- No filesystem, no shell, no other vendor's data.
+- No other Kaseya product. BMS, VSA, and Datto RMM share the vendor name but
+  are separate APIs with separate credentials; nothing here reaches a ticket,
+  an agent, or a managed device.
+- No write path of any kind — no create, update, delete, send, or approve.
+- No live event stream. Every tool is point-in-time; `modifiedAfter` is the
+  only incremental mechanism.
+
+## Data handling
+
+Responses pass through the gateway into model context for the session and are
+not persisted by this plugin. This plugin returns an unusually high
+concentration of sensitive data for a read-only surface:
+
+- **Margin.** `kqm_purchase_order_cost_list` / `_get` and
+  `kqm_product_supplier_list` / `_get` return distributor buy price and supplier
+  SKUs. Set against `kqm_quote_line_*` sell price, they expose your gross margin
+  per line, per customer. This is the data an MSP would least like to leak to a
+  customer or a competitor.
+- **Payment records.** `kqm_sales_order_payment_list` / `_get` return payment
+  amounts, methods, and dates against customer orders.
+- **Customer PII.** `kqm_customer_*`, `kqm_customer_address_*`, and
+  `kqm_contact_*` return client names, addresses, and contact details.
+- **Staff records.** `kqm_employee_list` / `_get` returns internal staff
+  identity.
+- **Supplier terms.** `kqm_supplier_*` returns distributor relationships and
+  the commercial terms behind them.
+
+Restrict the cost, product-supplier, and payment tools specifically if an agent
+ever renders output where a customer might see it.
+
+## Known sharp edges
+
+- **Read-only is not risk-free.** The classification above means the operational
+  risk here is disclosure, not damage. An agent that summarises a quote for a
+  customer and helpfully includes the cost line has caused a commercial
+  incident without changing a single record.
+- **Quote acceptance is invisible here.** A quote becoming a sales order
+  happens outside this API. An agent polling `kqm_quote_list` will not see the
+  transition until it queries `kqm_sales_order_list` as well.
+- **Payments recorded here are not accounting entries.**
+  `kqm_sales_order_payment_*` is what Quote Manager captured against an order.
+  Reconcile against `xero-payments` or `quickbooks-online-payments`; do not
+  treat either as authoritative for the other.
+- **`modifiedAfter` covers the parent, not the children.** A quote whose line
+  items changed may not surface if the quote header's own timestamp did not
+  move. Incremental syncs that only walk quotes will drift.

--- a/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/skills/api-patterns/SKILL.md
@@ -29,6 +29,15 @@ five domains:
 - **crm**: `customer`, `customer_address`, `contact`
 - **org**: `employee`, `warehouse`
 
+## Anti-triggers
+
+- **Any other Kaseya product** — BMS, VSA, and Datto RMM share the vendor name
+  but not this API, this key, or these tools.
+- **Entity fields and the quote/sales-order hierarchy** — use
+  `kaseya-quote-manager-quotes` or `kaseya-quote-manager-purchasing`.
+- **Write scopes or permissions** — there is no write surface to authenticate
+  for; every tool is a `_list` or `_get`.
+
 ## Connection & Authentication
 
 Kaseya Quote Manager uses a single API key. Against the upstream API the

--- a/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/skills/purchasing/SKILL.md
+++ b/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/skills/purchasing/SKILL.md
@@ -22,6 +22,16 @@ to supplier SKUs and pricing.
 
 All access here is **read-only**.
 
+## Anti-triggers
+
+- **What the customer was quoted or charged** — this is the buy side; the sell
+  side is `kaseya-quote-manager-quotes`.
+- **Supplier bills as accounting entries** — a Quote Manager purchase order is
+  not an ACCPAY bill and never posts to a GL; use `xero-invoices` or
+  `quickbooks-online-expenses`.
+- **Sell price and catalog descriptions for quoting** — use
+  `salesbuildr-products`.
+
 ## Tools
 
 | Tool | Purpose |

--- a/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/skills/quotes/SKILL.md
+++ b/msp-claude-plugins/kaseya-quote-manager/kaseya-quote-manager/skills/quotes/SKILL.md
@@ -22,6 +22,20 @@ which has its own **order lines** and **payments**.
 All access here is **read-only** — these tools list and retrieve data; they
 never create or modify records.
 
+## Anti-triggers
+
+- **Creating, editing, or sending a quote** — this surface is read-only. Build
+  the quote in `salesbuildr-quotes` or `connectwise-cpq-quotes`, and send it
+  for signature with `pandadoc-documents`.
+- **Kaseya BMS, VSA, or Datto RMM** — different Kaseya products sharing the
+  vendor name. Quote Manager is the former Datto Commerce and holds no
+  tickets, agents, or devices.
+- **What was bought to fulfil the order** — purchase orders, suppliers, and
+  cost sit on the buy side in `kaseya-quote-manager-purchasing`.
+- **Recording the payment in the books** — `kqm_sales_order_payment_*` reports
+  what Quote Manager captured, not the accounting ledger; use `xero-payments`
+  or `quickbooks-online-payments`.
+
 ## Tools
 
 | Tool | Purpose |

--- a/msp-claude-plugins/pandadoc/pandadoc/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/pandadoc/pandadoc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pandadoc",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Claude plugins for PandaDoc - documents, templates, e-signatures, and proposal management",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/pandadoc/pandadoc/GOVERNANCE.md
+++ b/msp-claude-plugins/pandadoc/pandadoc/GOVERNANCE.md
@@ -1,0 +1,112 @@
+# PandaDoc plugin — governance and safety model
+
+Unofficial. Community-built plugin for the PandaDoc API. Not affiliated with,
+endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches PandaDoc through the WYRE
+Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the workspace the operator is
+authorised for.
+
+- No PandaDoc API key is stored on the technician's machine, in this repo, or
+  in the model's context.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers "who
+  sent this contract". PandaDoc's own audit trail records the API key's owner,
+  which is the same name for every technician.
+- Revoking gateway access revokes PandaDoc access with it, immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change PandaDoc state. Safe for autonomous agents. | `pandadoc-list-documents`, `pandadoc-get-document`, `pandadoc-get-document-status`, `pandadoc-list-templates`, `pandadoc-get-template`, `pandadoc-download-document`, `pandadoc-search-docs`, `pandadoc-get-code-sample` |
+| **Write** | Creates or modifies drafts. Not yet visible to the customer. | `pandadoc-create-document`, `pandadoc-add-recipient` |
+| **Destructive** | Emails a real customer a document to sign. Requires explicit per-call human approval. | `pandadoc-send-document` |
+
+`pandadoc-send-document` is the entire reason this plugin needs a governance
+document. It does not modify a record in a database an operator can correct —
+it emails a named person at a client an executable agreement, priced with
+whatever the pricing table contained, and opens it for signature. The blast
+radius is a commitment your business is bound by if the recipient signs, and
+there is no unsend: the email has left, and voiding the document afterwards
+still leaves the customer holding a copy of a price you did not intend to
+offer. Treat it exactly as you would treat a delete tool in another vendor.
+
+`silent=true` does not downgrade it. That flag suppresses the notification
+email but still transitions the document out of draft into a signable state
+behind a live link. It reduces the noise, not the commitment.
+
+`pandadoc-create-document` stays in the write tier because a draft is inert:
+it exists in your workspace, nobody outside it can see it, and it can be
+discarded. `pandadoc-add-recipient` likewise only stages who *would* receive
+the document when it is eventually sent.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never self-approve
+destructive calls.**
+
+- Read tools: allow. Proposal-pipeline reporting, stale-document sweeps, and
+  template audits are the intended autonomous use.
+- Write tools: agent drafts the exact call, human approves, then it runs. The
+  approver must read the pricing table and the recipient list, not just the
+  tool name.
+- Destructive tools: `pandadoc-send-document` requires a named human approver
+  per invocation, every time. Do not grant it to scheduled or unattended
+  agents under any configuration — a nightly "chase stale proposals" job with
+  send access is a system that emails clients contracts at 3am.
+
+## What it cannot reach
+
+- Only the PandaDoc workspace the operator's gateway identity maps to.
+- No filesystem, no shell, no other vendor's data.
+- No void, delete, or expire tool. A document sent in error cannot be
+  withdrawn through this plugin; that is a manual action in the PandaDoc web
+  app, and it does not recall the email.
+- No template authoring. Templates can be read and used, never created or
+  edited.
+- No payment collection. Documents can reach `document.waiting_pay`, but this
+  plugin cannot take the payment.
+- No live event stream. Status is point-in-time; PandaDoc webhooks carry the
+  push feed.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session and are
+  not persisted by this plugin.
+- `pandadoc-download-document` returns the **signed PDF** — an executed
+  contract containing signatures, signer identity, and the full commercial
+  terms. It is read-tier by verb and highly sensitive by content. Restrict it
+  if agents render output anywhere it could be retained.
+- `pandadoc-get-document` and `pandadoc-list-documents` return recipient PII
+  (names, email addresses) and `grand_total` — the value of every deal in the
+  pipeline. An unfiltered list is a complete revenue disclosure.
+- `pandadoc-get-template` returns the pricing structure of your standard
+  offers, including default rates.
+- `pandadoc-search-docs` and `pandadoc-get-code-sample` touch PandaDoc's public
+  developer documentation only and carry no customer data.
+
+## Known sharp edges
+
+- **Send is irreversible and this plugin cannot void.** Covered above. It is the
+  single control that matters.
+- **Two tools that look like document search are not.**
+  `pandadoc-search-docs` searches PandaDoc's developer documentation, not your
+  documents. An agent that reaches for it to find a client's contract will
+  return confident, wrong results drawn from public API docs.
+- **Only drafts can be sent.** Attempting to send a document in any other
+  status fails. An agent retrying that error will not succeed by retrying — the
+  document needs recreating.
+- **Voided, expired, and declined are terminal.** None of them can be re-sent.
+  The recovery is always a new document, which means a new number and a new
+  audit trail entry the customer can see.
+- **Token names are exact-match and silent on failure.** A token whose name
+  does not match the template is not populated and does not error, so the
+  document goes out with a visible placeholder where the client's company name
+  should be.
+- **Signing order controls who sees what, when.** Getting the order wrong on a
+  multi-party MSA can expose your countersignature block, or your pricing, to a
+  party who should have seen it only after another approved.

--- a/msp-claude-plugins/pandadoc/pandadoc/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/pandadoc/pandadoc/skills/api-patterns/SKILL.md
@@ -19,6 +19,14 @@ when_to_use: >-
 
 PandaDoc provides a hosted MCP server at `https://developers.pandadoc.com/mcp` for AI tool integration. The MCP server provides direct API access to PandaDoc's document automation platform, documentation search, and code generation assistance.
 
+## Anti-triggers
+
+- **Your own documents** — `pandadoc-search-docs` and
+  `pandadoc-get-code-sample` search PandaDoc's developer documentation, not
+  your PandaDoc account; use `pandadoc-documents`.
+- **Document status values and what each transition allows** — use
+  `pandadoc-documents`.
+
 ## Connection & Authentication
 
 ### MCP Server

--- a/msp-claude-plugins/pandadoc/pandadoc/skills/documents/SKILL.md
+++ b/msp-claude-plugins/pandadoc/pandadoc/skills/documents/SKILL.md
@@ -19,6 +19,21 @@ when_to_use: >-
 
 Documents in PandaDoc represent proposals, quotes, contracts, statements of work (SOWs), managed service agreements (MSAs), and any other business documents that need to be created, sent, signed, and tracked. MSPs use PandaDoc documents to formalize client engagements -- from initial proposals through signed contracts. Documents are typically created from templates, populated with client-specific content, sent for e-signature, and archived after completion.
 
+## Anti-triggers
+
+- **Choosing or inspecting the blueprint before a document exists** — use
+  `pandadoc-templates`.
+- **Who signs, in what order, and whether they have signed** — use
+  `pandadoc-recipients`.
+- **The MSP sales motion layered over these same tools** — proposal types,
+  token conventions, and pipeline reporting are `pandadoc-proposals`.
+- **Building or pricing the offer** — PandaDoc renders and sends an
+  already-priced proposal; catalog and margin work happens in
+  `salesbuildr-quotes`, `connectwise-cpq-quotes`, or
+  `kaseya-quote-manager-quotes`.
+- **Searching PandaDoc's developer documentation** — `pandadoc-search-docs`
+  searches the docs site, not your account; use `pandadoc-api-patterns`.
+
 ## MCP Tools
 
 ### Available Tools

--- a/msp-claude-plugins/pandadoc/pandadoc/skills/proposals/SKILL.md
+++ b/msp-claude-plugins/pandadoc/pandadoc/skills/proposals/SKILL.md
@@ -19,6 +19,16 @@ when_to_use: >-
 
 MSPs use PandaDoc to create, send, and track proposals for managed services engagements. The proposal workflow covers the full lifecycle from initial client interest through signed contract -- creating professional proposals from templates, populating with client-specific content and pricing, sending for e-signature, and tracking the pipeline. PandaDoc's template system, content tokens, and pricing tables make it ideal for standardizing the MSP sales process while personalizing each proposal.
 
+## Anti-triggers
+
+- **Document mechanics rather than the sales motion** — the status enum,
+  transition rules, and pricing-table schema are `pandadoc-documents`.
+- **The pipeline as the CRM sees it** — proposal status is a proxy for deal
+  stage, not the system of record; use `hubspot-deals` or
+  `salesbuildr-opportunities`.
+- **Producing the priced quote the proposal wraps** — use `salesbuildr-quotes`,
+  `connectwise-cpq-quotes`, or `kaseya-quote-manager-quotes`.
+
 ## MCP Tools
 
 ### Available Tools

--- a/msp-claude-plugins/pandadoc/pandadoc/skills/recipients/SKILL.md
+++ b/msp-claude-plugins/pandadoc/pandadoc/skills/recipients/SKILL.md
@@ -18,6 +18,14 @@ when_to_use: >-
 
 Recipients in PandaDoc are the people who receive, view, and sign documents. In MSP engagements, documents typically involve multiple parties -- the client decision-maker who signs the agreement, sometimes a technical contact who reviews, and the MSP representative who countersigns. PandaDoc supports complex signing workflows with ordered signing, role-based assignments, and real-time completion tracking. Understanding recipient management is essential for smooth contract execution.
 
+## Anti-triggers
+
+- **Creating, sending, or downloading the document itself** — use
+  `pandadoc-documents`.
+- **A contact record in the CRM** — a PandaDoc recipient is an email address
+  attached to one document, not a stored contact; use `hubspot-contacts` or
+  `salesbuildr-companies-contacts`.
+
 ## MCP Tools
 
 ### Available Tools

--- a/msp-claude-plugins/pandadoc/pandadoc/skills/templates/SKILL.md
+++ b/msp-claude-plugins/pandadoc/pandadoc/skills/templates/SKILL.md
@@ -18,6 +18,12 @@ when_to_use: >-
 
 Templates in PandaDoc are reusable document blueprints that define the structure, layout, content, and fields of a document. MSPs use templates to standardize their business documents -- managed service agreements (MSAs), statements of work (SOWs), proposals, hardware quotes, and NDAs. Templates contain placeholders (tokens) for client-specific content, signature fields, and pricing tables that get populated when a document is created. A well-organized template library is the foundation of an efficient MSP sales process.
 
+## Anti-triggers
+
+- **A real document created from a template** — templates have no recipients,
+  status, or signatures; use `pandadoc-documents`.
+- **Which template suits a given MSP deal type** — use `pandadoc-proposals`.
+
 ## MCP Tools
 
 ### Available Tools

--- a/msp-claude-plugins/salesbuildr/salesbuildr/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/salesbuildr/salesbuildr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "salesbuildr",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Claude plugins for Salesbuildr CRM - companies, contacts, products, opportunities, quotes",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/salesbuildr/salesbuildr/GOVERNANCE.md
+++ b/msp-claude-plugins/salesbuildr/salesbuildr/GOVERNANCE.md
@@ -1,0 +1,97 @@
+# Salesbuildr plugin — governance and safety model
+
+Unofficial. Community-built plugin for the Salesbuildr API. Not affiliated
+with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches Salesbuildr through the WYRE
+Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the portal the operator is
+authorised for.
+
+- No Salesbuildr API key is stored on the technician's machine, in this repo,
+  or in the model's context.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers "who
+  built this quote". Salesbuildr sees one API key and cannot tell your
+  technicians apart.
+- Revoking gateway access revokes Salesbuildr access with it, immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change Salesbuildr state. Safe for autonomous agents. | `salesbuildr_companies_list`, `salesbuildr_companies_get`, `salesbuildr_contacts_list`, `salesbuildr_contacts_get`, `salesbuildr_opportunities_list`, `salesbuildr_opportunities_get`, `salesbuildr_products_list`, `salesbuildr_products_get`, `salesbuildr_quotes_list`, `salesbuildr_quotes_get`, `salesbuildr_status`, `salesbuildr_navigate` |
+| **Write** | Creates or modifies records. Reversible in principle, but see below. | `salesbuildr_companies_create`, `salesbuildr_companies_update`, `salesbuildr_contacts_create`, `salesbuildr_contacts_update`, `salesbuildr_opportunities_create`, `salesbuildr_opportunities_update`, `salesbuildr_quotes_create` |
+| **Destructive** | Removes records and everything hanging off them. Requires explicit per-call human approval. | `salesbuildr_companies_delete`, `salesbuildr_contacts_delete` |
+
+`salesbuildr_quotes_create` is deliberately **not** in the destructive tier.
+The API creates a priced quote record; it does not publish or email it — that
+is a separate action in the Salesbuildr portal. But it is the riskiest write
+here, and the sharp edges below explain why it needs a human read before the
+salesperson clicks publish.
+
+`salesbuildr_companies_delete` is destructive in the cascading sense: a company
+is the parent of its contacts, opportunities, and quotes. Deleting one removes
+the commercial history behind live deals, and there is no undelete tool.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never self-approve
+destructive calls.**
+
+- Read tools: allow. Catalog lookup, pipeline review, and margin analysis are
+  the intended autonomous use.
+- Write tools: agent drafts the exact call, human approves, then it runs.
+  Quote creation additionally needs the approver to check the line-item prices,
+  not just the shape of the call.
+- Destructive tools: require a named human approver per invocation. Do not
+  grant these to scheduled or unattended agents.
+
+## What it cannot reach
+
+- Only the Salesbuildr portal the operator's gateway identity maps to. The API
+  key is portal-scoped; there is no reseller or multi-portal tier.
+- No filesystem, no shell, no other vendor's data.
+- No publish, send, or e-signature surface. Quotes built here become
+  customer-visible only through a human action in the Salesbuildr portal.
+- No quote deletion. A quote created in error must be cleaned up in the portal.
+- No PSA, accounting, or payment system. Winning a quote here bills nobody.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session and are
+  not persisted by this plugin.
+- `salesbuildr_contacts_list` / `salesbuildr_contacts_get` return customer PII —
+  names, email addresses, phone numbers.
+- `salesbuildr_quotes_list` / `salesbuildr_quotes_get` return commercial data:
+  line-item pricing, recurring values, and quote totals across the pipeline.
+- `salesbuildr_products_list` returns the sell-price catalog. Combined with
+  distributor cost from `kaseya-quote-manager-purchasing`, this reconstructs
+  your margin — treat the pair as commercially sensitive even though neither is
+  alone.
+- Restrict contact and quote reads if your agents run unattended.
+
+## Known sharp edges
+
+- **A quote is one click from the customer.** The API stops at creating the
+  record, but the record it creates is the artefact a salesperson publishes as
+  a customer-facing web proposal. An agent-generated price error becomes a
+  binding-looking offer the moment a human clicks publish, without a second
+  review of the numbers.
+- **There is no quote delete tool.** A wrong quote cannot be withdrawn through
+  this plugin. Cleanup is manual, in the portal.
+- **`salesbuildr_quotes_create` elicits a company when one is not supplied.**
+  It prompts for a company name and searches. An unattended agent has nobody to
+  answer, so the call either stalls or proceeds against whatever the search
+  returned first.
+- **Line items detach from the catalog.** `unitPrice` on a line item is copied
+  at creation. A later catalog price change does not propagate, so quotes and
+  the catalog legitimately disagree — do not let an agent "correct" one from
+  the other.
+- **Deletes cascade quietly.** Removing a company takes its contacts,
+  opportunities, and quotes with it. The API reports success either way.
+- **Rate limit is 500 requests per 10 minutes.** A pipeline sweep that pages
+  through quotes and then fetches each one will exhaust the budget and degrade
+  mid-task, leaving partial results that look complete.

--- a/msp-claude-plugins/salesbuildr/salesbuildr/skills/companies-contacts/SKILL.md
+++ b/msp-claude-plugins/salesbuildr/salesbuildr/skills/companies-contacts/SKILL.md
@@ -16,6 +16,16 @@ when_to_use: >-
 
 Companies and contacts are the foundation of the Salesbuildr CRM. Companies represent organizations (customers, prospects), while contacts are individuals associated with companies.
 
+## Anti-triggers
+
+- **The same organization in the CRM of record** — use `hubspot-companies` or
+  `hubspot-contacts`.
+- **The organization as a billing entity** — Salesbuildr holds no AR balance
+  or payment method; use `xero-contacts`, `quickbooks-online-customers`, or
+  `alternative-payments-customers`.
+- **What the company has been quoted or is in the pipeline for** — use
+  `salesbuildr-quotes` or `salesbuildr-opportunities`.
+
 ## Companies
 
 ### Search Companies

--- a/msp-claude-plugins/salesbuildr/salesbuildr/skills/opportunities/SKILL.md
+++ b/msp-claude-plugins/salesbuildr/salesbuildr/skills/opportunities/SKILL.md
@@ -17,6 +17,13 @@ when_to_use: >-
 
 Opportunities represent potential deals in the sales pipeline. Each opportunity is linked to a company and optionally a contact, with a value, stage, and expected close date.
 
+## Anti-triggers
+
+- **The priced breakdown behind the opportunity** — an opportunity carries a
+  single value, not line items; use `salesbuildr-quotes`.
+- **HubSpot deals** — the same pipeline concept in a different CRM; use
+  `hubspot-deals`.
+
 ## Search Opportunities
 
 ```

--- a/msp-claude-plugins/salesbuildr/salesbuildr/skills/products/SKILL.md
+++ b/msp-claude-plugins/salesbuildr/salesbuildr/skills/products/SKILL.md
@@ -15,6 +15,14 @@ when_to_use: >-
 
 The product catalog in Salesbuildr contains items that can be added to quotes. Products include hardware, software licenses, services, and any other billable items.
 
+## Anti-triggers
+
+- **What a product costs from the distributor** — this catalog holds sell
+  price; supplier SKUs and buy price are `kaseya-quote-manager-purchasing`.
+- **A product already placed on a quote** — line items are copies with their
+  own quantity and price and diverge from the catalog; use
+  `salesbuildr-quotes`.
+
 ## Search Products
 
 ```

--- a/msp-claude-plugins/salesbuildr/salesbuildr/skills/quotes/SKILL.md
+++ b/msp-claude-plugins/salesbuildr/salesbuildr/skills/quotes/SKILL.md
@@ -16,6 +16,19 @@ when_to_use: >-
 
 Quotes are proposals sent to customers containing one or more products as line items. Each quote is linked to a company and contact, and can optionally be associated with an opportunity.
 
+## Anti-triggers
+
+- **Emailing the quote to the customer for signature** — Salesbuildr builds
+  and prices the quote; turning it into a sendable, signable document is
+  `pandadoc-documents`.
+- **Quotes in another quoting system** — Kaseya Quote Manager and ConnectWise
+  CPQ use identical vocabulary for their own records; use
+  `kaseya-quote-manager-quotes` or `connectwise-cpq-quotes`.
+- **Billing for a quote the customer accepted** — an accepted quote is not an
+  invoice; use `xero-invoices` or `quickbooks-online-invoices`.
+- **The pipeline record the quote hangs off** — stage, value, and close date
+  belong to the opportunity; use `salesbuildr-opportunities`.
+
 ## Search Quotes
 
 ```

--- a/msp-claude-plugins/warmly/warmly/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/warmly/warmly/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "warmly",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Warmly visitor intelligence - identified website visitors, account-level engagement, and credit balance",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/warmly/warmly/GOVERNANCE.md
+++ b/msp-claude-plugins/warmly/warmly/GOVERNANCE.md
@@ -1,0 +1,111 @@
+# Warmly plugin — governance and safety model
+
+Unofficial. Community-built plugin for the Warmly API. Not affiliated with,
+endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches Warmly through the WYRE
+Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the Warmly organization the
+operator is authorised for.
+
+- No Warmly OAuth client secret or access token is stored on the technician's
+  machine, in this repo, or in the model's context. Warmly delegates
+  authentication to a WorkOS AuthKit tenant; the gateway completes that flow.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers "who
+  pulled this visitor list" — which matters, because that list is third-party
+  personal data (see Data handling).
+- Revoking gateway access revokes Warmly access with it, immediately.
+
+## Tool permission tiers
+
+**This plugin is read-only.** Warmly exposes three tools and none of them
+changes vendor state.
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change Warmly state. Safe for autonomous agents. | `list_warm_visitors`, `list_warm_accounts`, `get_credits_remaining` |
+| **Write** | — | None. |
+| **Destructive** | — | None. |
+
+Retrieval is free: Warmly bills on identification, not on reading identified
+visitors back, so these calls do not consume the credit balance. That removes
+the usual reason to rate-limit an agent, and it means the only control worth
+applying here is on the data coming back rather than on the calls going out.
+
+## Recommended agent policy
+
+Read tools may be granted to autonomous and scheduled agents. Morning triage
+lists, ICP filtering, and CRM-intersection sweeps are the intended unattended
+uses, and there is nothing to approve per call because nothing changes state or
+reaches a customer.
+
+The two things worth building into an agent anyway:
+
+- **Check the balance before depending on volume.** Call
+  `get_credits_remaining` before a workflow that assumes identifications will
+  keep arriving. Exhaustion is silent (see sharp edges).
+- **Decide the retention question before the first run.** The governance
+  problem with this plugin is what happens to visitor data after the model sees
+  it, not what the model does to Warmly.
+
+## What it cannot reach
+
+- Only the Warmly organization the operator's gateway identity maps to. Warmly
+  is explicitly multi-organization; the OAuth token selects one.
+- No filesystem, no shell, no other vendor's data.
+- No write surface at all — no tagging, no suppression, no list management, no
+  CRM sync.
+- **No outreach.** Warmly identifies; it does not contact. Nothing in this
+  plugin can email, call, or message an identified visitor. Any sequence that
+  follows is initiated in your CRM or sequencer, under that tool's own
+  governance.
+- No live stream. Queries are point-in-time over a recent window.
+
+## Data handling
+
+Responses pass through the gateway into model context for the session and are
+not persisted by this plugin. The privacy posture here deserves specific
+attention:
+
+- `list_warm_visitors` returns **contact-level PII about people who did not
+  give it to you** — name, job title, employer, and where available a work
+  email address, derived from IP reverse lookup and third-party data overlays.
+  The visitor did not fill in a form. They browsed a website.
+- `list_warm_accounts` returns company-level identification and engagement
+  depth — less identifying, but still a record that a named organization was
+  researching you.
+- `get_credits_remaining` returns commercial account data (this month's
+  remaining identification balance) and nothing about any person.
+
+This is third-party-sourced personal data about identified individuals, which
+puts it squarely inside GDPR, CCPA, and equivalent regimes. Before piping
+visitor output into any system that retains it — a CRM, a spreadsheet, a
+prospecting list, an artifact — confirm your organization has a lawful basis to
+process it and a route to honour a deletion request. "The vendor gave it to us"
+is not one. Restrict `list_warm_visitors` specifically if that question is
+unsettled; `list_warm_accounts` carries far less exposure for the same triage
+value.
+
+## Known sharp edges
+
+- **Credit exhaustion is silent, and looks like quiet traffic.** When the
+  monthly identification budget runs out, new visitors simply stop being
+  identified. Previously identified ones stay visible, so `list_warm_visitors`
+  keeps returning results and an agent reasonably concludes the site went quiet.
+  It did not — you stopped paying to see who was on it. Only
+  `get_credits_remaining` distinguishes the two.
+- **Identification is probabilistic.** IP-to-company matching attributes
+  co-working spaces, VPN exits, and residential ISPs to the wrong organization
+  routinely. An agent that treats a visitor row as fact will brief a
+  salesperson to call a company that never visited.
+- **Intent is not interest.** A visit may be a competitor, a job applicant, a
+  vendor, or your own staff off-network. Warmly reports traffic; it does not
+  report buying intent, and the skill's own "What Warmly does NOT tell you"
+  section is worth reading before acting on a list.
+- **The session is stateful.** The server issues an `Mcp-Session-Id` on
+  `initialize` that must accompany subsequent requests. A dropped session
+  returns errors that read like an auth failure but are not — reconnecting, not
+  re-credentialing, is the fix.

--- a/msp-claude-plugins/warmly/warmly/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/warmly/warmly/skills/api-patterns/SKILL.md
@@ -20,6 +20,14 @@ Warmly hosts a remote MCP server at `https://opps-api.getwarmly.com/api/mcp` tha
 
 Official docs: [docs.getwarmly.com/mcp](https://docs.getwarmly.com/mcp)
 
+## Anti-triggers
+
+- **Which of the three tools to call, and what to do with the result** — use
+  `warmly-visitor-intelligence`.
+- **A different hosted OAuth MCP server** — HubSpot and PandaDoc have their
+  own tenants, scopes, and session models; use `hubspot-api-patterns` or
+  `pandadoc-api-patterns`.
+
 ## Connection & Authentication
 
 ### MCP Server Endpoint

--- a/msp-claude-plugins/warmly/warmly/skills/visitor-intelligence/SKILL.md
+++ b/msp-claude-plugins/warmly/warmly/skills/visitor-intelligence/SKILL.md
@@ -26,6 +26,16 @@ Warmly identifies anonymous website visitors by IP-to-company reverse lookup, th
 
 That is the raw material for prioritizing outreach: warm > cold, deep engagement > a single bounce, target ICP > unrelated traffic.
 
+## Anti-triggers
+
+- **Connection, OAuth, org-scoping, or session errors** — use
+  `warmly-api-patterns`.
+- **Anyone who is already a CRM record** — Warmly reports website traffic, not
+  relationships; contacts, companies, and pipeline are `hubspot-contacts`,
+  `hubspot-companies`, and `hubspot-deals`.
+- **Actually contacting the visitor** — Warmly is read-only and sends nothing;
+  the outreach happens in the CRM or sequencer.
+
 ## Tool selection
 
 | Task | Tool |

--- a/msp-claude-plugins/xero/xero/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/xero/xero/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "xero",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Claude plugins for Xero accounting - contacts, invoices, payments, accounts, reports",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/xero/xero/GOVERNANCE.md
+++ b/msp-claude-plugins/xero/xero/GOVERNANCE.md
@@ -1,0 +1,139 @@
+# Xero plugin — governance and safety model
+
+Unofficial. Community-built plugin for the Xero Accounting API. Not affiliated
+with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches Xero through the WYRE Conduit
+gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers authentication
+centrally and scopes every call to the Xero organization the operator is
+authorised for.
+
+- No Xero client id, client secret, or access token is stored on the
+  technician's machine, in this repo, or in the model's context. Xero Custom
+  Connections mint 30-minute tokens with no refresh token; the gateway handles
+  that cycle.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers "who
+  authorised this invoice". Xero's own history attributes every change to the
+  Custom Connection, which is one name for your whole team — and that matters
+  more here than in most connectors, because these are accounting records.
+- Revoking gateway access revokes Xero access with it, immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change Xero state. Safe for autonomous agents, but see Data handling. | `xero_accounts_list`, `xero_accounts_get`, `xero_contacts_list`, `xero_contacts_get`, `xero_contacts_search`, `xero_invoices_list`, `xero_invoices_get`, `xero_payments_list`, `xero_payments_get`, `xero_reports_profit_and_loss`, `xero_reports_balance_sheet`, `xero_reports_aged_receivables`, `xero_reports_aged_payables`, `xero_status`, `xero_navigate`, `xero_back` |
+| **Write** | Creates a record with no financial effect. Reversible. | `xero_contacts_create` |
+| **Destructive** | Creates, issues, cancels, or settles a financial obligation. Requires explicit per-call human approval. | `xero_invoices_create`, `xero_invoices_update_status`, `xero_payments_create` |
+
+The write tier holds exactly one tool. That is not an accident of the API
+surface — it reflects that in an accounting system almost nothing that changes
+state is safely reversible.
+
+- **`xero_invoices_create`** accepts `Status`, so a single call can create an
+  invoice straight to `AUTHORISED`. An authorised invoice cannot be edited or
+  deleted, only voided; it has consumed an invoice number, it appears on the
+  client's statement, and voiding it leaves a permanent gap in the sequence
+  that an auditor will ask about. Even created as `DRAFT` it is a proposed
+  receivable in your books.
+- **`xero_invoices_update_status`** is the tool that issues and cancels. Moving
+  to `AUTHORISED` turns a draft into a legally-issued demand for payment;
+  moving to `VOIDED` cancels a demand a client may already have paid against.
+  Both are one-way in accounting terms.
+- **`xero_payments_create`** applies money against an invoice. A Xero payment
+  cannot be edited — only deleted and re-entered. A payment applied to the
+  wrong invoice marks a bill as settled that is not, suppresses the dunning
+  that should have chased it, and misstates AR until someone notices.
+
+`xero_contacts_create` stays in the write tier because a contact carries no
+balance and no obligation. It is the one thing here you can create and then
+change your mind about.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never self-approve
+destructive calls.**
+
+- Read tools: allow. Cash-flow reporting, aged-receivables review, and
+  reconciliation analysis are the intended autonomous use, and are where this
+  plugin earns its place.
+- Write tools: agent drafts the exact call, human approves, then it runs.
+- Destructive tools: require a named human approver per invocation, and the
+  approver must check amounts, account codes, and the target invoice — not just
+  that the call is well-formed. Do not grant these to scheduled or unattended
+  agents. A monthly billing automation with `xero_invoices_create` and no human
+  in the loop is a system that can bill every client twice, or bill one client
+  another's amount.
+
+## What it cannot reach
+
+- Only the Xero organization selected by the `xero-tenant-id` the operator's
+  gateway identity maps to. A Custom Connection token can address multiple
+  organizations; the header, set at the gateway, picks one.
+- Only the scopes granted. Reports are read-only by scope
+  (`accounting.reports.read`) and cannot be made writable from this plugin.
+- No filesystem, no shell, no other vendor's data.
+- No bank feeds, bank transactions, or bank reconciliation. This plugin cannot
+  see or touch the connected bank account.
+- No payroll, no fixed assets, no purchase orders, no expense claims.
+- No credit notes. A service credit must be raised in the Xero web app; this
+  plugin can neither issue nor apply one.
+- No delete of any kind. There is no tool to remove an invoice, a payment, or a
+  contact.
+- **No money movement.** Xero is a ledger. `xero_payments_create` records that
+  money changed hands; it does not make it happen. Nothing here debits or
+  credits a real account.
+
+## Data handling
+
+Responses pass through the gateway into model context for the session and are
+not persisted by this plugin. This plugin returns the financial position of the
+business:
+
+- **Whole-company financials.** `xero_reports_profit_and_loss` and
+  `xero_reports_balance_sheet` return revenue, costs, margin, assets, and
+  liabilities. A single call discloses the company's complete financial
+  position. These are the most sensitive tools in the batch and the least
+  obviously so, because they are reads.
+- **Client credit position.** `xero_reports_aged_receivables` returns which
+  clients owe what, and how late they are — commercially sensitive about your
+  customers, not just about you.
+- **Supplier terms.** `xero_reports_aged_payables` exposes who you buy from and
+  how you pay them.
+- **Customer and supplier PII.** `xero_contacts_list`, `xero_contacts_get`, and
+  `xero_contacts_search` return names, addresses, email addresses, phone
+  numbers, and tax registration numbers.
+- **Transaction-level detail.** `xero_invoices_*` and `xero_payments_*` return
+  amounts, line items, and payment history per client.
+
+Restrict the report tools specifically if agents run unattended or render
+output where anyone outside finance could see it.
+
+## Known sharp edges
+
+- **Validation failures return HTTP 200.** Xero attaches `HasErrors: true` and
+  a `ValidationErrors` array to the individual resource rather than failing the
+  request. An agent that checks status codes will report a successful billing
+  run that created nothing — or, in a batch, created some invoices and not
+  others.
+- **Batches hide which item broke.** Without `?summarizeErrors=false` a batch
+  failure collapses into one aggregate message. Partial success plus an opaque
+  error is how a monthly run ends up half-issued with nobody sure which half.
+- **Authorised cannot be edited, only voided.** There is no correction path. A
+  batch created straight to `AUTHORISED` with a wrong rate means voiding and
+  re-issuing every invoice, each with a new number the client has to reconcile.
+- **Invoice numbers are consumed permanently.** A number used by a voided
+  invoice cannot be reused. Omitting `InvoiceNumber` and letting Xero assign
+  one avoids a collision error that reads like a duplicate-detection failure.
+- **A missing `xero-tenant-id` returns 403, not 400.** The error reads as a
+  permissions problem when the header is simply absent — an agent will
+  reasonably conclude its credentials were revoked and escalate.
+- **Rate limits are tight and dual.** 60 requests per minute *and* 5,000 per
+  day. Monthly billing plus a reporting sweep can exhaust the daily budget, and
+  the degradation lands mid-task.
+- **Payments are not editable.** Correcting a misapplied payment means deleting
+  and re-entering, which this plugin cannot do — it becomes a manual job in the
+  Xero web app.

--- a/msp-claude-plugins/xero/xero/skills/accounts/SKILL.md
+++ b/msp-claude-plugins/xero/xero/skills/accounts/SKILL.md
@@ -17,6 +17,14 @@ when_to_use: >-
 
 The chart of accounts (COA) in Xero defines the general ledger structure for your organization. Every invoice line item, payment, and bank transaction references an account code. For MSPs, a well-structured COA enables tracking revenue by service line (managed services, projects, hardware sales), expenses by vendor category, and provides the foundation for meaningful financial reporting.
 
+## Anti-triggers
+
+- **A customer or supplier account** — "account" in Xero means a general
+  ledger code; the organization you bill is `xero-contacts`.
+- **Balances and movement on those codes** — the chart of accounts is
+  structure only and carries no figures; use `xero-reports`.
+- **A login, tenant, or API credential** — use `xero-api-patterns`.
+
 ## Core Concepts
 
 ### Account Classes

--- a/msp-claude-plugins/xero/xero/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/xero/xero/skills/api-patterns/SKILL.md
@@ -18,6 +18,14 @@ when_to_use: >-
 
 The Xero API is a RESTful JSON API covering contacts, invoices, payments, accounts, bank transactions, credit notes, and reports. This skill covers the mechanics that aren't guessable from the resource names: OAuth2 Custom Connections, query building, pagination, error handling, and rate-limit behavior.
 
+## Anti-triggers
+
+- **What a resource's fields and status values mean** — use `xero-contacts`,
+  `xero-invoices`, `xero-payments`, `xero-accounts`, or `xero-reports`.
+- **QuickBooks Online's auth and query model** — also OAuth2, but a different
+  grant, a different query language, and different limits; use
+  `quickbooks-online-api-patterns`.
+
 ## Authentication
 
 Xero uses OAuth2 **Custom Connections** for machine-to-machine access — a plain `client_credentials` grant against `https://identity.xero.com/connect/token`, authenticated with HTTP Basic (`CLIENT_ID:CLIENT_SECRET`). Access tokens last **1800 seconds (30 minutes)**; there is no refresh token in this flow, you simply request a new one.

--- a/msp-claude-plugins/xero/xero/skills/contacts/SKILL.md
+++ b/msp-claude-plugins/xero/xero/skills/contacts/SKILL.md
@@ -16,6 +16,17 @@ when_to_use: >-
 
 Contacts are the foundational entity in Xero, representing customers (clients you invoice), suppliers (vendors you pay), or both. Every invoice, payment, credit note, and bank transaction is linked to a contact. For MSPs, contacts typically represent managed services clients, hardware vendors, software suppliers, and subcontractors.
 
+## Anti-triggers
+
+- **The CRM view of the same organization** — Xero contacts carry AR/AP
+  balances but no pipeline, owner, or activity history; use
+  `hubspot-companies` or `salesbuildr-companies-contacts`.
+- **The billing target on the payment rail** — use
+  `alternative-payments-customers`.
+- **Chart-of-accounts entries** — a Xero "account" is a general ledger code,
+  not a customer account; use `xero-accounts`.
+- **The same operation in QuickBooks** — use `quickbooks-online-customers`.
+
 ## Core Concepts
 
 ### Contact Types

--- a/msp-claude-plugins/xero/xero/skills/invoices/SKILL.md
+++ b/msp-claude-plugins/xero/xero/skills/invoices/SKILL.md
@@ -17,6 +17,18 @@ when_to_use: >-
 
 Invoices are the core transaction entity in Xero for billing and accounts payable. For MSPs, invoices represent two primary flows: sales invoices (ACCREC) for billing managed services clients, and supplier bills (ACCPAY) for vendor costs like software licenses, hardware purchases, and ISP charges.
 
+## Anti-triggers
+
+- **A quote or proposal the customer has not agreed to** — an invoice is a
+  demand for payment, not an offer; use `salesbuildr-quotes`,
+  `connectwise-cpq-quotes`, or `pandadoc-documents`.
+- **Collecting the money the invoice asks for** — Xero records the receivable;
+  the hosted payment rail is `alternative-payments-invoicing` and recording
+  the receipt is `xero-payments`.
+- **Aged receivables or revenue totals** — do not aggregate invoice rows by
+  hand; use `xero-reports`.
+- **The same operation in QuickBooks** — use `quickbooks-online-invoices`.
+
 ## Core Concepts
 
 ### Invoice Types

--- a/msp-claude-plugins/xero/xero/skills/payments/SKILL.md
+++ b/msp-claude-plugins/xero/xero/skills/payments/SKILL.md
@@ -17,6 +17,14 @@ when_to_use: >-
 
 Payments in Xero record the movement of money against invoices, credit notes, and overpayments. For MSPs, payment tracking is critical for cash flow management -- monitoring which clients have paid their monthly managed services invoices, which are overdue, and reconciling incoming payments against the correct invoices.
 
+## Anti-triggers
+
+- **Taking money from the customer** — Xero records a payment that already
+  happened; the collection rail is `alternative-payments-invoicing`.
+- **What is owed rather than what was paid** — `AmountDue` and invoice status
+  are `xero-invoices`; aging summaries are `xero-reports`.
+- **The same operation in QuickBooks** — use `quickbooks-online-payments`.
+
 ## Core Concepts
 
 ### Payment Types

--- a/msp-claude-plugins/xero/xero/skills/reports/SKILL.md
+++ b/msp-claude-plugins/xero/xero/skills/reports/SKILL.md
@@ -17,6 +17,14 @@ when_to_use: >-
 
 Xero exposes its financial reports through the API as structured, programmatically parseable data. For MSPs, these reports drive profitability tracking by service line, client payment-behavior monitoring, cash flow management, and financial statements for stakeholders.
 
+## Anti-triggers
+
+- **Individual transactions rather than aggregates** — reports return
+  summarized rows with no drill-through; the underlying records are
+  `xero-invoices` and `xero-payments`.
+- **The GL structure a report groups by** — use `xero-accounts`.
+- **The same reports in QuickBooks** — use `quickbooks-online-reports`.
+
 ## Core Concepts
 
 ### Available Reports


### PR DESCRIPTION
Applies the connector-quality standard from `feat/skill-anti-triggers-governance` (#158 follow-on) to the **revenue / quote-to-cash** batch. Branched from that standard, not from `main`.

Additive only. No `_standards/`, `_templates/`, `marketplace.json`, or `docs/src/data/plugins.ts` changes; no `npm run generate`; no `triggers:` frontmatter.

## The funnel-stage boundary

These seven plugins are unusually confusable because they are not siblings — they are consecutive stages of one revenue motion, and they all plausibly answer *"send the customer a quote."* Every anti-trigger section in this PR is written against this boundary:

| Stage | Owner | Says |
|---|---|---|
| Pre-CRM intent | `warmly` | **Who is interested** — identified site visitors, no record yet |
| CRM / forecast | `hubspot` | **That a deal exists and what it is worth** — no line items |
| Quote build + price | `salesbuildr`, `connectwise-cpq` | **The priced offer** — catalog, line items, margin |
| Procurement + order ledger | `kaseya-quote-manager` | **What sits behind a won quote** — PO, supplier cost, sales order, payments captured (read-only) |
| Document + signature | `pandadoc` | **Turns a priced proposal into a signable document and sends it** |
| Accounting | `xero`, `quickbooks-online` | **Invoices for the signed deal** — GL, AR, reports |
| Collection | `alternative-payments` | **Collects the money** — hosted links, transactions, payouts |

`connectwise-cpq` and `quickbooks-online` are referenced by skill name only — not edited (parallel agents own them).

## Task A — `## Anti-triggers`

**30 added across 31 skills. 1 skipped.**

| Plugin | Skills | Added | Skipped |
|---|---|---|---|
| `hubspot` | 6 | 6 | — |
| `salesbuildr` | 5 | 4 | `api-patterns` |
| `kaseya-quote-manager` | 3 | 3 | — |
| `pandadoc` | 5 | 5 | — |
| `warmly` | 2 | 2 | — |
| `alternative-payments` | 4 | 4 | — |
| `xero` | 6 | 6 | — |

**Skipped — `salesbuildr-api-patterns`.** No genuine routing mistake exists. Each Salesbuildr entity skill already documents its own endpoints and `from`/`size` paging, and no other vendor in the catalog shares the "salesbuildr" vocabulary. The only bullet available would be "entity questions go to entity skills," which is a restatement of `when_to_use` — filler, and the checklist says cut it. The other six `api-patterns` skills each earned one on a specific collision (see judgement calls).

## Task B — `GOVERNANCE.md`

One per plugin, from `_templates/governance-template.md`, Conduit framing preserved. Tool names derived from each plugin's own `skills/*/SKILL.md` and cross-checked against the `alternative-payments-mcp`, `xero-mcp`, `salesbuildr-mcp`, and `kaseya-quote-manager-mcp` sources. No invented tool names.

### Money-moving / customer-emailing tools classified **destructive**

Tiering is by blast radius, not verb, so several `create`-shaped calls land in the destructive tier:

| Tool | Why destructive |
|---|---|
| `pandadoc-send-document` | Emails a named client an executable agreement at whatever price the pricing table held, and opens it for signature. No unsend, and this plugin has **no void/delete tool** — voiding is a manual web-app action that does not recall the email. `silent=true` does not downgrade it: it suppresses the email but still transitions the document into a signable state behind a live link. |
| `ap_create_invoice` | Does **not** create a draft. The invoice is created at status `open` — issued, awaiting payment, payment link attached. A live AR demand against a named client from the moment the call returns. |
| `ap_create_payment_request` | Standalone hosted checkout link for an arbitrary amount. Anyone holding the URL can pay it, for the amount the agent chose. |
| `ap_archive_invoice` | Removes the customer's ability to pay an open invoice while looking like a resolved bill. Vendor's own high-impact op (server-side confirmation). |
| `ap_archive_customer` | Same at the customer level. Vendor-flagged `⚠ HIGH-IMPACT`. |
| `ap_delete_webhook` | Irreversible; stops payment-event delivery **silently**. Reconciliation keeps running and keeps being wrong. |
| `xero_invoices_create` | Accepts `Status`, so one call can create straight to `AUTHORISED` — uneditable, undeletable, invoice number consumed, on the client's statement. |
| `xero_invoices_update_status` | The issue/cancel tool. `AUTHORISED` = legally-issued demand; `VOIDED` = cancels a demand the client may already have paid against. One-way in accounting terms. |
| `xero_payments_create` | Applies money against an invoice. Xero payments cannot be edited, only deleted and re-entered — which this plugin cannot do. A misapplied payment marks a bill settled that is not, and suppresses the dunning that should have chased it. |
| `hubspot_create_contact` | See below. |
| `hubspot_update_contact` | See below. |

### Judgement calls

**HubSpot has no delete tool, so its destructive tier is defined by outbound reach, not data loss.** `hubspot_create_contact` and `hubspot_update_contact` are classified destructive because HubSpot workflows enrol on contact creation and property change — in a portal with any lifecycle-stage or lead-status workflow carrying an email action, a contact write hands a real named prospect to an outbound sequence. The plugin sends nothing; HubSpot does, on the strength of the write, and it cannot be recalled. Company, deal, and ticket objects carry no email address of their own, which is the principled line keeping them in the write tier.

**`salesbuildr_quotes_create` stays a *write*, deliberately.** Verified against `salesbuildr-mcp/src/domains/quotes.ts`: it creates a priced quote record and does not publish or email it. Escalating it would have been blanket application of the rule rather than judgement. It is still flagged as the riskiest write in that plugin's sharp edges — the record it creates is one portal click from being a customer-facing proposal, and there is no quote-delete tool.

**Two plugins are stated plainly as read-only** — `kaseya-quote-manager` (every tool is `_list`/`_get`) and `warmly` (three read tools). For KQM this reframes the governance question from damage to **disclosure**: `kqm_purchase_order_cost_*` and `kqm_product_supplier_*` return distributor buy price, which set against `kqm_quote_line_*` sell price exposes gross margin per line, per customer. An agent that summarises a quote for a customer and helpfully includes the cost line causes a commercial incident without changing a record.

**Warmly correction.** An early draft classified Warmly's reads as metered. `warmly-api-patterns` states explicitly that Warmly bills on *identification*, not retrieval, so the reads are free — corrected before commit. The real sharp edge is inverted and more interesting: credit exhaustion is **silent**, already-identified visitors stay visible, so `list_warm_visitors` keeps returning results and an agent concludes the site went quiet when in fact you stopped paying to see who was on it.

**Read-tier tools that still need restricting.** Flagged under Data handling rather than mis-tiered: `pandadoc-download-document` (the executed contract — signatures, signer identity, full commercial terms), `ap_get_invoice_payment_link` (a live unauthenticated payment URL — treat as a credential; anyone who lifts it from a transcript or log can act on it), `ap_get_invoice_pdf_link`, `xero_reports_profit_and_loss` / `_balance_sheet` (one call discloses the company's complete financial position), `xero_reports_aged_receivables` (your customers' credit behaviour), and `list_warm_visitors` (third-party-sourced PII about people who never filled in a form — GDPR/CCPA lawful-basis question flagged before it reaches a CRM).

## Verification

- `node scripts/check-marketplace-drift.mjs --base origin/main` — **all 7 plugins pass the bump gate** (patch-bumped: hubspot 0.2.4, salesbuildr 1.1.5, kaseya-quote-manager 1.0.5, pandadoc 0.2.4, warmly 0.1.3, alternative-payments 1.0.4, xero 0.2.4). Marketplace entries carry no `version` field by design, so `marketplace.json` is correctly untouched.
- `claude plugin validate` — passes on all 7.

## Two things for the coordinator

1. **Pre-existing base-branch failure, not from this PR.** The drift check reports `plugin "huntress" changed without a plugin.json version bump (still 0.2.3)` — the exemplar commit on `feat/skill-anti-triggers-governance` (`64389eb`) touched 4 huntress files without bumping. Every batch PR branched off that base inherits it. Not fixed here: `huntress` is outside this batch's hard scope, and fixing it once on the base branch clears all batch PRs at the same time rather than creating an N-way conflict.
2. **No `CHANGELOG.md` entry.** Following the precedent of the standards commit, which added the standard and exemplar without one — and because 8 parallel batches editing the same `## [Unreleased]` block would conflict on every merge. One consolidated entry for the whole quality pass is the right shape; happy to supply this batch's paragraph on request.
