### PR TITLE
feat(connectwise-cpq): add anti-triggers and governance doc

### DIFF
--- a/msp-claude-plugins/connectwise/cpq/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/connectwise/cpq/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "connectwise-cpq",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Claude Code plugin for ConnectWise CPQ (formerly Sell / Quosal) - quotes, line items, templates, quote customers, and payment terms",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/connectwise/cpq/GOVERNANCE.md
+++ b/msp-claude-plugins/connectwise/cpq/GOVERNANCE.md
@@ -1,0 +1,158 @@
+# ConnectWise CPQ plugin — governance and safety model
+
+Unofficial. Community-built plugin for the ConnectWise CPQ (Sell/Quosal)
+API. Not affiliated with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches ConnectWise CPQ through
+the WYRE Conduit gateway (`https://conduit.wyre.ai/v1/mcp`), which brokers
+authentication centrally and scopes every call to the tenant the operator
+is authorised for.
+
+- No access key, public key or private key is stored on the technician's
+  machine, in this repo, or in the model's context. The three arrive at
+  the MCP server as `X-CPQ-*` headers and the server assembles the
+  upstream Basic token itself.
+- Credential rotation happens once at the gateway, not per technician.
+  This matters more in CPQ than most: the private key is displayed once,
+  at creation, and losing it means regenerating the pair for everyone.
+- Every call carries operator identity, so the gateway audit log answers
+  "who repriced that quote". CPQ's own trail records only the single API
+  user the key pair belongs to, so without the gateway every agent action
+  looks like one shared robot.
+- Revoking gateway access revokes CPQ access with it, immediately.
+
+## Tool permission tiers
+
+25 tools, all prefixed `cpq_`. Tiering is by blast radius, not HTTP verb.
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change CPQ state. Safe for autonomous agents. | `cpq_test_connection`, `cpq_search_quotes`, `cpq_get_quote`, `cpq_get_quote_versions`, `cpq_search_quote_items`, `cpq_get_quote_item`, `cpq_search_quote_tabs`, `cpq_list_quote_customers`, `cpq_list_quote_terms`, `cpq_list_templates`, `cpq_list_tax_codes`, `cpq_list_recurring_revenues`, `cpq_list_users` |
+| **Write** | Builds and prices quote content. Reversible while the quote is still internal. | `cpq_create_quote_from_template`, `cpq_create_quote_item`, `cpq_update_quote_item`, `cpq_update_quote_customer`, `cpq_create_quote_term`, `cpq_update_quote_term` |
+| **Destructive** | Rewrites what a customer has been shown or told, or removes priced content with no undo. Requires explicit per-call human approval. | `cpq_update_quote`, `cpq_delete_quote`, `cpq_delete_quote_version`, `cpq_delete_quote_item`, `cpq_delete_quote_term`, `cpq_delete_quote_customer` |
+
+`cpq_update_quote` sits in the destructive tier despite being the plugin's
+plainest-looking write. It is the only route to `isSent`, `isAccepted`,
+`isLost`, `quoteStatus`, `approvalStatus` and the `orderPorter*` fields —
+the record of what the customer was sent, what they agreed to, and what
+the published proposal shows them. Setting `isAccepted` on the wrong quote
+does not just misfile a row; it is the signal the forecast, the commission
+run and the port-to-PSA step all read as truth. The tool also accepts raw
+JSON Patch, so `op: "remove"` can strip a field outright, and tiering is
+per-tool — the gateway cannot see which `path` an agent intends, so the
+whole tool inherits the blast radius of its worst operation. If your
+gateway can gate on argument values, the narrower rule is: allow
+`cpq_update_quote` freely for `name`, `expectedCloseDate` and the
+`zCustom*` slots, and require approval for any patch touching
+`quoteStatus`, `isSent`, `isAccepted`, `isLost`, `isArchive`,
+`expirationDate`, the approval fields, or `orderPorter*`.
+
+`cpq_delete_quote_term` and `cpq_delete_quote_customer` are in the same
+tier for the same reason rather than for their verb. A term carries
+`interestRate`, `downPayment` and `periodPaymentAmount` — the financing
+the customer was offered, and `isSelected` marks the one they were offered
+*specifically*. A quote customer is who the proposal is addressed to and
+who holds the Order Porter link. Neither is recoverable from this toolset.
+
+Line pricing (`cpq_update_quote_item`, `cpq_update_quote_term`) is
+deliberately **not** destructive. CPQ's API has no send, publish or e-sign
+verb, so a price change reaches nobody until a human publishes the quote
+in the web app — the customer-facing act stays behind a person either way.
+Tiering every pricing edit as destructive would leave the tier unable to
+discriminate, which is the failure mode that gets tiers ignored. The
+edits are still money, so they belong in the propose-and-approve loop
+below.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.**
+
+- Read tools: allow. Pipeline reporting, margin analysis across open
+  quotes, and reconciling quoted vs. contracted spend are the intended
+  autonomous use.
+- Write tools: agent drafts the exact call, human approves, then it runs.
+  Because these move money on the page, have the agent state the before
+  and after figures in its proposal, not just the patch body.
+- Destructive tools: require a named human approver per invocation. Do not
+  grant these to scheduled or unattended agents, and specifically do not
+  let a housekeeping agent hold `cpq_delete_quote` or
+  `cpq_delete_quote_version`.
+
+## What it cannot reach
+
+- Only the CPQ tenant the operator's gateway identity maps to. There is
+  one global host (`https://sellapi.quosalsell.com`) and no regional
+  variants — tenancy is carried entirely by the access key.
+- Within that tenant, only what the API user's own CPQ permissions allow.
+  `canAccessAllQuotes` on the user record is the real scope boundary; a
+  restricted API user makes the tiers above fail at CPQ, not at the
+  gateway.
+- No filesystem, no shell, no other vendor's data.
+- Not ConnectWise PSA and not ConnectWise Automate. Separate products,
+  separate APIs, separate gateway connectors, despite the shared brand.
+  `crmOpportunityId` on a quote is a pointer into the PSA, not a join this
+  plugin can follow.
+- **No delivery.** There is no send, publish, e-sign, PDF or attachment
+  verb, and no port-to-PSA. An agent holding every tool here still cannot
+  email a customer or put a document in front of one — that is the CPQ web
+  app and the CPQ↔PSA integration engine.
+- No live event stream. CPQ has no webhooks; every tool is point-in-time
+  and change detection means polling `modifyDate`.
+
+## Data handling
+
+- Responses pass through the gateway into model context for the session
+  and are not persisted by this plugin.
+- `cpq_list_quote_customers` returns customer contact records (33
+  properties of `CustomerView`) — client PII.
+- `cpq_list_users` returns your own staff (`userName`, `emailAddress`)
+  together with `isAdministrator`, `isApprover` and `canAccessAllQuotes`.
+  That is a map of who can approve a quote, which is worth restricting
+  independently of the PII.
+- Every quote read carries commercial data: `cost`, `grossMargin`,
+  `costModifier` and per-line cost sit alongside sell price. Restrict
+  these if agent transcripts are shared beyond the people allowed to see
+  your margins.
+- `orderPorterPasscode` is the access code for a customer's published
+  proposal and is returned by `cpq_get_quote` unless `includeFields`
+  excludes it.
+
+## Known sharp edges
+
+- **The delete confirmation is not a control.** The delete tools ask the
+  caller to confirm through MCP elicitation, but a client that does not
+  declare form-elicitation support gets no prompt and the delete proceeds.
+  Treat the gateway tier as the only enforced gate; the prompt is a
+  courtesy for interactive clients.
+- **`cpq_delete_quote` cascades.** It removes the quote and every tab,
+  line item and term on it. Setting `isArchive: True` is the reversible
+  way to retire a dead deal, and is almost always what was actually
+  wanted.
+- **Two different deletes, two different addresses.**
+  `cpq_delete_quote_version` targets `quoteNumber` + `quoteVersion` and
+  removes one revision; `cpq_delete_quote` targets a GUID and takes the
+  whole quote. An agent that conflates them destroys far more than it
+  meant to.
+- **Reads under-report by default, and silently.** `cpq_search_quotes`
+  called with no `conditions` falls back to the last 90 days, and searches
+  return latest versions only unless `showAllVersions: true` is passed.
+  The `count` in a result is the length of that page, never a collection
+  total. An agent that concludes "this account has no open quotes" from a
+  defaulted search is wrong, and that conclusion is exactly what bulk
+  decisions get built on.
+- **Order Porter changes cannot be walked back from here.** There is no
+  unpublish verb, so a bad `orderPorter*` patch has to be corrected by a
+  human in the CPQ web app while the customer may already be looking at
+  the page.
+- **Rate limits are undocumented.** CPQ publishes no limit and no
+  `Retry-After` has been observed. Treat `429`, `502`, `503` and `504` as
+  retryable with exponential backoff and keep concurrency modest —
+  a wide agent sweep has no documented ceiling to stay under.
+- **A missing credential answers `500`, not `401`.** When the
+  Authorization header is absent entirely, CPQ returns
+  `500 "An error has occurred."` — which reads as a vendor outage rather
+  than a configuration problem, and sends operators looking in the wrong
+  place.

