### PR TITLE
feat(psa-incident): anti-triggers and governance docs for freshdesk, halopsa, pagerduty, rootly

### DIFF
--- a/msp-claude-plugins/freshdesk/freshdesk/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/freshdesk/freshdesk/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "freshdesk",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Freshdesk - cloud helpdesk/PSA ticketing for MSPs: tickets, conversations, contacts, companies, knowledge base, SLA policies, and business hours",
   "author": {
     "name": "WYRE AI"

--- a/msp-claude-plugins/freshdesk/freshdesk/GOVERNANCE.md
+++ b/msp-claude-plugins/freshdesk/freshdesk/GOVERNANCE.md
@@ -1,0 +1,115 @@
+# Freshdesk plugin — governance and safety model
+
+Unofficial. Community-built plugin for the Freshdesk API. Not affiliated
+with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches Freshdesk through the
+WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the helpdesk the
+operator is authorised for.
+
+- No Freshdesk API key or helpdesk domain is stored on the technician's
+  machine, in this repo, or in the model's context. The gateway holds the
+  `X-Freshdesk-Domain` and `X-Freshdesk-Api-Key` pair and translates it
+  into the upstream HTTP Basic `apikey:X` credential.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers
+  "who sent that reply to the customer". Freshdesk's own activity log
+  records only the API key's agent account, so without the gateway every
+  action looks like it came from one shared robot.
+- Revoking gateway access revokes Freshdesk access with it, immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change Freshdesk state. Safe for autonomous agents. | `freshdesk_status`, `freshdesk_navigate`, `freshdesk_tickets_list`, `freshdesk_tickets_get`, `freshdesk_tickets_search`, `freshdesk_tickets_list_conversations`, `freshdesk_contacts_list`, `freshdesk_contacts_get`, `freshdesk_contacts_search`, `freshdesk_contacts_autocomplete`, `freshdesk_companies_list`, `freshdesk_companies_get`, `freshdesk_companies_search`, `freshdesk_companies_autocomplete`, `freshdesk_agents_list`, `freshdesk_agents_get`, `freshdesk_agents_me`, `freshdesk_groups_list`, `freshdesk_groups_get`, `freshdesk_sla_list`, `freshdesk_business_hours_list`, `freshdesk_business_hours_get`, `freshdesk_canned_responses_list_folders`, `freshdesk_canned_responses_get_folder`, `freshdesk_canned_responses_list_responses`, `freshdesk_solutions_categories_list`, `freshdesk_solutions_categories_get`, `freshdesk_solutions_folders_list`, `freshdesk_solutions_folders_get`, `freshdesk_solutions_articles_list`, `freshdesk_solutions_articles_get` |
+| **Write** | Creates or modifies records. Reversible, but visible to the customer. | `freshdesk_tickets_create`, `freshdesk_tickets_update`, `freshdesk_tickets_add_note`, `freshdesk_tickets_update_conversation`, `freshdesk_contacts_create`, `freshdesk_contacts_update`, `freshdesk_contacts_restore`, `freshdesk_companies_create`, `freshdesk_companies_update`, `freshdesk_groups_create`, `freshdesk_groups_update`, `freshdesk_agents_update`, `freshdesk_solutions_categories_create`, `freshdesk_solutions_categories_update`, `freshdesk_solutions_folders_create`, `freshdesk_solutions_folders_update`, `freshdesk_solutions_articles_create`, `freshdesk_solutions_articles_update` |
+| **Destructive** | Emails a customer, deletes data, grants access, or changes billing. Requires explicit per-call human approval. | `freshdesk_tickets_reply`, `freshdesk_contacts_send_invite`, `freshdesk_contacts_merge`, `freshdesk_contacts_make_agent`, `freshdesk_agents_create`, `freshdesk_agents_delete`, `freshdesk_sla_create`, `freshdesk_sla_update`, `freshdesk_tickets_delete`, `freshdesk_tickets_delete_conversation`, `freshdesk_contacts_soft_delete`, `freshdesk_contacts_hard_delete`, `freshdesk_companies_delete`, `freshdesk_groups_delete`, `freshdesk_solutions_categories_delete`, `freshdesk_solutions_folders_delete`, `freshdesk_solutions_articles_delete` |
+
+Four of those destructive entries look like ordinary writes in the API and
+are worth justifying:
+
+- **`freshdesk_tickets_reply`** does not write a record — it sends an
+  email to the customer, from your helpdesk, in your company's name.
+  There is no unsend. Treat it exactly as you would treat letting an
+  agent send mail from a shared mailbox. `freshdesk_contacts_send_invite`
+  is the same hazard pointed at the customer portal.
+- **`freshdesk_contacts_merge`** re-points the ticket history of every
+  secondary contact at the primary and is not reversible through the API.
+  Merging the wrong pair silently rewrites who asked for what.
+- **`freshdesk_contacts_make_agent` and `freshdesk_agents_create`** each
+  consume a licensed seat, which changes your Freshdesk bill, and grant a
+  human access to every ticket in the account. That is an access grant,
+  not a profile edit.
+- **`freshdesk_sla_create` / `freshdesk_sla_update`** re-compute `due_by`
+  and `fr_due_by` across the live queue. A single policy edit can put
+  tickets into breach retrospectively and change what your SLA reports —
+  and any contractual credits derived from them — say.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.**
+
+- Read tools: allow. Triage sweeps, SLA-risk reporting, and requester
+  enrichment are the intended autonomous use.
+- Write tools: agent drafts the exact call, human approves, then it runs.
+- Destructive tools: require a named human approver per invocation. Do
+  not grant these to scheduled or unattended agents. In particular, an
+  unattended agent with `freshdesk_tickets_reply` is an unattended agent
+  that emails your customers.
+
+## What it cannot reach
+
+- Only the Freshdesk helpdesk domain mapped to the operator's gateway
+  identity. Freshdesk credentials are per-helpdesk; there is no
+  cross-account or reseller view, so one credential means one tenant.
+- The API key inherits the permissions of the agent it belongs to. A
+  restricted agent's key cannot see tickets outside its groups, and tools
+  will return 403 rather than partial data.
+- No filesystem, no shell, no other vendor's data.
+- No live event stream. Every tool is point-in-time; Freshdesk webhooks
+  and automations carry the push feed.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session
+  and are not persisted by this plugin.
+- Customer PII is the default payload here, not an edge case.
+  `freshdesk_contacts_*` returns names, email addresses, phone and mobile
+  numbers, and job titles. `freshdesk_companies_*` returns account
+  domains and commercial health/tier fields.
+- `freshdesk_tickets_get` with conversations, and
+  `freshdesk_tickets_list_conversations`, return the full customer
+  message thread. End users paste passwords, account numbers, and
+  screenshots into tickets; assume this content is sensitive regardless
+  of what the ticket is about.
+- `freshdesk_agents_*` returns your own staff's PII.
+- Restrict all of the above if your agents run unattended.
+
+## Known sharp edges
+
+- **Closing a ticket is a reporting event, not a state flag.** Setting
+  `status` to Resolved (4) or Closed (5) via `freshdesk_tickets_update`
+  stops the SLA clock and stamps the resolution timestamps that
+  attainment reports read as final. Reopening restores the ticket but not
+  the original measurement. Bulk-closing a stale queue will quietly
+  rewrite last month's numbers.
+- **Public notes are not private notes.** `freshdesk_tickets_add_note`
+  defaults matter: `private: false` publishes the note to the requester
+  in the portal. An agent that drops its internal reasoning into a note
+  without setting `private: true` has just shown the customer its
+  working.
+- **Publishing is a status field.** `freshdesk_solutions_articles_update`
+  can move an article from draft to published, putting content on the
+  public support portal. The tool name gives no hint that it does this.
+- **Search silently truncates.** Ticket and contact search cap at 30
+  results per page and 10 pages — 300 records total. An agent that
+  reasons over "all matching tickets" from an unnarrowed query is
+  reasoning over an arbitrary subset, with no error to signal it.
+- **Rate limits are per-minute and per-plan.** Long autonomous sweeps
+  degrade mid-task with 429s; honour `Retry-After` rather than retrying
+  tightly.

--- a/msp-claude-plugins/freshdesk/freshdesk/skills/contacts-companies/SKILL.md
+++ b/msp-claude-plugins/freshdesk/freshdesk/skills/contacts-companies/SKILL.md
@@ -24,6 +24,29 @@ is the foundation for account-level context, SLA association, and reporting.
 This skill covers contact and company operations through tools named
 `freshdesk_contacts_<action>` and `freshdesk_companies_<action>`.
 
+## Anti-triggers
+
+In Freshdesk a **contact** is a customer who raises tickets; an **agent**
+is your own helpdesk staff. `freshdesk_contacts_make_agent` crosses that
+line permanently — it consumes a licensed seat and grants access to every
+ticket in the account, so it is not a labelling change.
+
+- **Technician rosters and team capacity** — this skill only converts a
+  contact *into* an agent. For looking up who your technicians are and
+  which teams they sit in, the PSA carries the richer model; use
+  `halopsa-agents`.
+- **The same customer in another system** — a HaloPSA client, a
+  ConnectWise company, or an Autotask company is a different record with
+  different required fields; use `halopsa-clients`,
+  `connectwise-manage-companies`, or `autotask-crm`. Do not
+  assume IDs or domains map across.
+- **Assets, sites, or contracts belonging to the customer** — Freshdesk
+  companies carry no CMDB or billing model; use `halopsa-assets` and
+  `halopsa-contracts`.
+- **Anything about the customer's tickets** — listing, replying, or
+  triaging is `freshdesk-ticketing`; this skill resolves who the
+  requester is.
+
 ## Contacts
 
 ### Key Contact Fields

--- a/msp-claude-plugins/freshdesk/freshdesk/skills/knowledge-base/SKILL.md
+++ b/msp-claude-plugins/freshdesk/freshdesk/skills/knowledge-base/SKILL.md
@@ -23,6 +23,23 @@ questions and speeds resolution. This skill covers navigating the hierarchy,
 reading and searching articles, and suggesting articles for tickets through
 tools named `freshdesk_solutions_<action>`.
 
+## Anti-triggers
+
+Freshdesk Solutions is a **customer-facing** knowledge base published to
+the support portal. Writing internal MSP documentation here exposes it to
+customers.
+
+- **Internal runbooks, network diagrams, and client documentation** —
+  those belong in an MSP documentation platform; use `hudu-articles` or
+  `it-glue-documents`. Never draft an internal procedure into a
+  Solutions article.
+- **Credentials or secrets referenced by a procedure** — use
+  `hudu-passwords` or `it-glue-passwords`; nothing in the
+  Solutions hierarchy is a safe place for them.
+- **Attaching the article to a ticket or replying with it** — ticket
+  replies and notes are `freshdesk-ticketing`; this skill finds the
+  article, it does not send it.
+
 ## The Three-Level Hierarchy
 
 ```

--- a/msp-claude-plugins/freshdesk/freshdesk/skills/sla-business-hours/SKILL.md
+++ b/msp-claude-plugins/freshdesk/freshdesk/skills/sla-business-hours/SKILL.md
@@ -23,6 +23,26 @@ Together they compute each ticket's `fr_due_by` (first-response deadline) and
 calendars and reasoning about deadlines and breaches through tools named
 `freshdesk_sla_policies_list` and `freshdesk_business_hours_list`.
 
+## Anti-triggers
+
+A Freshdesk SLA policy is helpdesk configuration that computes ticket
+deadlines. It is not the commercial SLA in a signed agreement, and not an
+on-call response target.
+
+- **The SLA a contract commits you to** — coverage hours, response
+  credits, and the agreement the customer signed are `halopsa-contracts`
+  or `autotask-contracts`. Freshdesk's policy is how the
+  helpdesk approximates that commitment; the two can legitimately
+  disagree.
+- **MTTA/MTTR for on-call responders** — those measure how fast a page
+  was answered, not helpdesk SLA attainment; use `pagerduty-analytics`.
+- **Escalation rotas and who is on-call after hours** — coverage windows
+  here only pause a clock; they do not page anyone. Use
+  `pagerduty-oncall`.
+- **Acting on a breached ticket** — re-prioritising, reassigning, or
+  replying is `freshdesk-ticketing`; this skill explains the deadline,
+  it does not change it.
+
 ## SLA Policies
 
 ### List SLA Policies

--- a/msp-claude-plugins/freshdesk/freshdesk/skills/ticketing/SKILL.md
+++ b/msp-claude-plugins/freshdesk/freshdesk/skills/ticketing/SKILL.md
@@ -23,6 +23,30 @@ covers listing, getting, searching, creating, updating, replying, adding
 notes, and reading conversation threads via the Freshdesk REST API v2,
 surfaced through tools named `freshdesk_tickets_<action>`.
 
+## Anti-triggers
+
+A Freshdesk ticket may carry `type: "Incident"`, which collides with two
+other meanings of the word. The routing test is what the operator does
+next: answer a customer under an SLA clock (this skill), page a
+responder, or approve a remediation on a compromised endpoint.
+
+- **An on-call service incident** — something is broken and a human must
+  be woken up; the deliverable is acknowledgement and restoration, not a
+  customer reply. Use `pagerduty-incidents` or `rootly-incidents`.
+- **A confirmed security incident** — malware or intrusion with a
+  remediation to approve. Use `huntress-incidents`, or
+  `sentinelone-alerts` for raw EDR detections. Never draft a customer
+  reply about containment from this skill's data alone.
+- **Tickets in another helpdesk or PSA** — the vocabulary is nearly
+  identical but the field models are not (Freshdesk encodes status and
+  priority as integers; the PSAs use instance-configurable IDs). Use
+  `halopsa-tickets`, `connectwise-manage-tickets`, or `autotask-tickets`.
+- **Why `due_by` or `fr_due_by` has the value it does** — deadline
+  computation, business-hours calendars, and breach detection are
+  `freshdesk-sla-business-hours`; this skill only reads the timestamps.
+- **Resolving the requester to a person or company** — contact lookup,
+  creation, and merge are `freshdesk-contacts-companies`.
+
 ## Status, Priority & Source Encodings
 
 Freshdesk encodes these fields as integers in both the API payloads and the

--- a/msp-claude-plugins/halopsa/halopsa/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/halopsa/halopsa/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "halopsa",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Claude Code plugin for HaloPSA - tickets, clients, assets, contracts",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/halopsa/halopsa/GOVERNANCE.md
+++ b/msp-claude-plugins/halopsa/halopsa/GOVERNANCE.md
@@ -1,0 +1,118 @@
+# HaloPSA plugin — governance and safety model
+
+Unofficial. Community-built plugin for the HaloPSA API. Not affiliated
+with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches HaloPSA through the
+WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the instance the
+operator is authorised for.
+
+- No HaloPSA client ID, client secret, or access token is stored on the
+  technician's machine, in this repo, or in the model's context. HaloPSA
+  uses OAuth 2.0 client credentials; the gateway runs that exchange and
+  holds the refreshing token.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers
+  "who billed that time" and "who emailed the client". HaloPSA's own
+  audit records only the API application, so without the gateway every
+  action is attributed to one integration user.
+- Revoking gateway access revokes HaloPSA access with it, immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change HaloPSA state. Safe for autonomous agents. | `halopsa_status`, `halopsa_navigate`, `halopsa_tickets_list`, `halopsa_tickets_get`, `halopsa_clients_list`, `halopsa_clients_get`, `halopsa_clients_search`, `halopsa_assets_list`, `halopsa_assets_get`, `halopsa_assets_search`, `halopsa_assets_list_types`, `halopsa_agents_list`, `halopsa_agents_get`, `halopsa_teams_list`, `halopsa_invoices_list`, `halopsa_invoices_get` |
+| **Write** | Creates or modifies records. Reversible, but visible to the client. | `halopsa_tickets_create`, `halopsa_tickets_update`, `halopsa_clients_create` |
+| **Destructive** | Emails the client or posts billable time. Requires explicit per-call human approval. | `halopsa_tickets_add_action` |
+
+There are no delete tools in this plugin. Nothing here can remove a
+ticket, client, asset, contract, or invoice.
+
+`halopsa_tickets_add_action` sits in the destructive tier deliberately,
+because the API calls it an "add" and it does two irreversible things
+depending on the payload:
+
+- With `hiddenfromuser: false` and an `emailto` address, it sends mail to
+  the client from your service desk. There is no unsend.
+- With `timetaken` and `charge: true`, it posts billable time against the
+  ticket's contract. That time flows into the next invoice run, deducts
+  from a prepaid-hours balance, and is corrected by a human in the
+  billing UI, not by another API call.
+
+An agent that adds actions unattended is an agent that can bill your
+clients and write to them in your name.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.**
+
+- Read tools: allow. Queue triage, SLA-risk reporting, asset lookups, and
+  invoice reconciliation are the intended autonomous use.
+- Write tools: agent drafts the exact call, human approves, then it runs.
+- Destructive tools: require a named human approver per invocation. Do
+  not grant `halopsa_tickets_add_action` to scheduled or unattended
+  agents.
+
+## What it cannot reach
+
+- Only the HaloPSA instance mapped to the operator's gateway identity.
+  Halo is single-tenant per instance; there is no cross-instance or
+  reseller view.
+- The OAuth client's granted scopes bound everything. A client
+  provisioned without ticket write scope will return 401/403 on the write
+  tools rather than partial success.
+- **No write path to money or coverage.** Invoices are read-only, and
+  there are no contract tools at all. An agent cannot raise, edit, send,
+  or credit an invoice, and cannot alter a service agreement, its rates,
+  or its prepaid-hour balance. Those changes happen in the HaloPSA UI.
+- **No write path to the CMDB.** Assets are read-only; an agent cannot
+  create, retire, or re-assign a configuration item.
+- No filesystem, no shell, no other vendor's data.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session
+  and are not persisted by this plugin.
+- Customer PII is the default payload. `halopsa_clients_*` returns client
+  contact and billing details and the end-user ("Users") records beneath
+  them. `halopsa_tickets_get` returns ticket details and action notes,
+  where end users routinely paste credentials, account numbers, and
+  personal information.
+- `halopsa_invoices_*` returns commercial data — line items, values, and
+  payment status for your clients.
+- `halopsa_agents_*` returns your own staff's PII.
+- `halopsa_assets_*` returns customer infrastructure detail: hostnames,
+  serial numbers, and site placement. Useful to an attacker mapping a
+  target.
+- Restrict all of the above if your agents run unattended.
+
+## Known sharp edges
+
+- **Closing a ticket is a contractual event, not a status flag.**
+  `halopsa_tickets_update` is the only way to move a ticket to Resolved
+  or Closed, which stops the SLA clock, stamps the attainment numbers
+  your client reports read, and in most configurations fires the
+  satisfaction-survey email. It sits in the Write tier because it is also
+  how you set a priority or assign an agent — but if you bill against SLA
+  attainment, gate it at the destructive tier instead. A bulk close of a
+  stale queue rewrites last month's numbers and mails every affected
+  client.
+- **Writes are array-wrapped.** Every create and update posts
+  `[{...}]`, not `{...}`. An agent that sends a bare object gets a
+  validation error whose message does not mention the array.
+- **An update is a create with an `id`.** Both go to `POST /api/Tickets`.
+  Omitting `id` on what was meant as an update silently creates a second
+  ticket rather than failing.
+- **Status and priority IDs are instance-specific.** The values in this
+  plugin's examples are conventions, not constants. An agent that
+  hardcodes `status_id: 8` for "Resolved" will set the wrong status on an
+  instance that renumbered its statuses, with no error.
+- **The asset record is not the device.** HaloPSA holds what you believe
+  is deployed and what it is billed under. Live health and patch state
+  live in the RMM, and the two drift. Do not let an agent act on Halo
+  asset data as though it were current.

--- a/msp-claude-plugins/halopsa/halopsa/skills/agents/SKILL.md
+++ b/msp-claude-plugins/halopsa/halopsa/skills/agents/SKILL.md
@@ -17,6 +17,22 @@ when_to_use: >-
 
 Agents in HaloPSA are the technicians who handle tickets and service delivery. Teams are groupings of agents that tickets can be assigned to. Use these tools to discover agent IDs and team structures before assigning tickets or filtering work queues.
 
+## Anti-triggers
+
+"Agent" is the most overloaded word in this marketplace. Here it means a
+human technician.
+
+- **Claude subagents** — definitions under `agents/*.md` are plugin
+  authoring, not HaloPSA records. Nothing here configures Claude.
+- **Endpoint software agents** — the sensor installed on a customer
+  device is `huntress-agents` or the RMM's device skills such as
+  `datto-rmm-devices`. A HaloPSA agent is never installed on anything.
+- **Client-side people** — end users who raise tickets are HaloPSA
+  *Users* under a client, a different entity entirely; use
+  `halopsa-clients`.
+- **Assigning or reassigning a ticket** — this skill resolves the
+  `agent_id`; performing the assignment is `halopsa-tickets`.
+
 ## API Patterns
 
 ### List Agents

--- a/msp-claude-plugins/halopsa/halopsa/skills/assets/SKILL.md
+++ b/msp-claude-plugins/halopsa/halopsa/skills/assets/SKILL.md
@@ -18,6 +18,25 @@ when_to_use: >-
 
 Assets (also called Configuration Items or CIs) in HaloPSA represent managed devices, software, and other trackable items. Effective asset management is crucial for MSPs to track what's deployed at client sites, manage hardware lifecycle, and link service tickets to affected equipment.
 
+## Anti-triggers
+
+A HaloPSA asset is the PSA's **record** of a device — what you believe is
+deployed, and what it is billed and contracted under. It is not the
+device's live state.
+
+- **Whether the machine is online, patched, or healthy right now** — that
+  is the RMM's answer, not the PSA's; use `datto-rmm-devices` or the
+  equivalent device skill for your RMM. The two routinely disagree, and
+  the PSA is the one that goes stale.
+- **Warranty dates and hardware lifecycle reporting** — use
+  `scalepad-lifecycle-manager`; Halo's warranty fields are a local copy
+  that drifts.
+- **Documentation about the asset** — runbooks, diagrams, and
+  configuration notes are `hudu-assets` or `it-glue-configurations`.
+- **What the asset costs or is covered by** — contract coverage and
+  billing are `halopsa-contracts`; the client and site it belongs to are
+  `halopsa-clients`.
+
 ## Key Concepts
 
 An asset is always owned by a client and optionally placed at a site, assigned to a

--- a/msp-claude-plugins/halopsa/halopsa/skills/clients/SKILL.md
+++ b/msp-claude-plugins/halopsa/halopsa/skills/clients/SKILL.md
@@ -18,6 +18,26 @@ when_to_use: >-
 
 Clients (customers) are the foundation of HaloPSA. All tickets, contracts, assets, and invoices are associated with clients. Proper client data management is critical for accurate service delivery and billing.
 
+## Anti-triggers
+
+HaloPSA calls end-user contacts **Users**. That word does not mean a
+HaloPSA login, and it does not mean a technician.
+
+- **Your own technicians and teams** — those are agents, a separate
+  entity with its own IDs; use `halopsa-agents`. Assigning a ticket needs
+  an `agent_id`, never a `user_id`.
+- **The same customer in another system** — a Freshdesk company, a
+  ConnectWise company, or an Autotask company is a different record with
+  different required fields; use `freshdesk-contacts-companies`,
+  `connectwise-manage-companies`, or `autotask-crm`. Do not assume IDs or
+  domains map across.
+- **Microsoft 365 or Entra user accounts** — mailbox, licence, and
+  identity questions are `cipp-users` or `cipp-mailboxes`; a HaloPSA User
+  is a CRM contact record with no directory presence.
+- **What the client is entitled to** — coverage, rates, and prepaid hours
+  are `halopsa-contracts`; what they have been billed is
+  `halopsa-invoices`.
+
 ## Key Concepts
 
 Three linked entities make up the CRM layer:

--- a/msp-claude-plugins/halopsa/halopsa/skills/contracts/SKILL.md
+++ b/msp-claude-plugins/halopsa/halopsa/skills/contracts/SKILL.md
@@ -18,6 +18,23 @@ when_to_use: >-
 
 Contracts in HaloPSA define the service relationship with clients - what services you provide, how you bill for them, and what service levels apply. Contracts control how time, expenses, and recurring charges flow to invoices and are critical for MSP financial management.
 
+## Anti-triggers
+
+A HaloPSA contract is the commercial agreement — coverage, rates, and the
+SLA you committed to. It is not the helpdesk configuration that computes
+a deadline, and it is not the bill.
+
+- **How a ticket's due date was calculated** — SLA policies and
+  business-hours calendars in the helpdesk are
+  `freshdesk-sla-business-hours`; the contract states the commitment, the
+  helpdesk approximates it, and the two can legitimately disagree.
+- **What has actually been billed** — issued invoices and payment status
+  are `halopsa-invoices` (read-only) and `xero-invoices` for the books.
+- **Contracts in another PSA** — the type taxonomy and prepaid-hour model
+  differ materially; use `autotask-contracts`.
+- **Which assets a contract covers** — asset records and their contract
+  links are `halopsa-assets`.
+
 ## Key Concepts
 
 ### Contract Types

--- a/msp-claude-plugins/halopsa/halopsa/skills/invoices/SKILL.md
+++ b/msp-claude-plugins/halopsa/halopsa/skills/invoices/SKILL.md
@@ -18,6 +18,23 @@ when_to_use: >-
 
 HaloPSA invoices represent bills generated for client work and contracts. Use these tools to view invoice status, track payment, and pull invoice data for reporting or reconciliation. Invoices are read-only via MCP; creation and dispatch happen through the HaloPSA UI or billing workflows.
 
+## Anti-triggers
+
+This surface is read-only. There is no tool here that raises, edits,
+sends, or credits an invoice — a request to do any of those cannot be
+satisfied by this skill.
+
+- **Raising, sending, or crediting an invoice** — no MCP tool exists;
+  route the operator to the HaloPSA UI rather than improvising a write.
+- **Payments, ledgers, and reconciliation in the accounting system** —
+  the invoice of record for the books lives there; use `xero-invoices`
+  and `xero-payments`.
+- **Why an invoice says what it says** — recurring charges, prepaid-hour
+  deduction, and billing frequency are configured on the agreement; use
+  `halopsa-contracts`.
+- **The billable time behind a line** — time entries are logged as ticket
+  actions; use `halopsa-tickets`.
+
 ## API Patterns
 
 ### List Invoices

--- a/msp-claude-plugins/halopsa/halopsa/skills/tickets/SKILL.md
+++ b/msp-claude-plugins/halopsa/halopsa/skills/tickets/SKILL.md
@@ -13,6 +13,31 @@ when_to_use: >-
 
 Tickets are the core unit of service delivery in HaloPSA. The API uses array-wrapped payloads for all write operations (`POST /api/Tickets` with `[{...}]`). Status, priority, and ticket type IDs are instance-configurable -- always query `/api/Status`, `/api/Priority`, and `/api/TicketType` to get valid values.
 
+## Anti-triggers
+
+A HaloPSA ticket type is often named "Incident", which collides with two
+other meanings of the word. The routing test is what the operator does
+next: answer a client under an SLA clock and bill the time (this skill),
+page a responder, or approve a remediation on a compromised endpoint.
+
+- **An on-call service incident** — something is broken and a human must
+  be woken up; the deliverable is acknowledgement and restoration, not a
+  client-visible action and a time entry. Use `pagerduty-incidents` or
+  `rootly-incidents`.
+- **A confirmed security incident** — malware or intrusion with a
+  remediation to approve. Use `huntress-incidents`, or
+  `sentinelone-alerts` for raw EDR detections.
+- **Tickets in another PSA or helpdesk** — the vocabulary is nearly
+  identical but the field models are not (Halo wraps every write in an
+  array and uses instance-configurable status IDs). Use
+  `freshdesk-ticketing`, `connectwise-manage-tickets`, or `autotask-tickets`.
+- **Whether the work is covered and at what rate** — contract type,
+  prepaid-hour balances, and the SLA attached to the agreement are
+  `halopsa-contracts`; this skill only reads the resulting SLA fields on
+  the ticket.
+- **The device the ticket is about** — asset and CI records are
+  `halopsa-assets`; the client, site, or end user are `halopsa-clients`.
+
 ## Core API Operations
 
 ### Create Ticket

--- a/msp-claude-plugins/pagerduty/pagerduty/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/pagerduty/pagerduty/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pagerduty",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Claude plugins for PagerDuty - incident management, on-call scheduling, service health monitoring, alert management, and analytics for MSPs",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/pagerduty/pagerduty/GOVERNANCE.md
+++ b/msp-claude-plugins/pagerduty/pagerduty/GOVERNANCE.md
@@ -1,0 +1,132 @@
+# PagerDuty plugin — governance and safety model
+
+Unofficial. Community-built plugin for the PagerDuty API. Not affiliated
+with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches PagerDuty through the
+WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the account the
+operator is authorised for. Upstream, the gateway fronts PagerDuty's own
+hosted MCP server (`mcp.pagerduty.com`, or `mcp.eu.pagerduty.com` for EU
+accounts) and its 66 generated tools.
+
+- No PagerDuty API token is stored on the technician's machine, in this
+  repo, or in the model's context. The gateway holds it and forwards
+  `Authorization: Token token=<key>` on every call.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers
+  "who paged the on-call at 3am". PagerDuty's own log attributes actions
+  to the token's user, so a shared General Access Token makes every
+  action anonymous.
+- Revoking gateway access revokes PagerDuty access with it, immediately.
+
+## Tool permission tiers
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change PagerDuty state or notify anyone. Safe for autonomous agents. | `list_incidents`, `get_incident`, `list_incident_alerts`, `list_incident_notes`, `list_incident_log_entries`, `list_past_incidents`, `get_incident_field_values`, `list_oncalls`, `list_schedules`, `get_schedule`, `list_schedule_overrides`, `list_escalation_policies`, `get_escalation_policy`, `list_services`, `get_service`, `list_event_orchestrations`, `get_event_orchestration`, `get_global_orchestration_rules`, `get_service_orchestration_rules`, `get_event_orchestration_active_status`, `list_status_pages`, `get_status_page`, `list_status_page_posts`, `list_status_page_post_updates`, `list_teams`, `get_team`, `list_team_members`, `list_users`, `get_user`, `get_alert_grouping_settings`, `list_intelligent_alert_grouping_settings`, `list_incident_workflows`, `get_incident_workflow`, `list_incident_workflow_instances`, `list_change_events`, `get_change_event`, `list_log_entries`, `get_log_entry` |
+| **Write** | Changes PagerDuty-side records. Reversible, visible to responders. | `update_incident`, `create_incident_note`, `snooze_incident`, `set_incident_field_values`, `create_service`, `update_service`, `update_change_event`, `create_schedule`, `update_schedule`, `create_team`, `update_team`, `add_team_member`, `update_alert_grouping_settings`, `create_intelligent_alert_grouping_settings`, `update_intelligent_alert_grouping_settings` |
+| **Destructive** | Wakes a human, publishes to customers, or silently removes paging coverage. Requires explicit per-call human approval. | `create_incident`, `merge_incidents`, `manage_incidents`, `delete_schedule`, `delete_team`, `update_global_orchestration_rules`, `update_service_orchestration_rules`, `create_status_page_post`, `update_status_page_post`, `create_status_page_post_update`, `delete_status_page_post` |
+
+Most of that destructive tier is classified by blast radius, not by HTTP
+verb. The four groups worth justifying:
+
+- **`create_incident` rings a phone.** The API calls it a create; what it
+  actually does is start an escalation policy. On a high-urgency service
+  that means a phone call and SMS to whoever is on-call, at whatever hour
+  it is for them, escalating up the tiers until somebody acknowledges.
+  There is no undo for a person who has been woken up. This is the single
+  most consequential tool in the plugin and the one most likely to be
+  mistaken for routine.
+- **`merge_incidents` and `manage_incidents` cannot be walked back.**
+  PagerDuty has no unmerge: merging moves alerts and log entries into the
+  target permanently and auto-resolves the sources. `manage_incidents`
+  applies a status change across many incidents at once, so a bulk
+  resolve ends the escalation clock on incidents nobody actually looked
+  at — the failure is silent and looks like a tidy queue.
+- **Orchestration rules decide what gets paged at all.**
+  `update_global_orchestration_rules` and
+  `update_service_orchestration_rules` sit upstream of every incident. A
+  bad suppression rule stops production alerts from ever becoming
+  incidents. Nobody is paged, nothing errors, and the gap is discovered
+  during the next outage. `delete_schedule` and `delete_team` produce the
+  same silent gap from the other end: an escalation policy tier pointing
+  at a deleted schedule pages nobody.
+- **Status page posts are customer communications.** The status page is
+  public and its subscribers are notified by email and SMS on publish.
+  You cannot unsend that, and customers screenshot status pages. Deleting
+  the post afterwards removes the page, not the notification.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.**
+
+- Read tools: allow. Triage sweeps, on-call rota checks, escalation
+  coverage audits, and MTTA/MTTR reporting are the intended autonomous
+  use.
+- Write tools: agent drafts the exact call, human approves, then it runs.
+- Destructive tools: require a named human approver per invocation. Do
+  not grant these to scheduled or unattended agents. An unattended agent
+  holding `create_incident` is an unattended agent that can page your
+  staff overnight; one holding the status page tools can publish an
+  outage notice to your customers.
+
+## What it cannot reach
+
+- Only the PagerDuty account mapped to the operator's gateway identity.
+  PagerDuty has no reseller or cross-account view, so one credential
+  means one account. MSPs running per-customer PagerDuty accounts need
+  one gateway credential per account.
+- The token's own permissions bound everything. A User API Token carries
+  that user's role; several tools require Account Owner and will return
+  403 otherwise.
+- **No event-send path.** The Events API v2
+  (`events.pagerduty.com/v2/enqueue`) is not exposed as a tool. An agent
+  cannot inject a synthetic trigger, acknowledge, or resolve event into a
+  monitoring integration; that stays with your monitoring tools.
+- **No schedule override tool.** Overrides can be listed but not created
+  through this surface; adding coverage for a gap is a UI or direct-API
+  action.
+- No filesystem, no shell, no other vendor's data.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session
+  and are not persisted by this plugin.
+- `list_users` / `get_user` return responder contact methods — personal
+  mobile numbers, personal email addresses, and push device
+  registrations. This is your staff's home contact detail. Restrict these
+  if your agents run unattended.
+- `get_incident` and `list_incident_alerts` return whatever the
+  monitoring integration put in `body.details` and `custom_details`:
+  hostnames, internal IPs, database identifiers, and stack traces that
+  sometimes carry secrets. Treat incident bodies as infrastructure
+  disclosure.
+- `list_incident_log_entries` and `list_log_entries` reconstruct who was
+  notified, when, and on which channel — an activity record of your
+  staff.
+
+## Known sharp edges
+
+- **Urgency, not priority, decides whether someone is woken.** `high`
+  urgency means phone and SMS; `low` means email only. Priority (P1–P5)
+  is a business label with no notification behaviour. An agent
+  "escalating" a P-value changes reporting; an agent changing urgency
+  changes whose phone rings.
+- **Acknowledging pauses the escalation clock.** An agent that
+  acknowledges an incident it cannot actually resolve has stopped the
+  incident from reaching the human who could. Acknowledgement is a
+  commitment to work it, not a read receipt.
+- **Snooze hides an active incident.** `snooze_incident` removes it from
+  the triage view for the duration with no further notification. On a
+  real outage that is indistinguishable from ignoring it.
+- **Resolving an incident resolves all its alerts.** The reverse is not
+  true. An agent resolving alerts one at a time will not close the
+  incident and may conclude the API is broken.
+- **Rate limits degrade long sweeps.** 900 requests per minute across the
+  account; a wide unbounded incident query on a large account will hit it
+  and return 429 mid-task. Scope with `since`/`until` and
+  `service_ids[]`.

--- a/msp-claude-plugins/pagerduty/pagerduty/skills/alerts/SKILL.md
+++ b/msp-claude-plugins/pagerduty/pagerduty/skills/alerts/SKILL.md
@@ -17,6 +17,22 @@ when_to_use: >-
 
 Alerts are the raw signals from monitoring tools that flow into PagerDuty. When an alert is received, PagerDuty creates or updates an incident based on the service's alert grouping configuration. Multiple alerts can be grouped into a single incident to reduce noise. Alerts can also be suppressed via event rules to prevent unnecessary notifications.
 
+## Anti-triggers
+
+- **The work item responders act on** — an alert is the signal; the
+  incident is the object with a status, an assignee, and an escalation
+  clock. Triage, acknowledgement, and resolution are
+  `pagerduty-incidents`.
+- **Alerts raised by another product** — "alert" is one of the most
+  overloaded words in the MSP stack. RMM device alerts are
+  `datto-rmm-alerts`; network alerts are `auvik-alerts`; EDR detections
+  are `sentinelone-alerts`; Rootly's alert-routing layer is
+  `rootly-alerts`. This skill only speaks the PagerDuty event model.
+- **Where an alert lands and who owns it** — the service, its
+  integration keys, and its escalation policy are `pagerduty-services`.
+- **How many alerts fired and how fast they were handled** — volume,
+  noise ratios, and MTTA/MTTR are `pagerduty-analytics`.
+
 ## Key Concepts
 
 ### Alert vs. Incident

--- a/msp-claude-plugins/pagerduty/pagerduty/skills/analytics/SKILL.md
+++ b/msp-claude-plugins/pagerduty/pagerduty/skills/analytics/SKILL.md
@@ -18,6 +18,21 @@ when_to_use: >-
 
 PagerDuty Analytics provides data-driven insights into incident response performance. Key metrics include Mean Time to Acknowledge (MTTA), Mean Time to Resolve (MTTR), incident frequency, and responder workload. These metrics help MSPs identify operational bottlenecks, measure SLA compliance, and demonstrate value to clients.
 
+## Anti-triggers
+
+MTTA and MTTR measure how fast responders reacted to a page. They are not
+the same number as contractual SLA attainment on customer tickets, and
+reporting one as the other misstates compliance to a client.
+
+- **SLA attainment against a customer agreement** — first-response and
+  resolution targets, business-hours clocks, and breach counts are
+  `freshdesk-sla-business-hours` or `halopsa-contracts`.
+- **Ticket volume, backlog, or technician utilisation** — those come from
+  the PSA, not PagerDuty; use `halopsa-tickets` or
+  `connectwise-manage-tickets`.
+- **Per-shift incident load and burnout risk** — Rootly models on-call
+  health directly; use `rootly-oncall`.
+
 ## Key Concepts
 
 ### Core Metrics

--- a/msp-claude-plugins/pagerduty/pagerduty/skills/incidents/SKILL.md
+++ b/msp-claude-plugins/pagerduty/pagerduty/skills/incidents/SKILL.md
@@ -21,6 +21,30 @@ Incidents are the core resource in PagerDuty — created automatically from aler
 
 PagerDuty has 14 MCP tools for incident management — more than any other domain.
 
+## Anti-triggers
+
+"Incident" names three different objects across this marketplace, and the
+routing test is what the operator does next: page a responder (this
+skill), approve a remediation on a compromised endpoint, or answer a
+customer under an SLA clock.
+
+- **A confirmed security incident** — malware, intrusion, a host to
+  contain. That object carries a SOC-recommended remediation to approve,
+  not a responder to page; use `huntress-incidents`, or
+  `sentinelone-alerts` for raw EDR detections.
+- **A customer ticket typed "Incident"** — ITIL ticket classification
+  inside a PSA or helpdesk, where the deliverable is an SLA-timed
+  response and a billable time entry rather than a page; use
+  `freshdesk-ticketing`, `halopsa-tickets`, `connectwise-manage-tickets`,
+  or `autotask-tickets`.
+- **A Rootly incident** — a different vendor with a different lifecycle
+  (`detected → in_triage → mitigated → resolved → closed`, not
+  `triggered → acknowledged → resolved`); use `rootly-incidents`.
+- **Who would be paged, rather than what fired** — schedules, escalation
+  policies, and overrides are `pagerduty-oncall`.
+- **The raw monitoring signal itself** — dedup keys, grouping modes, and
+  Events API payloads are `pagerduty-alerts`.
+
 ## MCP Tools
 
 ### Core Incident Tools

--- a/msp-claude-plugins/pagerduty/pagerduty/skills/oncall/SKILL.md
+++ b/msp-claude-plugins/pagerduty/pagerduty/skills/oncall/SKILL.md
@@ -19,6 +19,22 @@ when_to_use: >-
 
 PagerDuty's on-call system manages who receives pages for each service. Schedules define rotation layers (who is on-call when), and escalation policies define what happens if a page isn't acknowledged (Tier 1 → Tier 2 → Tier 3). For MSPs, PagerDuty on-call management typically covers internal SRE/IT rotations and can be configured per-customer if using multi-account setups.
 
+## Anti-triggers
+
+- **When the SLA clock runs against a customer** — business-hours
+  calendars and coverage windows in a helpdesk or PSA are a billing and
+  contractual construct, unrelated to who gets woken up. Use
+  `freshdesk-sla-business-hours` or `halopsa-contracts`.
+- **Escalating a ticket** — raising a PSA ticket's priority or moving it
+  to another queue is `freshdesk-ticketing` or `halopsa-tickets`;
+  escalation here means a page climbing tiers because nobody
+  acknowledged.
+- **Reviewing shift load or burnout risk** — Rootly analyses on-call
+  health and handoffs but does not author schedules; use `rootly-oncall`.
+- **Responder workload metrics and off-hours interruption counts** —
+  those are `pagerduty-analytics`; this skill covers coverage, not
+  measurement.
+
 ## MCP Tools
 
 ### On-Call & Schedule Tools

--- a/msp-claude-plugins/pagerduty/pagerduty/skills/services/SKILL.md
+++ b/msp-claude-plugins/pagerduty/pagerduty/skills/services/SKILL.md
@@ -17,6 +17,24 @@ when_to_use: >-
 
 Services in PagerDuty represent the applications, components, or infrastructure that your team is responsible for. Each service has an escalation policy, integrations (event sources), and configuration for how incidents are created and grouped. Services are the primary organizational unit for routing alerts to the right responders.
 
+## Anti-triggers
+
+A PagerDuty service is a technical component with an escalation policy
+attached. It is not a commercial service, and not a service ticket.
+
+- **A managed service you sell and bill for** — service lines, coverage
+  scope, and rates live in the contract; use `halopsa-contracts` or
+  `autotask-contracts`.
+- **A service request from a customer** — that is a ticket type in a
+  helpdesk or PSA; use `freshdesk-ticketing`, `halopsa-tickets`, or
+  `connectwise-manage-tickets`.
+- **Rootly's service catalog** — a different vendor's model, with tiers
+  and ownership metadata rather than integration keys; use
+  `rootly-services`.
+- **A maintenance window's effect on customer SLA** — suppressing alerts
+  here does not pause a PSA's SLA clock; use
+  `freshdesk-sla-business-hours` or `halopsa-contracts` for that side.
+
 ## Key Concepts
 
 ### Service Status

--- a/msp-claude-plugins/rootly/rootly/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/rootly/rootly/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rootly",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Claude plugins for Rootly - incident management, response automation, postmortems, service catalog, alert routing, and workflow orchestration",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/rootly/rootly/GOVERNANCE.md
+++ b/msp-claude-plugins/rootly/rootly/GOVERNANCE.md
@@ -1,0 +1,128 @@
+# Rootly plugin — governance and safety model
+
+Unofficial. Community-built plugin for the Rootly API. Not affiliated
+with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches Rootly through the
+WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the organisation the
+operator is authorised for.
+
+- No Rootly API token is stored on the technician's machine, in this
+  repo, or in the model's context. The gateway holds it and forwards
+  `Authorization: Bearer <token>` on every call.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers
+  "who declared that incident". Rootly's own log attributes actions to
+  the token, so a shared Global token makes every declaration anonymous.
+- Revoking gateway access revokes Rootly access with it, immediately.
+
+## Tool permission tiers
+
+The tool names below are the ones the gateway actually serves. Note that
+several of this plugin's skills document the wider Rootly REST API,
+including postmortem, action-item, workflow, and service-catalog
+endpoints that are **not** exposed as tools — see "What it cannot reach".
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change Rootly state or notify anyone. Safe for autonomous agents. | `rootly_status`, `rootly_navigate`, `rootly_back`, `rootly_incidents_list`, `rootly_incidents_get`, `rootly_alerts_list`, `rootly_schedules_list`, `rootly_schedules_get`, `rootly_org_teams_list`, `rootly_org_teams_get`, `rootly_org_severities_list`, `rootly_org_current_user` |
+| **Write** | Changes Rootly-side records. Reversible, visible to responders. | `rootly_incidents_update`, `rootly_alerts_update`, `rootly_alerts_acknowledge`, `rootly_org_teams_create`, `rootly_org_teams_update`, `rootly_org_teams_patch` |
+| **Destructive** | Wakes a human, fires customer-visible automation, or ends an escalation. Requires explicit per-call human approval. | `rootly_incidents_create`, `rootly_alerts_create`, `rootly_incidents_resolve`, `rootly_alerts_resolve`, `rootly_org_teams_delete` |
+
+None of those destructive entries deletes data except the last. They are
+classified by blast radius:
+
+- **`rootly_incidents_create` is not a record write, it is a trigger.**
+  Declaring an incident fires every workflow whose conditions match, and
+  Rootly workflow actions include paging the on-call via
+  PagerDuty/Opsgenie, creating a Slack channel and inviting responders,
+  opening a Jira ticket, posting to a public status page, and sending
+  email. One create can wake a person at 3am *and* tell your customers
+  you have an outage. `rootly_alerts_create` reaches the same paging
+  machinery through routing rules.
+- **`rootly_incidents_resolve` stamps the number everyone reports on.**
+  `resolved_at` is what MTTR and reliability reporting read, and
+  resolution fires the `status_changed` workflows — commonly the
+  postmortem and the customer "all clear". Reopening restores the
+  incident but not the original measurement or the messages already sent.
+- **`rootly_alerts_resolve` silently ends an escalation.** Resolving an
+  alert nobody actually handled stops it climbing to the responder who
+  could have handled it. The failure mode is that nothing happens, which
+  is exactly what it looks like when things are fine.
+- **`rootly_org_teams_delete`** orphans the routing and escalation
+  targets that reference the team, producing the same silent paging gap.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.**
+
+- Read tools: allow. Incident triage, shift handoff summaries, and
+  reliability reporting are the intended autonomous use.
+- Write tools: agent drafts the exact call, human approves, then it runs.
+- Destructive tools: require a named human approver per invocation. Do
+  not grant these to scheduled or unattended agents. Because workflows
+  sit downstream of `rootly_incidents_create`, an unattended agent
+  holding it has whatever reach your workflow actions have — including
+  your status page and your customers' inboxes.
+
+## What it cannot reach
+
+- Only the Rootly organisation mapped to the operator's gateway identity.
+  There is no cross-organisation or reseller view.
+- Token scope bounds everything. A Team-scoped token returns 403 on
+  organisation-wide queries; the gateway credential should be a Global
+  token.
+- **No postmortem, action-item, workflow, or service-catalog write
+  path.** This plugin's `postmortems`, `workflows`, and `services` skills
+  describe Rootly REST API endpoints, but the served tool surface does
+  not expose them. An agent cannot create or publish a postmortem, open
+  or close an action item, enable or disable a workflow, or edit the
+  service catalog. Those remain UI or direct-API actions.
+- **No schedule authoring.** Schedules can be listed and read but not
+  created, edited, or overridden.
+- No filesystem, no shell, no other vendor's data.
+- No live event stream. Every tool is point-in-time; Rootly's Slack
+  integration and webhooks carry the push feed.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session
+  and are not persisted by this plugin.
+- `rootly_org_teams_*` and `rootly_org_current_user` return staff
+  identity — names, email addresses, and team membership.
+  `rootly_schedules_*` returns who is on-call and when, which is a
+  roster of your responders' working patterns.
+- `rootly_incidents_get` returns incident titles, summaries, and
+  timelines. In practice these carry infrastructure detail — service
+  names, hostnames, error output — and, on customer-impacting incidents,
+  a description of which customers were affected.
+- `rootly_alerts_list` returns the raw monitoring payloads behind an
+  incident, with the same disclosure profile.
+- Restrict these if your agents run unattended.
+
+## Known sharp edges
+
+- **Two upstreams exist and they expose different tools.** This plugin
+  defaults to the WYRE gateway
+  (`https://mcp.wyre.ai/v1/rootly/mcp`), whose tools are the
+  `rootly_*` names listed above. Rootly also hosts its own MCP server at
+  `mcp.rootly.com`, which generates a different, larger set from their
+  OpenAPI spec (`incidents_get`, `find_related_incidents`, and similar).
+  Tool names are not interchangeable between the two; a runbook written
+  against one will fail against the other with "unknown tool".
+- **Acknowledging pauses the escalation clock.** An agent that
+  acknowledges an alert it cannot resolve has stopped it reaching the
+  human who could.
+- **Severity IDs are UUIDs and are per-organisation.** Nothing can be
+  hardcoded; `rootly_org_severities_list` is a required lookup before any
+  create. An agent guessing a severity ID gets a 422 whose message does
+  not explain why.
+- **Rootly's model is internal-first.** It is built for one engineering
+  organisation's own infrastructure, not per-client MSP ticketing. If you
+  route multiple customers through team-based scoping, be explicit that
+  incident titles and summaries are visible to anyone with organisation
+  scope — there is no per-client wall.

--- a/msp-claude-plugins/rootly/rootly/skills/alerts/SKILL.md
+++ b/msp-claude-plugins/rootly/rootly/skills/alerts/SKILL.md
@@ -18,6 +18,24 @@ when_to_use: >-
 
 Rootly's alerting system connects monitoring tools (Datadog, PagerDuty, New Relic, Grafana, etc.) to the incident management workflow. Alerts are routed through configurable rules to the right teams, and can automatically create incidents based on conditions. Escalation policies ensure alerts are acknowledged within SLA windows.
 
+## Anti-triggers
+
+PagerDuty appears here as an *upstream alert source and paging target*.
+Questions about PagerDuty's own objects are not this skill.
+
+- **Managing the PagerDuty side** — PagerDuty's own incidents, schedules,
+  and escalation policies are `pagerduty-incidents`, `pagerduty-oncall`,
+  and `pagerduty-alerts`. This skill only covers how a PagerDuty signal
+  enters Rootly and how Rootly pages back out to it.
+- **The incident an alert became** — once an alert creates or attaches to
+  an incident, lifecycle, severity, and response coordination are
+  `rootly-incidents`.
+- **Alerts raised by another product** — RMM device alerts are
+  `datto-rmm-alerts`, network alerts are `auvik-alerts`, EDR detections
+  are `sentinelone-alerts`.
+- **The automation that runs when an alert lands** — trigger, condition,
+  and action definitions are `rootly-workflows`.
+
 ## Key Concepts
 
 ### Alert Sources

--- a/msp-claude-plugins/rootly/rootly/skills/incidents/SKILL.md
+++ b/msp-claude-plugins/rootly/rootly/skills/incidents/SKILL.md
@@ -28,6 +28,32 @@ The incident system supports:
 
 All read and write operations on incidents are available through the Rootly MCP tools.
 
+## Anti-triggers
+
+"Incident" names three different objects across this marketplace, and the
+routing test is what the operator does next: coordinate a response and
+write it up (this skill), approve a remediation on a compromised
+endpoint, or answer a customer under an SLA clock.
+
+- **A confirmed security incident** — malware, intrusion, a host to
+  contain. That object carries a SOC-recommended remediation to approve,
+  not a response team to assemble; use `huntress-incidents`, or
+  `sentinelone-alerts` for raw EDR detections.
+- **A customer ticket typed "Incident"** — ITIL ticket classification
+  inside a PSA or helpdesk, where the deliverable is an SLA-timed
+  response and a billable time entry rather than a war room; use
+  `freshdesk-ticketing`, `halopsa-tickets`, `connectwise-manage-tickets`,
+  or `autotask-tickets`.
+- **A PagerDuty incident** — a different vendor with a different
+  lifecycle (`triggered → acknowledged → resolved`, not
+  `detected → in_triage → mitigated → resolved → closed`); use
+  `pagerduty-incidents`.
+- **The retrospective written after resolution** — postmortem content
+  and its action items are `rootly-postmortems`; this skill covers
+  action items only as live response tasks.
+- **What fired and who it routed to** — alert sources, routing rules,
+  and escalation policies are `rootly-alerts`.
+
 ## MCP Tools
 
 ### Core Incident Tools

--- a/msp-claude-plugins/rootly/rootly/skills/oncall/SKILL.md
+++ b/msp-claude-plugins/rootly/rootly/skills/oncall/SKILL.md
@@ -23,6 +23,23 @@ Rootly's on-call management provides visibility into who is currently on-call, w
 - **Shift Metrics** — Analyse incident volume, severity distribution, and response time per user, team, or schedule
 - **Incident Scoping** — Pull only the incidents that occurred during a specific shift period
 
+## Anti-triggers
+
+This skill *analyses* on-call — handoffs, shift load, burnout risk. It
+does not author rotations or decide who gets paged.
+
+- **Building or editing a rotation** — schedule layers, restrictions, and
+  temporary overrides are `pagerduty-oncall`; Rootly reads shift data
+  rather than authoring it.
+- **When the SLA clock runs against a customer** — business-hours
+  calendars and coverage windows are a contractual construct, unrelated
+  to responder shifts; use `freshdesk-sla-business-hours` or
+  `halopsa-contracts`.
+- **The incidents themselves** — triage, severity, and resolution are
+  `rootly-incidents`; this skill only scopes them to a shift window.
+- **Escalation policy configuration** — routing and escalation tiers are
+  `rootly-alerts`.
+
 ## MCP Tools
 
 ### On-Call Tools

--- a/msp-claude-plugins/rootly/rootly/skills/postmortems/SKILL.md
+++ b/msp-claude-plugins/rootly/rootly/skills/postmortems/SKILL.md
@@ -18,6 +18,22 @@ when_to_use: >-
 
 Postmortems in Rootly are structured retrospectives created after incidents are resolved. They document what happened, why it happened, and what will be done to prevent recurrence. Rootly supports templates, automatic timeline import, action item tracking, and integration with project management tools for follow-through.
 
+## Anti-triggers
+
+- **The resolution note a customer reads** — a PSA ticket's resolution
+  field is a customer-facing summary written to close the ticket, not a
+  blameless internal retrospective. Use `halopsa-tickets`,
+  `freshdesk-ticketing`, or `connectwise-manage-tickets`.
+- **A security incident write-up** — Huntress ships its own SOC
+  investigation detail on the incident record; use `huntress-incidents`.
+- **The live incident** — status, severity, and response coordination
+  while it is still open are `rootly-incidents`. This skill starts after
+  resolution.
+- **Automating postmortem creation** — the trigger that fires on
+  `incident_resolved` is a workflow; use `rootly-workflows`.
+- **Publishing the retrospective as customer documentation** — MSP
+  knowledge bases are `hudu-articles` or `it-glue-documents`.
+
 ## Key Concepts
 
 ### Postmortem Lifecycle

--- a/msp-claude-plugins/rootly/rootly/skills/services/SKILL.md
+++ b/msp-claude-plugins/rootly/rootly/skills/services/SKILL.md
@@ -17,6 +17,23 @@ when_to_use: >-
 
 The Rootly service catalog provides a centralized registry of all services in your infrastructure. Each service has ownership, tier classification, dependencies, and is linked to incidents and alerts. This enables rapid identification of affected components during incidents and accurate impact assessment.
 
+## Anti-triggers
+
+A Rootly service is a technical component with an owning team. It is not
+a commercial service, not a service ticket, and not a device record.
+
+- **A managed service you sell and bill for** — service lines, coverage
+  scope, and rates live in the contract; use `halopsa-contracts` or
+  `autotask-contracts`.
+- **A service request from a customer** — that is a ticket type in a
+  helpdesk or PSA; use `freshdesk-ticketing`, `halopsa-tickets`, or
+  `connectwise-manage-tickets`.
+- **PagerDuty's service catalog** — a different vendor's model, keyed on
+  integrations and escalation policies rather than tiers; use
+  `pagerduty-services`.
+- **The physical or virtual device behind a service** — asset and CI
+  records are `halopsa-assets` or the RMM's device skills.
+
 ## Key Concepts
 
 ### Service Tiers

--- a/msp-claude-plugins/rootly/rootly/skills/workflows/SKILL.md
+++ b/msp-claude-plugins/rootly/rootly/skills/workflows/SKILL.md
@@ -18,6 +18,25 @@ when_to_use: >-
 
 Rootly workflows automate repetitive incident response tasks. Each workflow consists of a trigger (what starts it), conditions (when it should run), and actions (what it does). Workflows can create Slack channels, page on-call, update status pages, create Jira tickets, send notifications, and more -- all automatically when incidents match specific criteria.
 
+## Anti-triggers
+
+"Workflow" means automation *inside Rootly, fired by incident events*.
+Several neighbouring things share the word.
+
+- **Claude Code automation** — subagents under `agents/*.md` and slash
+  commands under `commands/*.md` are plugin authoring concerns, not
+  Rootly resources. Nothing in this skill configures Claude.
+- **PSA workflow rules** — ticket routing, board automation, and
+  notification rules inside a PSA are `connectwise-manage-tickets`,
+  `halopsa-tickets`, or `autotask-tickets`.
+- **PagerDuty's automation** — event orchestrations and incident
+  workflows are a separate product surface; use `pagerduty-incidents`
+  and `pagerduty-alerts`.
+- **RMM scripts and scheduled jobs** — running a script on an endpoint is
+  `datto-rmm-jobs`, not a Rootly action.
+- **What a workflow did on a specific incident** — execution history is
+  read from the incident; use `rootly-incidents`.
+
 ## Key Concepts
 
 ### Workflow Components


### PR DESCRIPTION
Applies the repo-wide connector-quality standard to the PSA / incident-management batch: `freshdesk`, `halopsa`, `pagerduty`, `rootly`.

Branched from `feat/skill-anti-triggers-governance`, which carries the standard. **Additive only** — 400 insertions, 0 deletions across 21 skills, plus 4 new `GOVERNANCE.md`. No `triggers:` frontmatter, no `npm run generate`, nothing outside the four plugin directories.

## Task A — `## Anti-triggers`

**21 added, 4 skipped.**

| Plugin | Added | Skipped |
|---|---|---|
| `freshdesk` | 4/5 — ticketing, contacts-companies, knowledge-base, sla-business-hours | api-patterns |
| `halopsa` | 6/7 — tickets, clients, contracts, assets, invoices, agents | api-patterns |
| `pagerduty` | 5/6 — incidents, alerts, oncall, services, analytics | api-patterns |
| `rootly` | 6/7 — incidents, alerts, oncall, postmortems, services, workflows | api-patterns |

**Why all four `api-patterns` skills were skipped:** each is the auth / pagination / rate-limit skill for its vendor. The only routing mistake available is confusing one vendor's API-patterns skill with another's, and the names alone disambiguate that. Per the checklist, a bullet that only negates `when_to_use` is filler, so the section is omitted entirely rather than filled with boilerplate.

### The three-way "incident" boundary

The richest source of confusion in this batch, and the reason it was batched this way. The same wording anchors all four incident-adjacent skills, always routing on the same test — **what the operator does next**:

> "Incident" names three different objects across this marketplace, and the routing test is what the operator does next: page a responder (this skill), approve a remediation on a compromised endpoint, or answer a customer under an SLA clock.

Each plugin then states its own two neighbours, never itself. From `pagerduty-incidents`:

> - **A confirmed security incident** — malware, intrusion, a host to contain. That object carries a SOC-recommended remediation to approve, not a responder to page; use `huntress-incidents`, or `sentinelone-alerts` for raw EDR detections.
> - **A customer ticket typed "Incident"** — ITIL ticket classification inside a PSA or helpdesk, where the deliverable is an SLA-timed response and a billable time entry rather than a page; use `freshdesk-ticketing`, `halopsa-tickets`, `connectwise-manage-tickets`, or `autotask-tickets`.
> - **A Rootly incident** — a different vendor with a different lifecycle (`detected → in_triage → mitigated → resolved → closed`, not `triggered → acknowledged → resolved`); use `rootly-incidents`.

The ticket-side skills invert it — `halopsa-tickets` and `freshdesk-ticketing` lead with the fact that a ticket *type* is often literally named "Incident", which is what causes the misroute in the first place.

`huntress`, `sentinelone`, `connectwise`, and `kaseya/autotask` are referenced by name only; no files under those plugins were touched.

### Other collisions resolved

- **"agent"** — `halopsa-agents` distinguishes a human technician from a Claude subagent, from an endpoint sensor (`huntress-agents`, `datto-rmm-devices`), from a client-side end user. Mirrors the exemplar's `huntress-agents` treatment.
- **"service"** — `pagerduty-services` and `rootly-services` both state that a service is a technical component with an escalation policy, not a managed service you bill for (`halopsa-contracts`) and not a service ticket.
- **"SLA"** — `freshdesk-sla-business-hours` separates helpdesk deadline computation from the commercial SLA in a signed agreement, and notes the two can legitimately disagree. `pagerduty-analytics` warns that MTTA/MTTR is not contractual SLA attainment — reporting one as the other misstates compliance to a client.
- **"workflow"** — `rootly-workflows` routes out Claude Code agents/commands, PSA board automation, and RMM scripts.
- **Read-only surfaces** — `halopsa-invoices` states plainly that no tool raises, sends, or credits an invoice, so the operator gets routed to the UI instead of an improvised write.

All cross-plugin references were validated against the on-disk skill index (344 skills); every one resolves.

## Task B — `GOVERNANCE.md`

One per plugin, from `_templates/governance-template.md`, Conduit-gateway framing retained throughout.

**Tool names are real.** Derived from each plugin's own skills and cross-checked against `<vendor>-mcp/src/` where it exists (`freshdesk-mcp`, `halopsa-mcp`, `rootly-mcp`). `halopsa` matches the served gateway surface exactly (18 tools). `pagerduty` has no local server repo — it fronts the vendor's hosted MCP, so the 66-tool catalog in the plugin's own `api-patterns` skill is the source.

### Blast-radius calls worth reviewing

Classified by what happens in the world, not by HTTP verb. The non-obvious promotions, each justified in prose after the tier table:

- **`create_incident` (PagerDuty) → Destructive.** The API calls it a create; what it does is start an escalation policy — phone and SMS to whoever is on-call, at whatever hour it is for them, escalating until someone acknowledges. There is no undo for a person who has been woken up.
- **`rootly_incidents_create` → Destructive.** Not a record write but a trigger: declaring an incident fires every matching workflow, and Rootly's action catalog includes paging on-call, creating a Slack channel, posting to a **public status page**, and sending email. One call can wake someone at 3am *and* tell your customers you have an outage.
- **`halopsa_tickets_add_action` → Destructive.** Named like an append. With `emailto` it mails the client; with `charge: true` it posts billable time that flows into the next invoice run and deducts from prepaid hours. Corrected by a human in the billing UI, not by another API call.
- **`freshdesk_tickets_reply` → Destructive.** Sends email to the customer in your company's name. No unsend. Same treatment for `freshdesk_contacts_send_invite`.
- **PagerDuty status-page tools → Destructive.** Publishing notifies every subscriber by email and SMS; deleting the post afterwards removes the page, not the notification.
- **PagerDuty orchestration-rule updaters → Destructive.** They sit upstream of every incident. A bad suppression rule means production alerts never become incidents — nobody is paged, nothing errors, and the gap surfaces during the next outage. `delete_schedule` / `delete_team` create the same silent gap from the other end.
- **`freshdesk_contacts_make_agent` / `freshdesk_agents_create` → Destructive.** Each consumes a licensed seat (a billing change) and grants a human access to every ticket in the account. That is an access grant, not a profile edit.
- **`merge_incidents` (PagerDuty) and `freshdesk_contacts_merge` → Destructive.** Neither is reversible through the API.

### Disputable calls — flagging explicitly for review

1. **`halopsa_tickets_update` left in Write, not Destructive.** By the strict "closes a ticket against SLA is effectively irreversible" reading it belongs in Destructive: it is the only path to Resolved/Closed, it stops the SLA clock, stamps the attainment numbers, and usually fires the satisfaction-survey email. It is also the only way to set a priority or assign an agent, so promoting it collapses the entire write tier. Resolved by keeping it in Write and documenting the hazard under Known sharp edges with an explicit recommendation: *if you bill against SLA attainment, gate it at the destructive tier.* Happy to promote it outright if reviewers prefer the blunter call.
2. **`freshdesk_sla_create` / `freshdesk_sla_update` → Destructive.** These delete nothing, but a single policy edit re-computes `due_by` / `fr_due_by` across the live queue, can put tickets into breach retrospectively, and changes what SLA reports — and any contractual credits derived from them — say. Judged as "changes billing" under the template's definition.
3. **`freshdesk_agents_create` in the same tier as the deletes** looks odd at a glance. Justified on seat licensing plus blanket ticket access, but it is the entry most likely to read as over-classification.
4. **`rootly_alerts_resolve` → Destructive.** Inverted blast radius: resolving an alert nobody handled stops it climbing to the responder who could have handled it. The failure mode is that nothing happens, which is exactly what it looks like when things are fine.

## Findings surfaced along the way (not fixed here — additive-only scope)

1. **Rootly tool names are inconsistent across the plugin, and partly fictional.** `api-patterns`, `incidents`, and `oncall` document the vendor-hosted `mcp.rootly.com` surface (`incidents_get`, `find_related_incidents`); `postmortems`, `alerts`, `services`, and `workflows` document `rootly_list_postmortems`-style names that **do not exist in `rootly-mcp`**, which is what the plugin's default `ROOTLY_MCP_URL` actually points at. The served surface is 23 `rootly_*` tools with no postmortem, action-item, workflow, or service-catalog write path at all. `GOVERNANCE.md` states this under "What it cannot reach" and flags the two-upstream trap under Known sharp edges, but the affected skills need a follow-up pass.
2. **Freshdesk skill/server drift:** skills reference `freshdesk_sla_policies_list`, `freshdesk_tickets_conversations`, and `freshdesk_solutions_articles_search`; the server registers `freshdesk_sla_list`, `freshdesk_tickets_list_conversations`, and no article search. Governance uses the server names.
3. **PagerDuty naming is split within the plugin** — `api-patterns`/`incidents`/`oncall` use bare names (`list_incidents`), while `alerts`/`services`/`analytics` use a `pagerduty_` prefix. Governance follows the `api-patterns` catalog as the plugin's own authoritative reference.

Suggest these become a follow-up issue rather than expanding this PR.