--- a/msp-claude-plugins/connectwise/cpq/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/connectwise/cpq/skills/api-patterns/SKILL.md
@@ -28,6 +28,22 @@ CPQ is not ConnectWise PSA. It has its own host, its own auth scheme (no `client
 and a much narrower surface — pair it with the `connectwise-psa` plugin when a workflow
 needs opportunities, products, or agreements.
 
+## Anti-triggers
+
+"ConnectWise" brands three products with three unrelated APIs, and their credentials are
+not interchangeable. PSA's and CPQ's Basic tokens are the trap: both are
+`base64(<something>+<publicKey>:<privateKey>)`, so a company ID and an access key look
+identical in the same slot. Authenticating against the wrong product fails as a `401` —
+or a `500` when a header is absent entirely — which reads like a permissions problem on
+an account that is in fact fine.
+
+- **ConnectWise PSA (Manage)** — regional `api-{na,eu,au}.myconnectwise.net` hosts, a
+  `companyId` in the Basic string, and a mandatory `clientId` header CPQ does not use.
+  Use `connectwise-manage-api-patterns`.
+- **ConnectWise Automate** — on-premise RMM server, `/cwa/api/v1/` base path,
+  Bearer-token auth, singular `condition=` filters. Use
+  `connectwise-automate-api-patterns`.
+
 ## Connection & Authentication
 
 Upstream CPQ uses HTTP Basic with a **three-part** credential:

--- a/msp-claude-plugins/connectwise/cpq/skills/quote-items/SKILL.md
+++ b/msp-claude-plugins/connectwise/cpq/skills/quote-items/SKILL.md
@@ -21,6 +21,17 @@ services. Each item belongs to exactly one **tab** (a section of the quote), and
 belongs to one quote. Items carry both sell and cost figures, so margin is computed per
 line, per tab and per quote.
 
+## Anti-triggers
+
+- **Looking up a product, SKU, list price or manufacturer** — CPQ has no catalog to
+  search (see below). The priced SKU master list is ConnectWise PSA's; use
+  `connectwise-manage-product-catalog` and carry the values onto the line yourself.
+- **Quote-level fields — status, totals, expiry, versions, quote customers, payment
+  terms** — those hang off the quote header, not its lines; use `connectwise-cpq-quotes`.
+- **Line items on another vendor's quote** — Kaseya Quote Manager quote lines and
+  SalesBuildr quote products share this vocabulary exactly; use
+  `kaseya-quote-manager-quotes` or `salesbuildr-quotes`.
+
 ## Key Concepts
 
 ### Items live on tabs, and tabs are read-only

--- a/msp-claude-plugins/connectwise/cpq/skills/quotes/SKILL.md
+++ b/msp-claude-plugins/connectwise/cpq/skills/quotes/SKILL.md
@@ -27,6 +27,26 @@ Everything an MSP does after the quote is built — publishing to Order Porter, 
 porting a won quote into the PSA as a sales order — happens in the CPQ web app. The API
 covers building and reading quotes, not delivering them.
 
+## Anti-triggers
+
+CPQ owns one stage of the quote funnel: **composing and pricing the quote document**.
+It does not source the SKUs that go into it, it cannot deliver it, and it is not the
+only tool in the stack that holds something called a quote.
+
+- **The priced SKU master list rather than this deal's document** — catalog items,
+  costs, categories and manufacturers live in ConnectWise PSA; use
+  `connectwise-manage-product-catalog`.
+- **"Send the customer the quote", e-signature, or signed-document status** — CPQ's API
+  has no publish, send or e-sign verb. `isSent` and the `orderPorter*` fields are
+  state you can read (and patch), not actions you can trigger. Delivery and signature
+  tracking are `pandadoc-documents`.
+- **A quote that was built in a different quoting product** — Kaseya Quote Manager and
+  SalesBuildr each keep their own quotes, numbering and APIs; use
+  `kaseya-quote-manager-quotes` or `salesbuildr-quotes`. Route on the product the quote
+  lives in, not on the word "quote".
+- **Adding, repricing or removing a line** — the quote header and its line items are
+  separate tool sets; use `connectwise-cpq-quote-items`.
+
 ## Key Concepts
 
 ### Two ways to address a quote


### PR DESCRIPTION
Applies the connector-quality standard from `feat/skill-anti-triggers-governance` to `connectwise-cpq`.

**This closes the CPQ coverage gap.** The ConnectWise PSA/Automate PR (#164) explicitly scoped CPQ out — it is a separately registered plugin that happens to live under the same `connectwise/` category dir — so nobody covered it. Branched from `feat/skill-anti-triggers-governance`, not `main`.

## Counts

| | |
|---|---|
| Skills with anti-triggers added | **3 of 3** (`quotes`, `quote-items`, `api-patterns`) |
| Skills skipped | 0 |
| GOVERNANCE.md | added (25 tools tiered) |
| Plugin version | 1.0.0 → 1.1.0 |

Nothing was skipped: every CPQ skill sits on a real routing collision. Bullet counts were kept tight instead (4 / 3 / 2) — an "another quoting vendor's API" bullet was cut from `api-patterns` as filler, since the ConnectWise-family credential clash is the genuine failure there and the cross-vendor routing is already carried by `quotes` and `quote-items`.

## The funnel-stage boundary

CPQ's routing problem is a **funnel boundary**, not a naming clash. The line drawn, and used consistently across all three skills:

> CPQ owns one stage of the quote funnel: **composing and pricing the quote document**. It does not source the SKUs that go into it, it cannot deliver it, and it is not the only tool in the stack that holds something called a quote.

That resolves each collision the same way:

- **ConnectWise PSA product catalog** — the priced SKU master list. `product-catalog` already routes *into* CPQ on this PR's sibling; this is the reciprocal, worded to match.
- **PandaDoc** — CPQ's API has **no send, publish or e-sign verb**. `isSent` and `orderPorter*` are state you can read and patch, not actions you can trigger. So "send the customer the quote" and signature tracking are `pandadoc-documents`, unambiguously.
- **Kaseya Quote Manager / SalesBuildr** — different quoting *products*, own numbering and APIs. Route on the product the quote lives in, not on the word "quote".
- **Within the plugin** — quote header vs. line items.

`api-patterns` carries the credential collision instead: PSA and CPQ both authenticate as `base64(<something>+publicKey:privateKey)`, so a company ID and an access key look identical in the same slot. A mixup fails as a `401` — or a `500` when the header is absent entirely — that reads like a permissions problem on an account that is fine.

## Governance

Tool names verified against the shipped `connectwise-cpq-mcp` server (`src/tools.ts`): **25 tools, zero drift** from what the skills document. Every name and its annotation tier matched. No drift note needed.

Tiering is by blast radius, not verb:

- **`cpq_update_quote` → destructive**, despite being the plugin's plainest-looking PATCH. It is the *only* route to `isSent`, `isAccepted`, `isLost`, `quoteStatus`, `approvalStatus` and `orderPorter*` — the record of what the customer was sent and what they agreed to. Setting `isAccepted` on the wrong quote is what the forecast, the commission run and the port-to-PSA step all read as truth. It also takes raw JSON Patch, so `op: "remove"` can strip a field, and tiering is per-tool — the gateway can't see which `path` is intended. (The shipped server independently marks it `destructiveHint: true`.)
- **`cpq_delete_quote_term` / `cpq_delete_quote_customer` → destructive** for blast radius, not verb: a term is the financing the customer was offered (`isSelected` marks the specific one), and a quote customer is who the proposal is addressed to and who holds the Order Porter link.

## Judgement calls

**1. Line repricing stays in the *write* tier — the disputable one.** `cpq_update_quote_item` and `cpq_update_quote_term` move money on the page, which by the "anything that moves money" rule argues for destructive. I left them write, and the doc states the reasoning inline: CPQ's API has no delivery verb, so a price change reaches nobody until a human publishes in the web app — the customer-facing act stays behind a person either way. Tiering every pricing edit as destructive would leave the tier unable to discriminate, which is the failure mode that gets tiers ignored. **Happy to move these if you'd rather the tier err loud.**

**2. A sharp edge worth reading:** the delete tools' confirmation prompt is **not an enforced control**. Verified in `connectwise-cpq-mcp/src/elicitation.ts` — a client that doesn't declare form-elicitation capability returns `unavailable`, which `isRefusal()` does not treat as a refusal, so the delete proceeds with no prompt. The skills say deletes "ask for confirmation first", which is true only for interactive clients. Documented under *Known sharp edges*: the gateway tier is the only real gate.

**3. Scope.** Additive only. No `triggers:` frontmatter (#158). `connectwise/automate` and `connectwise/manage` untouched — the sibling PR owns those. `_standards/`, `_templates/`, `marketplace.json` and `docs/src/data/plugins.ts` untouched; `npm run generate` not run.

## Verification

```
$ node scripts/check-marketplace-drift.mjs
✔ marketplace drift check passed (76 entries)

$ node scripts/check-marketplace-drift.mjs --base origin/feat/skill-anti-triggers-governance
bump gate: compared HEAD against merge base 3229a5c440b4 (5 changed files, 1 plugins touched)
✔ marketplace drift check passed (76 entries)

$ claude plugin validate ./msp-claude-plugins/connectwise/cpq
✔ Validation passed
```

Refs #158
