### PR TITLE
feat(rmm): anti-triggers and governance docs for the RMM/PSA batch

### DIFF
--- a/msp-claude-plugins/atera/atera/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/atera/atera/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atera",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Claude Code plugin for Atera RMM/PSA - tickets, agents, customers, alerts",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/atera/atera/GOVERNANCE.md
+++ b/msp-claude-plugins/atera/atera/GOVERNANCE.md
@@ -1,0 +1,107 @@
+# Atera plugin — governance and safety model
+
+Unofficial. Community-built plugin for the Atera API. Not affiliated
+with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+The supported deployment reaches Atera through the WYRE Conduit gateway
+(`https://conduit.wyre.ai/v1/atera/mcp`), which brokers authentication
+centrally and scopes every call to the tenant the operator is authorised
+for.
+
+- No Atera API key is stored on the technician's machine, in this repo,
+  or in the model's context.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers
+  "who asked for this". Atera's own log records only the user that owns
+  the API key, which is usually a shared service account.
+- Revoking a technician's gateway access revokes Atera access with it,
+  immediately.
+
+**If you run without the gateway**, the plugin README documents a direct
+mode where `ATERA_API_KEY` sits in the technician's Claude settings.
+That mode gives up all four properties above: the key lives on the
+endpoint, rotation is per technician, and every action in Atera is
+attributed to one shared key holder. The tiers below are then advisory
+rather than enforced.
+
+## Tool permission tiers
+
+Grouped by blast radius, not HTTP verb.
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change Atera or endpoint state. Safe for autonomous agents. | `atera_navigate`, `atera_back`, `atera_agents_list`, `atera_agents_get`, `atera_agents_get_by_machine`, `atera_alerts_list`, `atera_alerts_get`, `atera_alerts_by_agent`, `atera_alerts_by_device`, `atera_customers_list`, `atera_customers_get`, `atera_contacts_list`, `atera_contacts_get`, `atera_contacts_by_customer`, `atera_tickets_list`, `atera_tickets_get` |
+| **Write** | Creates or modifies records. Reversible, but customer-visible. | `atera_customers_create`, `atera_tickets_create`, `atera_tickets_update`, `atera_tickets_add_comment` |
+| **Destructive** | Empty. | — |
+
+**The destructive tier is empty, and that is a deliberate property of
+this plugin, not an oversight.** The Atera REST API can run PowerShell
+on an agent (`POST /agents/{id}/runscript`) and delete an agent record
+(`DELETE /agents/{id}`) — both documented in the `atera-agents` skill
+because a technician will meet them in the API — but the MCP surface
+exposes neither. Nothing this plugin can call reaches a customer's
+production machine. If a future release adds script execution, it
+belongs in the destructive tier on day one: script execution is
+destructive regardless of what the API calls it.
+
+`atera_tickets_add_comment` defaults to `isInternal: true`, so the
+plugin's default is a private note. The moment an agent passes
+`isInternal: false` the comment becomes an end-user-visible reply — a
+write to the customer's inbox, not just to the database. Treat that
+parameter as the approval boundary.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.**
+
+- Read tools: allow. Fleet audits, alert sweeps, and ticket reporting
+  across customers are the intended autonomous use.
+- Write tools: agent drafts the exact call, human approves, then it
+  runs. `atera_tickets_add_comment` deserves the same care as an
+  outbound email, because it often is one.
+- Destructive tools: none exist today. Do not work around that by
+  driving the Atera web UI or a raw HTTP client from an agent.
+
+## What it cannot reach
+
+- Only the Atera account mapped to the operator's gateway identity.
+  Atera has one API key per account; there is no reseller scope that
+  spans tenants.
+- No filesystem, no shell, no other vendor's data.
+- No endpoint. There is no remote-execution, patch, reboot, or wipe
+  tool in this surface.
+- No billing, contract, or knowledge-base surface — those Atera
+  entities have no tools here.
+- No live event stream. Every tool is point-in-time; Atera webhooks
+  carry the push feed.
+
+## Data handling
+
+- Atera responses pass through the gateway into model context for the
+  session and are not persisted by this plugin.
+- `atera_contacts_*` returns end-user PII (names, email addresses,
+  phone numbers) for the MSP's clients' staff. `atera_agents_*` returns
+  hostnames, IP and MAC addresses, domain membership, serial numbers,
+  and installed OS versions — an inventory that is useful to an
+  attacker. Restrict both if agents run unattended.
+- An Atera API key inherits the permissions of the user who created it.
+  A key made by an admin is an admin key. Create a dedicated
+  least-privilege API user rather than reusing a technician's account.
+
+## Known sharp edges
+
+- **"Device" does not mean endpoint.** In Atera a device is an
+  agentless HTTP/SNMP/TCP monitor; the managed endpoint is an agent.
+  An agent told to "list the customer's devices" can silently return
+  the wrong set. Every other RMM in this marketplace uses the opposite
+  convention.
+- **Resolving an alert deletes it.** Atera's alert resolution is a
+  DELETE against the alert record. The alert does not move to a
+  resolved state you can review later — it is gone. Do not let an agent
+  bulk-clear alerts to tidy a dashboard.
+- **700 requests/minute, shared.** The rate limit is per account, not
+  per technician. A full-fleet sweep by one unattended agent will
+  throttle the humans working alongside it.

--- a/msp-claude-plugins/atera/atera/skills/agents/SKILL.md
+++ b/msp-claude-plugins/atera/atera/skills/agents/SKILL.md
@@ -17,6 +17,27 @@ when_to_use: >-
 
 Atera agents are lightweight software installed on managed endpoints that provide remote monitoring and management capabilities. Agents report system information, health metrics, and enable remote execution of scripts and commands.
 
+## Anti-triggers
+
+- **Atera's own "devices"** — an Atera *device* is an agentless HTTP,
+  SNMP, or TCP monitor with no agent behind it; use `atera-devices`.
+  Atera is the odd one out: in `ncentral-devices`,
+  `ninjaone-rmm-devices`, and `datto-rmm-devices` "device" means the
+  managed endpoint, which here is an agent.
+- **Claude subagents** — "agent" here is an Atera endpoint sensor, never
+  an AI subagent definition under `agents/*.md`. In `halopsa-agents` it
+  is a human technician, and in `liongard-overview` it is one
+  inspection runner per customer site.
+- **Running a script on an endpoint managed by another RMM** — "run
+  PowerShell on this machine" matches every RMM in this marketplace
+  equally, and none of them reach Atera's agents. Confirm which RMM the
+  endpoint is enrolled in, then use `syncro-assets`,
+  `superops-runbooks`, `immybot-script-execution`,
+  `ncentral-monitoring-tasks`, `connectwise-automate-scripts`, or
+  `datto-rmm-jobs`.
+- **The alert an agent raised** — agent records carry health and
+  inventory, not monitoring output; use `atera-alerts`.
+
 ## Agent Information Fields
 
 ### Core Fields

--- a/msp-claude-plugins/atera/atera/skills/alerts/SKILL.md
+++ b/msp-claude-plugins/atera/atera/skills/alerts/SKILL.md
@@ -16,6 +16,23 @@ when_to_use: >-
 
 Alerts in Atera are notifications generated when monitored systems exceed defined thresholds or encounter issues. They serve as the early warning system for MSPs, enabling proactive response to client issues before they become critical problems.
 
+## Anti-triggers
+
+- **The work the alert generated** — an alert promoted into a service
+  desk record is a ticket; use `atera-tickets`.
+- **What raises the alert** — thresholds and monitor configuration are
+  `atera-devices` for agentless monitors and `atera-agents` for
+  endpoint health.
+- **Alerts from a different RMM** — `superops-alerts`,
+  `ninjaone-rmm-alerts`, `datto-rmm-alerts`,
+  `connectwise-automate-alerts`, and N-central active issues
+  (`ncentral-monitoring-tasks`) are separate stores with their own
+  severity scales. Nothing here reads them, and the counts are not
+  comparable.
+- **A security detection** — endpoint threat findings come from the EDR,
+  not the RMM; use `huntress-incidents`, `sentinelone-alerts`, or
+  `rocketcyber-incidents`.
+
 ## Alert Severity Levels
 
 | Severity | Description | Typical Response |

--- a/msp-claude-plugins/atera/atera/skills/customers/SKILL.md
+++ b/msp-claude-plugins/atera/atera/skills/customers/SKILL.md
@@ -16,6 +16,18 @@ when_to_use: >-
 
 Customers in Atera represent the organizations you provide IT services to. Each customer can have multiple contacts (end users), agents (managed devices), contracts, and associated tickets. Proper customer management is essential for organized service delivery.
 
+## Anti-triggers
+
+- **The client's commercial record** — an Atera customer scopes
+  monitoring, not contracts or billing. The company of record lives in
+  `connectwise-psa-companies`, `autotask-crm`, `syncro-customers`, or
+  `superops-clients`; onboarding a client in the wrong system is the
+  expensive version of this mistake.
+- **The endpoints a customer owns** — a customer owns agents; list them
+  with `atera-agents` filtered by `CustomerID`.
+- **Documentation about the client** — passwords, configurations, and
+  procedures live in `hudu-companies` or `it-glue-organizations`.
+
 ## Customer Fields
 
 ### Core Fields

--- a/msp-claude-plugins/atera/atera/skills/devices/SKILL.md
+++ b/msp-claude-plugins/atera/atera/skills/devices/SKILL.md
@@ -17,6 +17,18 @@ when_to_use: >-
 
 Atera device monitors extend monitoring capabilities beyond agent-based endpoints to include network devices, services, and applications. These agentless monitors use HTTP, SNMP, and TCP protocols to check availability and gather metrics.
 
+## Anti-triggers
+
+- **A workstation or server running the Atera agent** — that is an agent
+  record, not a device monitor; use `atera-agents`. This is the single
+  most common misroute in this plugin, because "device" means the
+  managed endpoint in every other RMM here.
+- **The alert a monitor fired** — monitor configuration and thresholds
+  live here; the acknowledge/resolve lifecycle is `atera-alerts`.
+- **Network discovery, topology, or interface statistics as a product**
+  — use `auvik-devices` or `auvik-networks`; this skill only configures
+  Atera's own HTTP, SNMP, and TCP checks.
+
 ## Monitor Types
 
 ### HTTP Monitors

--- a/msp-claude-plugins/atera/atera/skills/tickets/SKILL.md
+++ b/msp-claude-plugins/atera/atera/skills/tickets/SKILL.md
@@ -17,6 +17,16 @@ when_to_use: >-
 
 Atera tickets are the core unit of service delivery in the RMM/PSA platform. Every client request, incident, and service call flows through the ticketing system. This skill covers comprehensive ticket management including creation, updates, comments, and time tracking.
 
+## Anti-triggers
+
+- **The MSP's system-of-record helpdesk** — plenty of shops run Atera
+  for RMM and a separate PSA for service desk. If tickets live
+  elsewhere, use `connectwise-psa-tickets`, `autotask-tickets`,
+  `halopsa-tickets`, `syncro-tickets`, or `superops-tickets`; a ticket
+  created in the wrong system is a ticket nobody is watching.
+- **The alert behind the ticket** — alert-to-ticket conversion rules and
+  the alert side of that workflow are `atera-alerts`.
+
 ## Ticket Status Values
 
 | Status | Description | Business Logic |

--- a/msp-claude-plugins/immybot/immybot/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/immybot/immybot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "immybot",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "ImmyBot - desired-state Windows software deployment, maintenance sessions, and script execution for MSPs (Entra ID OAuth)",
   "author": {
     "name": "WYRE AI"

--- a/msp-claude-plugins/immybot/immybot/GOVERNANCE.md
+++ b/msp-claude-plugins/immybot/immybot/GOVERNANCE.md
@@ -1,0 +1,158 @@
+# ImmyBot plugin — governance and safety model
+
+Unofficial. Community-built plugin for the ImmyBot API. Not affiliated
+with, endorsed by, or sponsored by the vendor.
+
+Read this one before granting access. ImmyBot exists to change Windows
+endpoints, so most of its interesting tools act on customer production
+machines by design.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches ImmyBot through the
+WYRE gateway (`https://mcp.wyre.ai/v1/immybot/mcp`), which brokers
+authentication centrally and scopes every call to the instance the
+operator is authorised for.
+
+- No ImmyBot instance subdomain, Entra tenant ID, client ID, or client
+  secret is stored in this repo or in the model's context. The four
+  connection fields are supplied once through the gateway's connect
+  page, not per technician.
+- The gateway exchanges them for a token and manages refresh; no token
+  lifecycle happens client-side.
+- Every call carries operator identity, so the gateway audit log answers
+  "who approved that maintenance session". ImmyBot's own log records
+  only the Entra app registration.
+- Revoking a technician's gateway access revokes ImmyBot access with it,
+  immediately.
+
+The Entra app registration is the real credential here, and it is
+long-lived. Its ImmyBot RBAC role is the only thing standing between an
+agent and every endpoint in every tenant — scope it deliberately rather
+than granting the app full administrative rights for convenience.
+
+## Tool permission tiers
+
+Grouped by blast radius, not HTTP verb. Several tools that look like
+reads or harmless writes are classified destructive below, with the
+reasoning stated.
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change ImmyBot or endpoint state. Safe for autonomous agents. | `immybot_navigate`, `immybot_back`, `immybot_status`, `immybot_computers_list`, `immybot_computers_get`, `immybot_computers_search`, `immybot_computers_inventory`, `immybot_computers_deployments`, `immybot_software_list`, `immybot_software_list_global`, `immybot_software_get`, `immybot_software_search`, `immybot_software_versions`, `immybot_software_latest_version`, `immybot_software_categories`, `immybot_software_publishers`, `immybot_software_stats`, `immybot_deployments_list`, `immybot_deployments_get`, `immybot_deployments_compliance`, `immybot_deployments_for_computer`, `immybot_deployments_for_software`, `immybot_scripts_list`, `immybot_scripts_get`, `immybot_scripts_search`, `immybot_scripts_categories`, `immybot_scripts_validate`, `immybot_scripts_execution_history`, `immybot_scripts_execution_result`, `immybot_tenants_list`, `immybot_tenants_get`, `immybot_tenants_search`, `immybot_tenants_stats`, `immybot_tenants_computers`, `immybot_tenants_deployments`, `immybot_tenants_compliance`, `immybot_tenants_software_inventory`, `immybot_maintenance_sessions_list`, `immybot_maintenance_sessions_get`, `immybot_maintenance_sessions_active`, `immybot_maintenance_sessions_summary`, `immybot_maintenance_sessions_logs`, `immybot_maintenance_sessions_results`, `immybot_tasks_list`, `immybot_tasks_get`, `immybot_tasks_logs`, `immybot_tasks_history`, `immybot_tasks_queued`, `immybot_tasks_running`, `immybot_tasks_failed`, `immybot_tasks_for_computer`, `immybot_tasks_for_tenant`, `immybot_tasks_by_type`, `immybot_tasks_child_tasks`, `immybot_tasks_dependencies`, `immybot_tasks_estimated_completion`, `immybot_tasks_queue_stats`, `immybot_tasks_metrics` |
+| **Write** | Changes ImmyBot-side records or session flow. Reversible. | `immybot_computers_create`, `immybot_maintenance_sessions_pause`, `immybot_maintenance_sessions_resume` |
+| **Destructive** | Acts on customer Windows endpoints, or arms an action that will. Requires explicit per-call human approval. | `immybot_scripts_run`, `immybot_software_install`, `immybot_deployments_trigger`, `immybot_deployments_create`, `immybot_maintenance_sessions_start`, `immybot_maintenance_sessions_cancel`, `immybot_computers_trigger_checkin` |
+
+### Why each destructive tool is there
+
+- **`immybot_scripts_run`** — executes PowerShell on a live endpoint in
+  SYSTEM context. It can install and uninstall software, change system
+  settings, read any file, and reboot the machine. This is the plainest
+  case in the batch.
+- **`immybot_software_install`** and **`immybot_deployments_trigger`** —
+  install software and force immediate reconciliation. Both land on the
+  endpoint now.
+- **`immybot_maintenance_sessions_start`** — installs, updates, removes
+  software and reboots, across a single computer or an entire tenant
+  depending on the scope argument. One parameter is the difference
+  between one machine and every machine a client owns.
+- **`immybot_maintenance_sessions_cancel`** — cancelling mid-run can
+  leave an install half-applied on a production machine. Stopping a
+  destructive operation is itself destructive here.
+- **`immybot_deployments_create`** — this is the non-obvious one. On its
+  own it changes nothing, which is why it looks like a write. But it
+  asserts desired state, and the next scheduled maintenance window will
+  act on that assertion across the whole scope with no further human
+  approval. It is a delayed-action version of
+  `immybot_maintenance_sessions_start`, and **there is no
+  `immybot_deployments_delete` in this tool surface** — an agent that
+  creates the wrong deployment cannot undo it through this plugin. A
+  latent, unrevocable, fleet-wide install is a destructive-tier blast
+  radius no matter how quiet the API call is.
+- **`immybot_computers_trigger_checkin`** — forces an agent to phone
+  home immediately. Innocuous on an idle machine; on one with a staged
+  deployment or pending session it is the trigger that makes the install
+  happen now. Its blast radius is the pending work's, not its own, and
+  the caller usually cannot see what is pending.
+
+`immybot_scripts_validate` is safe and belongs in Read: it checks
+PowerShell syntax without executing anything. Use it before every
+`immybot_scripts_run`.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.**
+
+- Read tools: allow. Compliance scorecards, task-queue audits, per-tenant
+  QBR assembly, and failed-install investigation are the intended
+  autonomous use and cover most day-to-day work.
+- Write tools: agent drafts the exact call, human approves, then it
+  runs.
+- Destructive tools: require a named human approver per invocation. The
+  approval must state the **exact target scope** — computer ID or tenant
+  ID — because ImmyBot's scope argument is where the damage multiplies.
+  Do not grant any destructive tool to a scheduled or unattended agent.
+- Additional rule for `immybot_scripts_run`: name the script ID and the
+  target computer ID in the approval request, and validate custom script
+  content with `immybot_scripts_validate` first. The MCP server returns
+  its own SYSTEM-context confirmation warning; surface that warning to
+  the approver rather than summarising it.
+- Additional rule for tenant-scoped sessions: pilot on one computer,
+  read `immybot_maintenance_sessions_results`, then expand. Never let
+  the first run of anything be tenant-wide.
+
+## What it cannot reach
+
+- Only the ImmyBot instance mapped to the operator's gateway identity,
+  and within it only the tenants the Entra app registration's ImmyBot
+  role can see.
+- Windows only. ImmyBot does not manage macOS or Linux endpoints, so
+  the mac and Linux half of a mixed fleet is invisible here and lives in
+  the RMM.
+- Endpoints that are enrolled but offline. Work queues rather than
+  failing, which is its own hazard — see below.
+- No filesystem or shell on the technician's machine, no other vendor's
+  data.
+- No PSA, no ticketing, no billing. Nothing here opens a ticket or tells
+  a customer what happened.
+
+## Data handling
+
+- ImmyBot responses pass through the gateway into model context for the
+  session and are not persisted by this plugin.
+- `immybot_computers_inventory` and
+  `immybot_tenants_software_inventory` return a complete per-endpoint
+  software bill of materials including versions — effectively a
+  vulnerability map of the client's fleet. `immybot_computers_*` returns
+  hostnames and serial numbers.
+- `immybot_scripts_get` returns full PowerShell source. Scripts written
+  in-house frequently contain embedded endpoints, service account
+  names, or credentials that the author assumed nobody would read. Treat
+  script bodies as potentially secret-bearing before pasting them into a
+  ticket or a chat.
+- `immybot_maintenance_sessions_logs` and `immybot_tasks_logs` return
+  raw execution output, which can include anything the script printed.
+
+## Known sharp edges
+
+- **Nothing happens until a session runs.** Creating a deployment is
+  step one of two. An agent that reports "software deployed" after
+  `immybot_deployments_create` is wrong, and the operator will not find
+  out until the next maintenance window proves it.
+- **Offline endpoints queue rather than fail.** Targeting an offline
+  computer returns success and does nothing until it checks in — at
+  which point the work runs unattended, possibly days later, with
+  nobody watching. Confirm the target is online before starting
+  anything.
+- **Reboots are a flag, not a prompt.** `reboot` on a session start
+  authorises restarts across the whole scope. A tenant-wide session with
+  reboots allowed will restart production servers.
+- **Cancel is not undo.** `immybot_maintenance_sessions_cancel` stops
+  further work; it does not roll back what already ran.
+- **Conflicting deployments fight.** Two deployments covering the same
+  software on the same scope produce install/uninstall churn on the
+  endpoint. Check `immybot_deployments_for_computer` before adding one —
+  and remember you cannot delete the loser through this plugin.
+- **HTTP 409 means a session is already running.** Retrying is the wrong
+  response; find and inspect the existing session first.

--- a/msp-claude-plugins/immybot/immybot/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/immybot/immybot/skills/api-patterns/SKILL.md
@@ -23,6 +23,17 @@ to the desired state. The MCP surface mirrors that model — listing
 and configuring desired state is one set of tools; running and
 inspecting maintenance sessions is another.
 
+## Anti-triggers
+
+- **Entra ID app registrations, consent, or Graph scopes in general** —
+  ImmyBot happens to authenticate with an Entra client-credentials app,
+  but this skill covers only the four ImmyBot credential fields.
+  Questions about Entra apps themselves are
+  `microsoft-graph-connection`.
+- **What a maintenance session actually does** — the polling cadence is
+  here; session scope, reboot behaviour, and cancel semantics are
+  `immybot-maintenance-sessions`.
+
 ## Connection & Authentication
 
 ImmyBot uses Microsoft Entra ID (Azure AD) OAuth 2.0 client

--- a/msp-claude-plugins/immybot/immybot/skills/endpoint-management/SKILL.md
+++ b/msp-claude-plugins/immybot/immybot/skills/endpoint-management/SKILL.md
@@ -18,6 +18,19 @@ ImmyBot manages Windows endpoints (computers) grouped under tenants
 (client organizations). This skill covers querying and onboarding
 those computers and inspecting their state.
 
+## Anti-triggers
+
+- **The same machine under the RMM** — ImmyBot sees only Windows
+  computers enrolled in this instance, and an endpoint is normally
+  enrolled in an RMM as well: `atera-agents`, `syncro-assets`,
+  `superops-assets`, `ncentral-devices`, `ninjaone-rmm-devices`, or
+  `datto-rmm-devices`. Inventory from the two will legitimately differ.
+- **What *should* be installed on a computer** — this skill reads what
+  is actually there; desired state is
+  `immybot-software-deployment`.
+- **Fleet-wide or per-tenant rollups** — use
+  `immybot-tenant-compliance`.
+
 ## API Tools
 
 | Tool | Purpose |

--- a/msp-claude-plugins/immybot/immybot/skills/maintenance-sessions/SKILL.md
+++ b/msp-claude-plugins/immybot/immybot/skills/maintenance-sessions/SKILL.md
@@ -21,6 +21,18 @@ updating, or removing software and running remediation. Starting a
 session is **destructive**: it can install software and reboot
 machines.
 
+## Anti-triggers
+
+- **An N-central maintenance window** — a *window* is a scheduled alert
+  suppression period that executes nothing; an ImmyBot *session* is an
+  execution run that installs software and reboots machines. For
+  windows use `ncentral-monitoring-tasks`. SuperOps script schedules
+  (`superops-runbooks`) are likewise a calendar, not a session.
+- **What should be installed** — the desired state a session reconciles
+  is configured in `immybot-software-deployment`.
+- **Running one script now** — a session reconciles everything in scope;
+  for a single script use `immybot-script-execution`.
+
 ## API Tools
 
 | Tool | Purpose |

--- a/msp-claude-plugins/immybot/immybot/skills/script-execution/SKILL.md
+++ b/msp-claude-plugins/immybot/immybot/skills/script-execution/SKILL.md
@@ -18,6 +18,21 @@ endpoints in **SYSTEM context**. This is a privileged, destructive
 capability — scripts can install/uninstall software, change system
 settings, access files, and reboot the machine.
 
+## Anti-triggers
+
+- **Installing or updating software** — ImmyBot has no "install this
+  now" call, and a PowerShell installer script is exactly the
+  anti-pattern the platform exists to remove; use
+  `immybot-software-deployment`.
+- **Running a script on an endpoint managed by another RMM** — ImmyBot
+  reaches only computers enrolled in this ImmyBot instance, and ImmyBot
+  is Windows-only. The same request against another fleet is
+  `atera-agents`, `syncro-assets`, `superops-runbooks`,
+  `ncentral-monitoring-tasks`, `connectwise-automate-scripts`, or
+  `datto-rmm-jobs`.
+- **A script that ran inside a reconciliation** — scripts executed by a
+  session are tasks; use `immybot-maintenance-sessions`.
+
 ## API Tools
 
 | Tool | Purpose |

--- a/msp-claude-plugins/immybot/immybot/skills/software-deployment/SKILL.md
+++ b/msp-claude-plugins/immybot/immybot/skills/software-deployment/SKILL.md
@@ -19,6 +19,19 @@ you assert what should be installed, then a maintenance session
 brings the endpoint into compliance. This skill walks the canonical
 deployment workflow end-to-end.
 
+## Anti-triggers
+
+- **Making the install actually happen** — creating a deployment changes
+  nothing on any endpoint; the reconciliation run that acts on it is
+  `immybot-maintenance-sessions`.
+- **OS and security patching** — ImmyBot deploys applications, not
+  Windows Update. Patch compliance lives in the RMM: `superops-assets`,
+  `syncro-assets`, or `ncentral-devices`.
+- **A one-off command on one machine** — use
+  `immybot-script-execution`.
+- **Whether a tenant is compliant overall** — rollups and scorecards are
+  `immybot-tenant-compliance`.
+
 ## API Tools
 
 ### Discover the catalog

--- a/msp-claude-plugins/immybot/immybot/skills/tenant-compliance/SKILL.md
+++ b/msp-claude-plugins/immybot/immybot/skills/tenant-compliance/SKILL.md
@@ -18,6 +18,19 @@ Tenants are ImmyBot's client organizations. This skill covers
 tenant-level queries, compliance rollups, and the background-task
 queue that powers fleet-wide operational and QBR reporting.
 
+## Anti-triggers
+
+- **Regulatory or framework compliance** — "compliance" here means
+  installed software matches desired state, nothing more. CIS, NIST, and
+  SOC 2 control mapping is `scalepad-controlmap`; Microsoft 365 security
+  baselines are `cipp-standards`.
+- **A Microsoft 365 or Entra tenant** — an ImmyBot tenant is a client
+  organization inside this ImmyBot instance and is unrelated to an M365
+  tenant ID, even though ImmyBot authenticates via Entra. Use
+  `cipp-tenants`.
+- **Fixing what the report shows** — this skill reports; remediation is
+  `immybot-software-deployment` and `immybot-maintenance-sessions`.
+
 ## Tenant API Tools
 
 | Tool | Purpose |

--- a/msp-claude-plugins/liongard/liongard/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/liongard/liongard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "liongard",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Claude plugins for Liongard - environments, inspections, systems, detections, agents",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/liongard/liongard/GOVERNANCE.md
+++ b/msp-claude-plugins/liongard/liongard/GOVERNANCE.md
@@ -1,0 +1,164 @@
+# Liongard plugin — governance and safety model
+
+Unofficial. Community-built plugin for the Liongard (ROAR) API. Not
+affiliated with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+The supported deployment reaches Liongard through the WYRE Conduit
+gateway (`https://conduit.wyre.ai/v1/liongard/mcp`), which brokers
+authentication centrally and scopes every call to the instance the
+operator is authorised for.
+
+- No Liongard instance name or `X-ROAR-API-KEY` value is stored on the
+  technician's machine, in this repo, or in the model's context.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers
+  "who deleted that agent". Liongard's timeline records the API key's
+  identity, which is shared.
+- Revoking a technician's gateway access revokes Liongard access with
+  it, immediately.
+
+**If you run without the gateway**, the plugin README documents a direct
+mode where `LIONGARD_INSTANCE` and `LIONGARD_API_KEY` sit in the
+technician's MCP config. That mode gives up all four properties above.
+
+## Tool permission tiers
+
+Grouped by blast radius, not HTTP verb.
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change Liongard or any inspected system. Safe for autonomous agents. | `liongard_navigate`, `liongard_environments_list`, `liongard_environments_get`, `liongard_environments_count`, `liongard_environments_related`, `liongard_agents_list`, `liongard_inspections_inspectors`, `liongard_inspections_launchpoints`, `liongard_systems_list`, `liongard_systems_get`, `liongard_detections_list`, `liongard_detections_get`, `liongard_metrics_list`, `liongard_metrics_evaluate`, `liongard_metrics_evaluate_systems`, `liongard_inventory_devices`, `liongard_inventory_device_get`, `liongard_inventory_identities`, `liongard_inventory_identity_get`, `liongard_timeline_list` |
+| **Write** | Creates Liongard-side configuration, or authenticates to a customer system. Reversible. | `liongard_environments_create`, `liongard_inspections_create_launchpoint`, `liongard_inspections_run` |
+| **Destructive** | Removes a customer's data collection. Requires explicit per-call human approval. | `liongard_agents_delete` |
+
+**This plugin cannot touch a customer endpoint, and that is the headline
+governance fact about it.** Liongard reads and documents; it does not
+remediate. There is no script execution, no patch push, no reboot, no
+account disable. Everything an operator wants to *do* about a Liongard
+finding happens in the RMM or PSA, under that plugin's tiers.
+
+### Why the classifications land where they do
+
+- **`liongard_agents_delete` is the only destructive tool.** A Liongard
+  agent is one piece of software per customer site that runs every
+  inspection bound to it. Deleting it does not remove data already
+  collected, but every launchpoint that depended on it silently stops
+  collecting. The failure mode is a monitoring blind spot that looks
+  exactly like "no changes detected" — the customer's configuration
+  drift becomes invisible rather than alarming. Recovery needs a
+  physical or remote reinstall at the site, which this plugin cannot do.
+- **`liongard_inspections_run` is Write, not Destructive**, and that is
+  deliberate. It triggers a data collection using stored credentials. It
+  changes nothing on the target, so despite the word "run" it does not
+  belong in the same tier as an RMM's script execution. Over-classifying
+  it would make the destructive tier meaningless. It is not a Read
+  either: it consumes a privileged authenticated session against the
+  customer's production domain controller, firewall, or M365 tenant, and
+  it can trip conditional-access or lockout policies.
+- **`liongard_inspections_create_launchpoint` is Write with weight.** A
+  launchpoint binds an inspector, an environment, an agent, stored
+  credentials, and a cron schedule. Creating one commits the MSP to
+  recurring privileged authentication against a customer system on a
+  schedule nobody may revisit.
+- **`liongard_metrics_evaluate` stays in Read.** It runs a JMESPath
+  expression against already-collected inspection data. The expression
+  is caller-supplied, but it evaluates over a JSON document — it is not
+  a remote-execution surface.
+
+The Liongard REST API's two genuinely catastrophic calls — deleting an
+environment and deleting a launchpoint — **are not exposed by this MCP
+surface**. Both cascade: they destroy all associated systems,
+detections, and historical inspection data with no undo. An agent
+cannot reach them here, and if either is ever added it belongs in the
+destructive tier immediately. Until then, decommissioning a client is a
+console operation a human does, and `Status = Inactive` is the
+reversible alternative.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.**
+
+- Read tools: allow, generously. Cross-environment change review,
+  compliance metric evaluation, and asset correlation are exactly what
+  an autonomous agent should be doing with Liongard.
+- Write tools: agent drafts the exact call, human approves, then it
+  runs. For `liongard_inspections_run`, name the launchpoint and the
+  customer; for `create_launchpoint`, the approver should confirm which
+  credential the launchpoint will use.
+- Destructive tools: `liongard_agents_delete` needs a named human
+  approver who has checked which launchpoints are bound to that agent
+  first (`liongard_inspections_launchpoints`). Do not grant it to
+  scheduled or unattended agents.
+
+## What it cannot reach
+
+- Only the Liongard instance mapped to the operator's gateway identity.
+  Liongard URLs are instance-scoped (`https://{instance}.app.liongard.com`)
+  and a key is valid on exactly one instance.
+- No customer endpoint, in any sense. No shell, no script, no file, no
+  reboot.
+- Not the credentials themselves. Launchpoint credentials are stored in
+  Liongard's vault; no tool in this surface returns a stored secret.
+- No filesystem, no shell on the technician's machine, no other
+  vendor's data.
+- No live event stream. Detections appear only after the next
+  inspection runs.
+
+## Data handling
+
+This is the most sensitive read surface in this batch. Liongard's whole
+purpose is to concentrate the configuration of every system an MSP
+manages into one queryable store, which means an agent with read access
+has an unusually complete picture of the client estate.
+
+- `liongard_systems_get` returns raw inspection detail: Active Directory
+  users and group membership, firewall rules and VPN configuration,
+  Microsoft 365 security settings and licence assignments, backup job
+  state, certificate inventory. This is a full configuration blueprint
+  of the customer's environment.
+- `liongard_inventory_identities` and `liongard_inventory_identity_get`
+  return correlated user identities across platforms — names, email
+  addresses, and where each account exists.
+- `liongard_detections_list` reveals security posture changes, including
+  MFA policies being disabled. Read access here is reconnaissance-grade
+  intelligence about which clients are currently weakest.
+- `liongard_timeline_list` is the audit trail. Preserve it; do not let
+  automation depend on being able to alter it (nothing here can).
+- Responses pass through the gateway into model context for the session
+  and are not persisted by this plugin.
+
+## Known sharp edges
+
+- **"Agent" means something different here.** A Liongard agent is a
+  per-site inspection runner, not a per-endpoint sensor. An operator who
+  reads `liongard_agents_list` expecting an endpoint count will
+  misreport coverage by orders of magnitude, and an agent deletion that
+  seems to affect "one machine" affects an entire site's collection.
+- **Stale data reads as good news.** A system whose inspection stopped
+  running keeps returning its last snapshot. Always check
+  `LastInspection` before reporting a configuration as current;
+  "no detections this month" and "no inspections this month" look
+  identical in a summary.
+- **Inspections carry privileged credentials.** A launchpoint holds
+  Domain Admin or Global Admin-class credentials for the customer's
+  environment. Running or scheduling one is spending that privilege.
+- **Detections are change events, not alerts.** A detection means
+  something changed, not that something is wrong. An agent that escalates
+  every `Added` detection will bury the operator in noise and train them
+  to ignore the real ones.
+- **Credential rotation on the target breaks inspections silently.**
+  When a customer changes the Domain Admin password, the launchpoint
+  stays `Active` and its runs fail with an authentication error. The
+  failure appears in the timeline, not in the launchpoint's own status,
+  so a "healthy launchpoints" report can be entirely wrong.
+- **Environment names are unique instance-wide.** A create collision
+  returns 409 rather than a validation body. An agent retrying a failed
+  onboarding can end up creating "ACME 2" and splitting one client's
+  history across two environments.
+- **300 requests/minute.** Batch-triggering an environment's
+  launchpoints needs pacing — roughly 500 ms between runs — both to stay
+  under the limit and to avoid swamping the single site agent that has
+  to execute all of them.

--- a/msp-claude-plugins/liongard/liongard/skills/detections/SKILL.md
+++ b/msp-claude-plugins/liongard/liongard/skills/detections/SKILL.md
@@ -19,6 +19,22 @@ when_to_use: >-
 
 Detections are Liongard's automated change and anomaly detection system. Every time an inspection runs, Liongard compares the new data with previous inspection results and identifies changes. Those changes become detections that MSPs monitor, investigate, and act upon. Around detections sit **alerts** (configurable rules that turn detections into notifications), **metrics** (custom measurements evaluated across systems for compliance reporting), and the **timeline** (a platform-wide audit trail of inspections, detections, and user actions).
 
+## Anti-triggers
+
+- **Security detections and EDR alerts** — a Liongard detection is a
+  configuration *change*, not a threat. Malicious activity is
+  `huntress-signals`, `huntress-incidents`, `sentinelone-alerts`, or
+  `rocketcyber-incidents`.
+- **RMM threshold and availability alerts** — disk-full, offline, and
+  service-down alerts come from the RMM: `atera-alerts`,
+  `superops-alerts`, `ncentral-monitoring-tasks`,
+  `ninjaone-rmm-alerts`, or `datto-rmm-alerts`.
+- **Compliance frameworks** — Liongard metrics are custom JMESPath
+  measurements over inspection data; mapping evidence to CIS, NIST, or
+  SOC 2 controls is `scalepad-controlmap`.
+- **Why the underlying data changed at all** — the inspection that
+  produced the comparison is `liongard-inspections`.
+
 ## Key Concepts
 
 ### Detections

--- a/msp-claude-plugins/liongard/liongard/skills/environments/SKILL.md
+++ b/msp-claude-plugins/liongard/liongard/skills/environments/SKILL.md
@@ -18,6 +18,19 @@ when_to_use: >-
 
 Environments in Liongard represent customer organizations or sites being monitored. Each environment is the top-level container for all inspection activity, discovered systems, detections, and metrics associated with a particular client, so nearly every other Liongard query is scoped by `EnvironmentID`.
 
+## Anti-triggers
+
+- **A dev, staging, or production environment** — a Liongard environment
+  is a customer organization. It has nothing to do with deployment
+  tiers.
+- **The client's commercial record** — creating an environment does not
+  onboard a client; use `connectwise-psa-companies`, `autotask-crm`, or
+  `superops-clients`.
+- **A Microsoft 365 tenant** — an environment can hold an M365
+  inspection but is not a tenant; use `cipp-tenants`.
+- **What was discovered inside an environment** — `liongard-systems` for
+  the assets, `liongard-detections` for the changes.
+
 ## Key Concepts
 
 ### Environments

--- a/msp-claude-plugins/liongard/liongard/skills/inspections/SKILL.md
+++ b/msp-claude-plugins/liongard/liongard/skills/inspections/SKILL.md
@@ -19,6 +19,20 @@ when_to_use: >-
 
 Inspections are the core mechanism by which Liongard captures IT documentation. The system has three parts: **inspectors** (templates defining what to inspect), **launchpoints** (configured instances tying an inspector to an environment, agent, credentials, and schedule), and **inspections** (individual execution runs that produce system data and potentially trigger detections). The relationship flows: **Inspector** (template) -> **Launchpoint** (configuration) -> **Inspection** (execution) -> **System** (discovered data).
 
+## Anti-triggers
+
+- **"Run" meaning execute a script on an endpoint** —
+  `liongard_inspections_run` collects configuration data. It runs no
+  operator-supplied code and changes nothing on the target. Script
+  execution is `immybot-script-execution`,
+  `ncentral-monitoring-tasks`, `superops-runbooks`, `atera-agents`,
+  `syncro-assets`, `connectwise-automate-scripts`, or `datto-rmm-jobs`.
+- **Scheduled maintenance on endpoints** — a launchpoint cron schedules
+  data collection, not patching or reboots; use
+  `immybot-maintenance-sessions` or `ncentral-monitoring-tasks`.
+- **What an inspection produced** — `liongard-systems` for the data,
+  `liongard-detections` for the changes it surfaced.
+
 ## Key Concepts
 
 ### Inspectors

--- a/msp-claude-plugins/liongard/liongard/skills/overview/SKILL.md
+++ b/msp-claude-plugins/liongard/liongard/skills/overview/SKILL.md
@@ -27,6 +27,23 @@ Liongard is an automated IT documentation and configuration management platform 
 
 Liongard replaces manual documentation processes with automated, scheduled inspections that capture the state of servers, firewalls, cloud services, and more.
 
+## Anti-triggers
+
+- **"Agent" meaning an endpoint sensor** — a Liongard agent is one piece
+  of software per customer *site* that runs inspections against many
+  targets. It is not a per-endpoint monitor and reports nothing about
+  the machine it sits on. For endpoint agents use `atera-agents`,
+  `syncro-assets`, `ncentral-devices`, or
+  `immybot-endpoint-management`; in `halopsa-agents` an agent is a human
+  technician.
+- **Doing something about what Liongard found** — Liongard documents and
+  detects; it does not remediate. Action belongs to the RMM
+  (`ncentral-monitoring-tasks`, `superops-runbooks`,
+  `immybot-script-execution`) or the PSA.
+- **Working with a specific entity** — this skill only orients. Go
+  straight to `liongard-environments`, `liongard-inspections`,
+  `liongard-systems`, or `liongard-detections`.
+
 ## Key Terminology
 
 ### Environments

--- a/msp-claude-plugins/liongard/liongard/skills/systems/SKILL.md
+++ b/msp-claude-plugins/liongard/liongard/skills/systems/SKILL.md
@@ -20,6 +20,20 @@ when_to_use: >-
 
 Systems are the entities discovered during Liongard inspections. When a launchpoint runs an inspection, it discovers systems such as servers, firewalls, cloud services, user accounts, domain controllers, and other infrastructure components. Each system carries detailed configuration data captured at the time of inspection, giving a historical record of the IT environment.
 
+## Anti-triggers
+
+- **Acting on the device** — a Liongard system is a read-only snapshot
+  of something an inspection found. Rebooting it, patching it, or
+  running a script needs the RMM that manages it: `ncentral-devices`,
+  `atera-agents`, `syncro-assets`, `superops-assets`, or
+  `immybot-endpoint-management`.
+- **The MSP's documentation of record** — Liongard auto-discovers.
+  Hand-maintained documentation, passwords, and CIs live in
+  `hudu-assets` or `it-glue-configurations`.
+- **Why a system's data is stale or missing** — that is an inspection
+  problem; use `liongard-inspections`.
+- **What changed between two snapshots** — use `liongard-detections`.
+
 ## Key Concepts
 
 ### Systems

--- a/msp-claude-plugins/ncentral/ncentral/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/ncentral/ncentral/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ncentral",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "N-able N-central RMM — devices, org units, active issues, scheduled tasks, custom properties for on-prem and hosted servers",
   "author": {
     "name": "WYRE Technology"

--- a/msp-claude-plugins/ncentral/ncentral/GOVERNANCE.md
+++ b/msp-claude-plugins/ncentral/ncentral/GOVERNANCE.md
@@ -1,0 +1,171 @@
+# N-central plugin — governance and safety model
+
+Unofficial. Community-built plugin for the N-able N-central API. Not
+affiliated with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches N-central through the
+WYRE Conduit gateway (`https://conduit.wyre.ai/v1/ncentral/mcp`), which
+brokers authentication centrally and scopes every call to the server the
+operator is authorised for.
+
+- No User-API Token (JWT) or server URL is stored on the technician's
+  machine, in this repo, or in the model's context. Both are entered
+  once in Conduit's connect page and injected server-side per request.
+- The gateway exchanges the permanent JWT for short-lived access and
+  refresh tokens and rotates them transparently. No token lifecycle
+  happens client-side.
+- Every call carries operator identity, so the gateway audit log answers
+  "who dispatched that direct task". N-central's own log records only
+  the API user the token belongs to.
+- Revoking a technician's gateway access revokes N-central access with
+  it, immediately.
+
+Unlike the SaaS RMMs in this batch, every MSP runs its own N-central
+server. Conduit must be able to reach it over HTTPS, which for an
+on-prem deployment means deliberately opening an inbound path. That is a
+network-perimeter decision, not just a plugin decision.
+
+The API user behind the JWT is the real boundary. It must have MFA
+disabled — N-central rejects token auth for MFA-enabled users — so it is
+a standing, non-MFA account whose role and access groups determine
+everything an agent can see or do. Create a dedicated least-privilege
+API user; do not attach the token to a technician's own account.
+
+## Tool permission tiers
+
+Grouped by blast radius, not HTTP verb. Two of the three destructive
+entries are GET requests.
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change N-central or endpoint state. Safe for autonomous agents. | `ncentral_navigate`, `ncentral_back`, `ncentral_status`, `ncentral_health`, `ncentral_server_info`, `ncentral_validate_token`, `ncentral_list_service_orgs`, `ncentral_list_customers`, `ncentral_get_customer`, `ncentral_list_sites`, `ncentral_get_site`, `ncentral_list_org_units`, `ncentral_get_org_unit`, `ncentral_list_org_unit_children`, `ncentral_list_devices`, `ncentral_list_devices_by_org_unit`, `ncentral_list_device_filters`, `ncentral_get_device`, `ncentral_get_device_assets`, `ncentral_get_device_lifecycle`, `ncentral_get_device_service_status`, `ncentral_list_active_issues`, `ncentral_list_job_statuses`, `ncentral_list_device_tasks`, `ncentral_get_task`, `ncentral_get_task_status`, `ncentral_get_task_status_details`, `ncentral_list_org_custom_properties`, `ncentral_get_org_custom_property`, `ncentral_list_device_custom_properties`, `ncentral_get_device_custom_property`, `ncentral_list_maintenance_windows`, `ncentral_list_access_groups`, `ncentral_get_access_group` |
+| **Write** | Changes N-central-side records. Reversible, but see the custom-property caveat. | `ncentral_update_device_lifecycle`, `ncentral_update_org_custom_property`, `ncentral_update_device_custom_property`, `ncentral_add_maintenance_windows`, `ncentral_create_device_access_group`, `ncentral_create_org_unit_access_group` |
+| **Destructive** | Executes on a live endpoint, discloses a credential, or removes alert suppression. Requires explicit per-call human approval. | `ncentral_create_direct_task`, `ncentral_get_registration_token`, `ncentral_delete_maintenance_windows` |
+
+### Why each destructive tool is there
+
+- **`ncentral_create_direct_task`** — executes a task, script, or
+  command **immediately** on a live production device as SYSTEM/root.
+  There is no scheduling, no dry run, and no cancel once dispatched.
+  Whatever the script does, it does now. This is the only tool in the
+  plugin that changes machine state, and it is the reason the plugin
+  needs a governance document at all.
+- **`ncentral_get_registration_token`** — a GET, and destructive
+  anyway. It returns the token embedded in agent installers for an org
+  unit. Anyone holding it can enrol a device into that customer's
+  N-central environment. Classifying it as a read because HTTP says so
+  would put credential disclosure in the tier marked "safe for
+  autonomous agents". Fetch it only when a human is actively deploying
+  an agent, paste it to that human and nowhere else, and never write it
+  to a ticket, a file, or a chat log. If one leaks, it is rotated in the
+  N-central UI, which this plugin cannot do.
+- **`ncentral_delete_maintenance_windows`** — deleting a window does not
+  touch an endpoint, but it removes the suppression that was keeping a
+  planned outage quiet. Delete one mid-patch-run and the NOC floods,
+  tickets auto-generate, and on-call gets paged for expected behaviour.
+  It is also irreversible through this surface: the original window
+  definition is gone and `ncentral_add_maintenance_windows` cannot
+  recreate what you did not record.
+
+### The custom-property caveat
+
+`ncentral_update_device_custom_property` and
+`ncentral_update_org_custom_property` sit in Write, but **treat them as
+destructive whenever the property drives automation.** N-central
+automation policies and device filters commonly key off custom property
+values — "Patch Ring", "Maintenance Group", "Backup Policy". Changing
+one of those does not look like an endpoint operation and is not
+recorded as one, yet it can silently move a device into a different
+patch schedule and cause patches to be pushed to a production server
+that was deliberately excluded. Updates also overwrite with no history:
+there is no undo and no record of the previous value unless the caller
+read it first.
+
+Rule: before any custom-property write, read the current value, echo
+before-and-after to the operator, and ask explicitly whether the
+property is policy-keyed. If the answer is yes or unknown, require the
+same approval as a direct task.
+
+`ncentral_update_device_lifecycle` is the mildest write here — warranty
+dates, purchase cost, expected replacement. It touches no monitoring and
+no endpoint. It still overwrites without history, so a bulk stamp from a
+vendor export can quietly destroy hand-entered data.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.**
+
+- Read tools: allow. Cross-customer active-issue sweeps, warranty
+  audits, task-outcome drill-downs, and monitor-health triage are the
+  intended autonomous use, and the bundled `device-auditor` and
+  `issue-triager` agents are built to stay inside this tier.
+- Write tools: agent drafts the exact call with before-and-after values,
+  human approves, then it runs.
+- Destructive tools: require a named human approver per invocation. For
+  `ncentral_create_direct_task` the approval must name the device (name
+  **and** ID), the customer, the task or script, and its parameters —
+  and it must be a fresh approval, never one chained silently onto the
+  end of a triage. Target one device per task; fleet-wide remediation
+  belongs in a scheduled task authored in the N-central UI, not a loop
+  of direct tasks.
+- After any direct task, poll `ncentral_get_task_status` and report the
+  real outcome. "Task created" is not "task succeeded", and an agent
+  that stops at dispatch has told the operator nothing.
+- Do not grant any destructive tool to a scheduled or unattended agent.
+
+## What it cannot reach
+
+- Only the single N-central server whose URL and JWT are registered in
+  Conduit. There is no shared cloud endpoint and no cross-server scope;
+  credentials are valid on exactly one server.
+- Within that server, only what the API user's role and access groups
+  permit. A least-privilege API user is a real, enforced boundary here,
+  unlike vendors with a single all-powerful key.
+- No filesystem or shell on the technician's machine, no other vendor's
+  data.
+- No PSA. Active issues are not tickets, and nothing here opens one.
+- No SO-level active-issue query. Issues list per customer or site only,
+  so a cross-client sweep is an explicit loop, not a firehose.
+- No live event stream. Every tool is point-in-time.
+
+## Data handling
+
+- N-central responses pass through the gateway into model context for
+  the session and are not persisted by this plugin.
+- `ncentral_get_registration_token` returns a **credential**. It is the
+  only tool in this batch whose normal output should be treated as a
+  secret. Do not let it land in a transcript that gets pasted anywhere.
+- `ncentral_get_device_assets` returns full hardware and software
+  inventory — OS build, installed software, disks, NICs — per endpoint.
+  `ncentral_get_task_status_details` returns captured script output,
+  which can contain anything the script printed, including credentials
+  a script author embedded.
+- `ncentral_list_customers` and the org-unit tools return the MSP's
+  entire client list; `ncentral_get_device_lifecycle` returns purchase
+  cost and lease terms.
+
+## Known sharp edges
+
+- **Stale monitors are not healthy monitors.** A device whose service
+  status reads `Stale` or `Disconnected` has stopped reporting; every
+  other monitor on it is untrustworthy until the agent checks in. An
+  agent that reads "no failures" off a disconnected device reports a
+  green light on a dark machine. `Misconfigured` is a setup error, not
+  an outage.
+- **A "down" server inside its maintenance window is expected.** Check
+  `ncentral_list_maintenance_windows` before escalating anything, and
+  before deleting a window check what is running inside it.
+- **Preview-stage endpoints vary by release.** Active issues, scheduled
+  tasks, maintenance windows, and custom properties sit on preview
+  endpoints in some N-central versions. A 404 may mean "your server does
+  not ship this", not "the ID is wrong" — check
+  `https://<server>/api-explorer`.
+- **Device IDs are per-server.** When correlating with a PSA or
+  documentation tool, match on hostname or serial number, never on ID.
+- **Private-CA certificates.** On-prem servers presenting an internal CA
+  certificate need the CA bundle supplied to the sidecar via
+  `NODE_EXTRA_CA_CERTS`. Disabling TLS verification to get past it turns
+  a trusted inbound path into an unauthenticated one.

--- a/msp-claude-plugins/ncentral/ncentral/skills/devices/SKILL.md
+++ b/msp-claude-plugins/ncentral/ncentral/skills/devices/SKILL.md
@@ -19,6 +19,23 @@ device record scoped to a customer or site org unit. This skill covers
 listing strategy (filters vs org-unit scoping), the asset/lifecycle data
 model, and service-monitor triage.
 
+## Anti-triggers
+
+- **Doing something to the device** — everything here reads, apart from
+  lifecycle writes. Running a script, restarting a service, or pushing a
+  fix is `ncentral-monitoring-tasks` and its direct-task tool.
+- **The same endpoint under a different RMM** — `atera-agents`,
+  `syncro-assets`, `superops-assets`, `immybot-endpoint-management`,
+  `ninjaone-rmm-devices`, `datto-rmm-devices`, and
+  `connectwise-automate-computers` each see only their own fleet. Watch
+  for `atera-devices` in particular, where "device" means an agentless
+  SNMP or HTTP monitor rather than an endpoint.
+- **Hardware refresh programmes** — N-central lifecycle fields are a
+  free-text store someone has to populate; procurement-grade planning is
+  `scalepad-lifecycle-manager`.
+- **Which customer or site a device belongs to** — org-unit resolution
+  is `ncentral-organizations`.
+
 ## Tools
 
 | Tool | Use For |

--- a/msp-claude-plugins/ncentral/ncentral/skills/monitoring-tasks/SKILL.md
+++ b/msp-claude-plugins/ncentral/ncentral/skills/monitoring-tasks/SKILL.md
@@ -18,6 +18,24 @@ wrong — active issues and job statuses) and **tasks** (automation that has
 run or will run — scheduled tasks and direct support tasks). Triage flows
 from the first into the second.
 
+## Anti-triggers
+
+- **Running a task on an endpoint managed elsewhere** —
+  `ncentral_create_direct_task` executes only on N-central-managed
+  devices. The same request against another fleet is
+  `immybot-script-execution`, `superops-runbooks`, `atera-agents`,
+  `syncro-assets`, `connectwise-automate-scripts`, or `datto-rmm-jobs`.
+- **ImmyBot maintenance sessions** — an N-central maintenance *window*
+  suppresses alerting for a period and executes nothing. The
+  reconciliation run that shares the name is
+  `immybot-maintenance-sessions`.
+- **Turning an active issue into customer-visible work** — active issues
+  are not tickets; the service desk of record is
+  `connectwise-psa-tickets`, `autotask-tickets`, `halopsa-tickets`, or
+  the PSA the MSP actually uses.
+- **Per-device monitor state** — the drill-down from an active issue is
+  `ncentral-devices`.
+
 ## Active Issues
 
 | Tool | Use For |

--- a/msp-claude-plugins/ncentral/ncentral/skills/organizations/SKILL.md
+++ b/msp-claude-plugins/ncentral/ncentral/skills/organizations/SKILL.md
@@ -19,6 +19,17 @@ units**. Almost every other object — devices, active issues, tasks, custom
 properties, access groups — is scoped to an org unit, so getting the
 hierarchy right is the first step of any workflow.
 
+## Anti-triggers
+
+- **The client's commercial record** — an N-central customer is a
+  monitoring scope, not a billing entity. The company of record is
+  `connectwise-psa-companies`, `autotask-crm`, `syncro-customers`, or
+  `superops-clients`.
+- **A Microsoft 365 tenant or an Entra OU** — an N-central org unit is
+  neither, despite the shared "organizational unit" wording; use
+  `cipp-tenants`.
+- **Devices inside an org unit** — use `ncentral-devices`.
+
 ## The Hierarchy
 
 ```

--- a/msp-claude-plugins/superops/superops-ai/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/superops/superops-ai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "superops",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Claude Code plugin for SuperOps.ai PSA/RMM - tickets, assets, clients, alerts",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/superops/superops-ai/GOVERNANCE.md
+++ b/msp-claude-plugins/superops/superops-ai/GOVERNANCE.md
@@ -1,0 +1,109 @@
+# SuperOps plugin — governance and safety model
+
+Unofficial. Community-built plugin for the SuperOps.ai API. Not
+affiliated with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+The supported deployment reaches SuperOps through the WYRE Conduit
+gateway (`https://conduit.wyre.ai/v1/superops/mcp`), which brokers
+authentication centrally and scopes every call to the tenant the
+operator is authorised for.
+
+- No SuperOps API token or `CustomerSubDomain` value is stored on the
+  technician's machine, in this repo, or in the model's context.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers
+  "who ran this mutation". SuperOps records only the token's owner.
+- Revoking a technician's gateway access revokes SuperOps access with
+  it, immediately.
+
+**If you run without the gateway**, the plugin README documents a direct
+mode where the API token sits in the technician's Claude settings. That
+mode gives up all four properties above, and it matters more here than
+for most vendors because of `superops_custom_mutation` (below).
+
+## Tool permission tiers
+
+Grouped by blast radius, not HTTP verb.
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change SuperOps or endpoint state. Safe for autonomous agents. | `superops_navigate`, `superops_status`, `superops_test_connection`, `superops_assets_list`, `superops_assets_get`, `superops_assets_patches`, `superops_assets_software`, `superops_clients_list`, `superops_clients_get`, `superops_clients_search`, `superops_technicians_list`, `superops_technicians_get`, `superops_technicians_groups`, `superops_tickets_list`, `superops_tickets_get`, `superops_custom_query` |
+| **Write** | Creates or modifies PSA records. Reversible, customer-visible. | `superops_tickets_create`, `superops_tickets_update`, `superops_tickets_add_note`, `superops_tickets_log_time` |
+| **Destructive** | Unbounded write access to the tenant. Requires explicit per-call human approval. | `superops_custom_mutation` |
+
+`superops_custom_mutation` is the single most dangerous tool in this
+plugin and the reason its destructive tier is not empty. It executes an
+arbitrary GraphQL mutation string against the tenant. Whatever the
+SuperOps schema permits — deleting a client, reassigning every ticket,
+changing contract terms, or triggering a script execution across an
+asset group — this tool can do, and neither the tool name nor its
+schema constrains it. The typed tools above are a curated safe subset;
+`superops_custom_mutation` bypasses that curation entirely. Treat it as
+handing an agent the tenant's admin console.
+
+The typed script-execution surface described in the `superops-runbooks`
+skill is **not** exposed as its own tool. That means script execution
+against customer endpoints is only reachable through
+`superops_custom_mutation` — a second, independent reason it belongs in
+the destructive tier. Script execution is destructive regardless of what
+the API calls it.
+
+`superops_custom_query` stays in Read because it cannot mutate, but it
+can read anything the token can see, including entities no typed tool
+surfaces. It is the exfiltration path, not the damage path.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.**
+
+- Read tools: allow. Cross-client asset audits, patch-compliance
+  reporting, and ticket triage are the intended autonomous use.
+- Write tools: agent drafts the exact call, human approves, then it
+  runs.
+- Destructive tools: `superops_custom_mutation` needs a named human
+  approver per invocation, and the approver must read the full mutation
+  string — not a summary of it. Do not grant this tool to scheduled or
+  unattended agents under any circumstances. If your operators do not
+  read GraphQL, disable it at the gateway.
+
+## What it cannot reach
+
+- Only the SuperOps tenant (`CustomerSubDomain`) mapped to the
+  operator's gateway identity. SuperOps tokens are single-tenant;
+  there is no cross-MSP scope.
+- No filesystem, no shell, no other vendor's data.
+- No endpoint, via the typed tools. There is no remote-execution,
+  patch-push, reboot, or wipe tool in the curated surface — but see
+  `superops_custom_mutation`, which is not bounded by that statement.
+- No live event stream. Every tool is point-in-time.
+
+## Data handling
+
+- SuperOps responses pass through the gateway into model context for the
+  session and are not persisted by this plugin.
+- `superops_technicians_*` returns MSP staff PII. `superops_clients_*`
+  returns client contacts and email domains.
+  `superops_assets_*` returns hostnames, IP and MAC addresses, serial
+  numbers, installed software, and per-asset missing-patch lists — a
+  ready-made target list. Restrict these if agents run unattended.
+- `superops_custom_query` can return any object in the schema,
+  including ones with no typed tool and therefore no review above. Its
+  output should be treated as unclassified until a human looks at it.
+
+## Known sharp edges
+
+- **Null resets values.** SuperOps mutations treat an explicit `null`
+  as "clear this field" rather than "leave it alone". An agent that
+  serialises an unset optional as `null` will silently wipe data on
+  update.
+- **The subdomain header is load-bearing.** Omitting
+  `CustomerSubDomain` returns an authentication failure even with a
+  valid token, which reads like a credential problem and is not.
+- **Region-specific endpoints.** Tokens are scoped to a region; a
+  correct token against the wrong regional endpoint fails in a way that
+  looks like a permissions error.
+- **800 requests/minute, shared per tenant.** A full-fleet asset sweep
+  by an unattended agent throttles the technicians working alongside it.

--- a/msp-claude-plugins/superops/superops-ai/skills/alerts/SKILL.md
+++ b/msp-claude-plugins/superops/superops-ai/skills/alerts/SKILL.md
@@ -17,6 +17,21 @@ when_to_use: >-
 
 SuperOps.ai RMM generates alerts when monitored conditions are triggered on managed assets. Alerts can indicate hardware issues, software problems, security events, or custom monitoring conditions. This skill covers alert listing, filtering, acknowledgment, resolution, and automated workflows.
 
+## Anti-triggers
+
+- **The customer-facing work an alert becomes** — use
+  `superops-tickets`; the conversion is described here but the ticket
+  lifecycle is not.
+- **Alerts from a different RMM** — `atera-alerts`,
+  `ninjaone-rmm-alerts`, `datto-rmm-alerts`, and N-central active issues
+  (`ncentral-monitoring-tasks`) are separate stores with their own
+  severity scales.
+- **Security detections** — EDR and MDR findings are not RMM alerts; use
+  `huntress-incidents`, `sentinelone-alerts`, or
+  `rocketcyber-incidents`.
+- **Fixing what the alert reports** — remediation runs through
+  `superops-runbooks`; resolving an alert does not fix a machine.
+
 ## Alert Severity Levels
 
 | Severity | Description | Typical Response |

--- a/msp-claude-plugins/superops/superops-ai/skills/assets/SKILL.md
+++ b/msp-claude-plugins/superops/superops-ai/skills/assets/SKILL.md
@@ -19,6 +19,22 @@ when_to_use: >-
 
 SuperOps.ai RMM provides comprehensive asset management capabilities. Assets represent managed endpoints (workstations, servers, network devices) with rich telemetry including hardware specs, software inventory, patch status, and activity history. This skill covers querying, managing, and automating actions on assets.
 
+## Anti-triggers
+
+- **Running or scheduling a script on an asset** — asset records tell
+  you whether a target is online and what is installed; execution,
+  batching, and exit codes are `superops-runbooks`.
+- **An "asset" that is a documentation record** — in `hudu-assets` and
+  `it-glue-configurations` an asset is a documented configuration item
+  with no agent behind it. SuperOps assets are live RMM endpoints.
+- **Endpoints under a different RMM** — `atera-agents`, `syncro-assets`,
+  `ncentral-devices`, `immybot-endpoint-management`,
+  `ninjaone-rmm-devices`, and `datto-rmm-devices` each see only their
+  own fleet. Patch and software inventory counts are not comparable
+  across them.
+- **Hardware refresh and warranty programmes** — asset lifecycle
+  planning is `scalepad-lifecycle-manager`.
+
 ## Asset Status Values
 
 | Status | Description | Indicator |

--- a/msp-claude-plugins/superops/superops-ai/skills/clients/SKILL.md
+++ b/msp-claude-plugins/superops/superops-ai/skills/clients/SKILL.md
@@ -16,6 +16,17 @@ when_to_use: >-
 
 Clients (also called Accounts) are the foundation of SuperOps.ai's PSA. Every ticket, asset, and service is associated with a client. This skill covers client CRUD operations, site management, contact handling, and custom field configuration.
 
+## Anti-triggers
+
+- **The same client in a different PSA** — `connectwise-psa-companies`,
+  `autotask-crm`, `syncro-customers`, `halopsa-clients`, and
+  `atera-customers` are separate systems of record. Create the account
+  in the one the MSP actually bills from.
+- **A Microsoft 365 tenant** — a SuperOps client is a PSA account, not
+  an M365 tenant; use `cipp-tenants`.
+- **What a client owns** — endpoints are `superops-assets`, open work is
+  `superops-tickets`.
+
 ## Key Concepts
 
 **Stage** tracks the sales lifecycle; **status** tracks the service relationship. They are independent — a `Customer` can be `Inactive`.

--- a/msp-claude-plugins/superops/superops-ai/skills/runbooks/SKILL.md
+++ b/msp-claude-plugins/superops/superops-ai/skills/runbooks/SKILL.md
@@ -16,6 +16,23 @@ when_to_use: >-
 
 SuperOps.ai provides automation through scripts (runbooks) that execute on managed assets — maintenance tasks, remediation actions, data collection, and custom automation. This skill covers script discovery, execution, scheduling, and result monitoring.
 
+## Anti-triggers
+
+- **A written procedure or checklist** — SuperOps runbooks are
+  executable scripts, not documentation. Prose runbooks live in
+  `hudu-articles` or `it-glue-documents`.
+- **Running a script on an endpoint managed by another RMM** — "run a
+  script on this device" matches five other plugins here just as well.
+  Confirm which RMM owns the endpoint, then use `atera-agents`,
+  `syncro-assets`, `immybot-script-execution`,
+  `ncentral-monitoring-tasks`, `connectwise-automate-scripts`, or
+  `datto-rmm-jobs`.
+- **Deploying or updating an application** — a script that installs
+  software is the anti-pattern `immybot-software-deployment` exists to
+  replace when the fleet is on ImmyBot.
+- **Choosing the targets** — asset selection and online checks are
+  `superops-assets`.
+
 ## Key Concepts
 
 A **script** is a stored definition (`scriptId`, type, content, parameters, timeout, `osType`).

--- a/msp-claude-plugins/superops/superops-ai/skills/tickets/SKILL.md
+++ b/msp-claude-plugins/superops/superops-ai/skills/tickets/SKILL.md
@@ -18,6 +18,16 @@ when_to_use: >-
 
 SuperOps.ai tickets are the core unit of service delivery in the PSA. Every client request, incident, and service task flows through the ticketing system. This skill covers comprehensive ticket management including creation, updates, notes, time entries, and workflow automation using the GraphQL API.
 
+## Anti-triggers
+
+- **Tickets in another PSA** — `connectwise-psa-tickets`,
+  `autotask-tickets`, `halopsa-tickets`, `syncro-tickets`, and
+  `atera-tickets` are separate queues. Nothing here reads or writes
+  them.
+- **The alert that produced the ticket** — use `superops-alerts`.
+- **Running the fix on the endpoint** — remediation is
+  `superops-runbooks`; a resolved ticket does not imply a fixed machine.
+
 ## Ticket Status Values
 
 | Status | Description | Business Logic |

--- a/msp-claude-plugins/syncro/syncro-msp/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/syncro/syncro-msp/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syncro",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Claude Code plugin for Syncro MSP - tickets, customers, assets, invoices",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/syncro/syncro-msp/GOVERNANCE.md
+++ b/msp-claude-plugins/syncro/syncro-msp/GOVERNANCE.md
@@ -1,0 +1,118 @@
+# Syncro plugin — governance and safety model
+
+Unofficial. Community-built plugin for the Syncro MSP API. Not
+affiliated with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+The supported deployment reaches Syncro through the WYRE Conduit gateway
+(`https://conduit.wyre.ai/v1/syncro/mcp`), which brokers authentication
+centrally and scopes every call to the tenant the operator is authorised
+for.
+
+- No Syncro API token or subdomain is stored on the technician's
+  machine, in this repo, or in the model's context.
+- Credential rotation happens once at the gateway, not per technician.
+- Every call carries operator identity, so the gateway audit log answers
+  "who emailed that invoice". Syncro records only the token's owner.
+- Revoking a technician's gateway access revokes Syncro access with it,
+  immediately.
+
+**If you run without the gateway**, the plugin README documents a direct
+mode where `SYNCRO_API_KEY` sits in the technician's Claude settings.
+That mode gives up all four properties above, and Syncro's token
+permissions are coarse — see "Known sharp edges".
+
+## Tool permission tiers
+
+Grouped by blast radius, not HTTP verb.
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change Syncro or endpoint state. Safe for autonomous agents. | `syncro_navigate`, `syncro_status`, `syncro_assets_list`, `syncro_assets_get`, `syncro_assets_search`, `syncro_customers_list`, `syncro_customers_get`, `syncro_customers_search`, `syncro_contacts_list`, `syncro_contacts_get`, `syncro_tickets_list`, `syncro_tickets_get`, `syncro_invoices_list`, `syncro_invoices_get` |
+| **Write** | Creates or modifies records. Reversible, but customer-visible. | `syncro_customers_create`, `syncro_contacts_create`, `syncro_tickets_create`, `syncro_tickets_update`, `syncro_tickets_add_comment`, `syncro_invoices_create` |
+| **Destructive** | Sends money documents to the customer. Requires explicit per-call human approval. | `syncro_invoices_email` |
+
+`syncro_invoices_email` is classified destructive despite being an
+ordinary POST, because the tier is about blast radius. It sends a
+finished invoice to the client's billing contact (plus any `cc_emails`
+the caller supplies, with a caller-supplied subject and body). There is
+no unsend. An agent that emails a draft, a duplicate, or the wrong
+client's invoice creates a commercial incident that a human has to
+apologise for, and the damage is done the instant the call returns.
+Nothing else in this plugin leaves the MSP's own systems.
+
+`syncro_invoices_create` stays in Write, but it is the closest call in
+this batch. It creates a financial record that flows into revenue
+reporting and, in most Syncro deployments, syncs onward to QuickBooks or
+Xero. It is reversible inside Syncro, which is why it is not
+destructive — but treat a batch of them as if it were.
+
+**No script execution and no delete tools are exposed.** Syncro's REST
+API supports running scripts on managed assets
+(`POST /customer_assets/{id}/run_script`, documented in the
+`syncro-assets` skill) and deleting assets, customers, and tickets. This
+MCP surface exposes none of them, so nothing here reaches a customer's
+production machine. If script execution is added later it belongs in the
+destructive tier on day one.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve destructive calls.**
+
+- Read tools: allow. Asset audits, ticket reporting, and AR ageing
+  reviews across customers are the intended autonomous use.
+- Write tools: agent drafts the exact call, human approves, then it
+  runs. Invoice creation deserves a second reader.
+- Destructive tools: `syncro_invoices_email` requires a named human
+  approver per invocation who has seen the invoice total, the recipient,
+  and the CC list. Do not grant it to scheduled or unattended agents —
+  "email last month's invoices" is exactly the automation that goes
+  wrong at scale.
+
+## What it cannot reach
+
+- Only the Syncro subdomain mapped to the operator's gateway identity.
+  Syncro tokens are single-tenant.
+- No filesystem, no shell, no other vendor's data.
+- No endpoint. There is no remote-execution, remote-access, patch,
+  reboot, or wipe tool in this surface, even though the Syncro product
+  has all of them.
+- No payment capture. Recording or taking payment is not exposed; only
+  invoice creation, retrieval, and emailing.
+- No live event stream. Every tool is point-in-time.
+
+## Data handling
+
+- Syncro responses pass through the gateway into model context for the
+  session and are not persisted by this plugin.
+- `syncro_invoices_*` returns commercial data: line items, totals,
+  balances, and payment terms per client. `syncro_customers_*` and
+  `syncro_contacts_*` return client PII including addresses and phone
+  numbers. `syncro_assets_*` returns hostnames, serial numbers, and RMM
+  inventory. Restrict all three if agents run unattended.
+- Invoice data is the most commercially sensitive payload in this
+  batch: an agent with read access to `syncro_invoices_list` can
+  reconstruct the MSP's entire revenue book by client.
+
+## Known sharp edges
+
+- **The rate limit is per IP, not per key — 180 requests/minute.**
+  Behind a gateway every operator shares one egress address, so a single
+  unattended agent running a full-fleet sweep throttles every other
+  technician and every other integration on that address. This is the
+  one vendor in this batch where the gateway concentrates the risk
+  rather than reducing it. Scope sweeps, and do not schedule them.
+- **Emailing is not idempotent.** A retried `syncro_invoices_email`
+  after a timeout sends the invoice twice. If a call's outcome is
+  uncertain, verify in Syncro before retrying — do not let an agent
+  retry automatically.
+- **A running ticket timer inflates the next invoice.** Tickets carry
+  `timer_active` and `total_time_seconds`; this plugin cannot start or
+  stop a timer, but it can read one. An agent reporting effort or
+  drafting an invoice should check `timer_active` rather than trusting
+  `total_time_seconds` as final.
+- **Invoices sync onward.** In deployments wired to QuickBooks or Xero,
+  an invoice created here propagates to the ledger. Correcting it means
+  correcting it in two systems.

--- a/msp-claude-plugins/syncro/syncro-msp/skills/assets/SKILL.md
+++ b/msp-claude-plugins/syncro/syncro-msp/skills/assets/SKILL.md
@@ -17,6 +17,21 @@ when_to_use: >-
 
 Syncro assets represent the hardware, software, and devices you manage for customers. Assets integrate with Syncro's built-in RMM capabilities for monitoring, patch management, and remote access. This skill covers asset tracking, RMM integration, and inventory management.
 
+## Anti-triggers
+
+- **Running a script on the asset** — the `run_script` endpoint is
+  documented here, but the routing decision matters more than the
+  request shape: "run a script on this machine" matches `atera-agents`,
+  `superops-runbooks`, `immybot-script-execution`,
+  `ncentral-monitoring-tasks`, `connectwise-automate-scripts`, and
+  `datto-rmm-jobs` equally well. Confirm the endpoint is Syncro-managed
+  before executing anything.
+- **An "asset" that is a documentation record** — in `hudu-assets` and
+  `it-glue-configurations` an asset is a documented CI with no agent.
+  Syncro assets are live RMM endpoints.
+- **Hardware refresh programmes** — Syncro stores `warranty_expires` but
+  does no lifecycle planning; use `scalepad-lifecycle-manager`.
+
 ## Key Concepts
 
 ### Asset

--- a/msp-claude-plugins/syncro/syncro-msp/skills/customers/SKILL.md
+++ b/msp-claude-plugins/syncro/syncro-msp/skills/customers/SKILL.md
@@ -16,6 +16,17 @@ when_to_use: >-
 
 Syncro customers are the foundation of your service delivery. Every ticket, asset, invoice, and contract is associated with a customer. This skill covers comprehensive customer management including CRUD operations, contact management, and site/location handling.
 
+## Anti-triggers
+
+- **The same client in another PSA or the accounting ledger** —
+  `connectwise-psa-companies`, `autotask-crm`, `superops-clients`,
+  `atera-customers`, `quickbooks-online-customers`, and `xero-contacts`
+  are separate records of the same company. Creating a duplicate in the
+  wrong one is a reconciliation problem later.
+- **A customer's devices** — use `syncro-assets`.
+- **Documentation about the client** — `hudu-companies` or
+  `it-glue-organizations`.
+
 ## Key Concepts
 
 ### Customer

--- a/msp-claude-plugins/syncro/syncro-msp/skills/invoices/SKILL.md
+++ b/msp-claude-plugins/syncro/syncro-msp/skills/invoices/SKILL.md
@@ -16,6 +16,19 @@ when_to_use: >-
 
 Syncro invoices are the core of your billing workflow. Invoices can be created manually, generated from tickets, or produced automatically from recurring contracts. This skill covers invoice creation, line item management, payment processing, and billing workflows.
 
+## Anti-triggers
+
+- **The invoice in the accounting system** — Syncro usually sits
+  upstream of QuickBooks or Xero and the same invoice exists in both.
+  Raising or editing it on the ledger side is
+  `quickbooks-online-invoices` or `xero-invoices`; doing it in the wrong
+  place produces two versions of one document.
+- **Recording the payment against the ledger** — Syncro marks its own
+  invoice paid; the accounting entry is `quickbooks-online-payments` or
+  `xero-payments`.
+- **The unbilled work behind an invoice** — ticket timers and time
+  entries are `syncro-tickets`.
+
 ## Key Concepts
 
 ### Invoice

--- a/msp-claude-plugins/syncro/syncro-msp/skills/tickets/SKILL.md
+++ b/msp-claude-plugins/syncro/syncro-msp/skills/tickets/SKILL.md
@@ -18,6 +18,16 @@ when_to_use: >-
 
 Syncro tickets are the core unit of service delivery in the platform. Every client request, incident, and service task flows through the ticketing system. This skill covers comprehensive ticket management including creation, updates, timer operations, comments, and time tracking.
 
+## Anti-triggers
+
+- **Tickets in another PSA** — `connectwise-psa-tickets`,
+  `autotask-tickets`, `halopsa-tickets`, `superops-tickets`, and
+  `atera-tickets` are separate queues; Syncro shops that migrated often
+  still have both.
+- **Billing the time a timer recorded** — timers and time entries live
+  here, invoicing in `syncro-invoices`. Stopping a timer bills nothing.
+- **Fixing the endpoint the ticket is about** — use `syncro-assets`.
+
 ## Ticket Status Values
 
 Syncro provides configurable ticket statuses. These are the common default values:


### PR DESCRIPTION
Applies the connector-quality standard from `feat/skill-anti-triggers-governance` to the RMM/PSA batch: **atera, superops, syncro, immybot, liongard, ncentral**.

> **Base-branch dependency.** This branches from `feat/skill-anti-triggers-governance`, so that commit (standards + templates + the huntress exemplar) appears in this diff and disappears once it merges. **The base branch fails the CI bump gate on its own**: commit 64389eb changed `huntress/huntress/` (GOVERNANCE.md + 3 skills) without bumping huntress's `plugin.json` (still `0.2.3`). That is the only drift error in this branch and it is not fixable from here — huntress is outside this batch's allowed paths. Every parallel batch PR built on the same base will show the same failure. Verified locally:
>
> ```
> $ node scripts/check-marketplace-drift.mjs --base origin/main
> bump gate: compared HEAD against merge base ad26f4fe3f69 (47 changed files, 7 plugins touched)
> ✘ 1 marketplace drift error(s):
>   - bump gate: plugin "huntress" changed without a plugin.json version bump (still "0.2.3")
> ```
>
> All six plugins in this batch pass. All six pass `claude plugin validate`.

## Task A — `## Anti-triggers`

**28 of 32 skills.** Placed after the opening overview paragraph; every bullet names the skill to load instead.

| Plugin | Added | Skipped | Why skipped |
|---|---|---|---|
| `atera` | 5 / 6 | `api-patterns` | Vendor-qualified name already disambiguates; any bullet would restate `when_to_use` |
| `superops` | 5 / 6 | `api-patterns` | Same |
| `syncro` | 4 / 5 | `api-patterns` | Same |
| `immybot` | 6 / 6 | — | `api-patterns` earned one: it is the Entra-auth landing spot |
| `liongard` | 5 / 5 | — | |
| `ncentral` | 3 / 4 | `api-patterns` | Same |

All 225 skill slugs referenced across the new sections were machine-checked against `plugin.json` names + on-disk `skills/*/` directories. All resolve.

### The three most valuable

1. **"Agent" means four different things in this marketplace.** An RMM endpoint sensor (`atera-agents`), a *per-site* inspection runner that monitors nothing about the box it sits on (`liongard-overview`), a human technician (`halopsa-agents`), and a Claude subagent under `agents/*.md`. `atera-agents` and `liongard-overview` now both spell this out. The Liongard case has teeth beyond routing: an operator who reads `liongard_agents_list` as an endpoint count misreports coverage by orders of magnitude, and an agent deletion that looks like "one machine" takes out a whole site's data collection.

2. **"Device" inverts between Atera and everyone else.** In Atera a *device* is an agentless HTTP/SNMP/TCP monitor; the managed endpoint is an *agent*. In `ncentral-devices`, `ninjaone-rmm-devices`, `datto-rmm-devices`, and `connectwise-automate-computers` a device *is* the endpoint. "List the customer's devices" silently returns the wrong set. Cross-referenced from both `atera-agents` and `atera-devices`, and called out again from `ncentral-devices`.

3. **"Maintenance window" vs "maintenance session".** An N-central maintenance window is a scheduled *alert suppression* period that executes nothing. An ImmyBot maintenance session *installs software and reboots machines*. Same words, opposite blast radius. Cross-referenced in both directions between `immybot-maintenance-sessions` and `ncentral-monitoring-tasks`.

Runner-up worth reading: `immybot-tenant-compliance` — "compliance" there means software matches desired state, not CIS/NIST/SOC 2 (`scalepad-controlmap`) or M365 baselines (`cipp-standards`); and an ImmyBot "tenant" is a client org, not the Entra tenant ImmyBot authenticates against (`cipp-tenants`).

The script-execution cluster is the batch's connective tissue: `atera-agents`, `syncro-assets`, `superops-runbooks`, `immybot-script-execution`, `ncentral-monitoring-tasks`, and `liongard-inspections` all now say "run a script on this device" matches the others equally and name `connectwise-automate-scripts` and `datto-rmm-jobs` alongside. `liongard-inspections` carries the inverse: `liongard_inspections_run` *sounds* like execution and is not.

## Task B — `GOVERNANCE.md`

One per plugin, from `_templates/governance-template.md`. Every tool name machine-verified against the vendor's MCP server source (`~/mcp/{atera,superops,syncro,liongard,ncentral}-mcp/src`) or, for ImmyBot which has no local server repo, the plugin's own skills + README. **0 unmatched names out of 198 used**; the only authoritative names absent from the docs are test fixtures (`*_invalid`, `*_unknown`, `ncentral_not_a_real_tool`) and config placeholders (`superops_region`, `syncro_subdomain`).

### Full destructive tier — all 13, for review

| Plugin | Tool | Why it is destructive |
|---|---|---|
| `immybot` | `immybot_scripts_run` | PowerShell on a live endpoint in SYSTEM context |
| `immybot` | `immybot_software_install` | Installs on the endpoint now |
| `immybot` | `immybot_deployments_trigger` | Forces immediate reconciliation |
| `immybot` | `immybot_maintenance_sessions_start` | Installs/removes software and reboots; one arg switches scope from one computer to an entire tenant |
| `immybot` | `immybot_maintenance_sessions_cancel` | Leaves an install half-applied. Stopping a destructive op is destructive here |
| `immybot` | `immybot_deployments_create` | **Judgement call.** Looks inert — changes nothing immediately. But it arms a fleet-wide install that the next scheduled window fires with no further approval, and **there is no `immybot_deployments_delete` in the surface**, so an agent cannot undo its own mistake |
| `immybot` | `immybot_computers_trigger_checkin` | **Judgement call.** Harmless on an idle machine; on one with staged work it is the trigger that makes the install happen now. Blast radius is the pending work's, and the caller usually cannot see what is pending |
| `ncentral` | `ncentral_create_direct_task` | Executes immediately on a live device as SYSTEM/root. No scheduling, no dry run, no cancel |
| `ncentral` | `ncentral_get_registration_token` | **Judgement call — this is a GET.** Returns the token embedded in agent installers; anyone holding it can enrol a device into that customer's environment. Calling it a read because HTTP says so would put credential disclosure in the tier marked "safe for autonomous agents" |
| `ncentral` | `ncentral_delete_maintenance_windows` | Removes the suppression keeping a planned outage quiet — floods the NOC, auto-generates tickets, pages on-call for expected behaviour. Irreversible through this surface |
| `superops` | `superops_custom_mutation` | Arbitrary GraphQL mutation against the tenant, unbounded by name or schema. Also the *only* path to SuperOps script execution, since no typed script tool is exposed |
| `syncro` | `syncro_invoices_email` | **Judgement call — ordinary POST.** Sends a finished invoice to the client's billing contact with caller-supplied subject, body, and CC list. No unsend. The only tool in this plugin that leaves the MSP's own systems |
| `liongard` | `liongard_agents_delete` | Every launchpoint bound to that site agent silently stops collecting. Failure mode is a blind spot that reads as "no changes detected"; recovery needs an on-site reinstall this plugin cannot do |

### Deliberate non-escalations (stated, not omitted)

- **`liongard_inspections_run` stays Write.** It collects data using stored credentials and changes nothing on the target. Over-classifying on the strength of the word "run" would make the destructive tier meaningless. It is not a Read either — it spends a privileged authenticated session against a production DC/firewall/M365 tenant and can trip conditional-access or lockout policies.
- **`superops_custom_query` stays Read.** It cannot mutate. It is the exfiltration path, not the damage path — noted under Data handling instead.
- **`atera` destructive tier is empty**, stated as a property rather than omitted. The Atera REST API can run PowerShell and delete agents; the MCP surface exposes neither, so nothing this plugin calls reaches a customer machine. Same for `syncro` apart from invoice email: `run_script` exists in the API, not in the tool surface. Both docs say that if script execution is ever added it goes in the destructive tier on day one.
- **`liongard` environment/launchpoint delete** — the API's two genuinely catastrophic cascading deletes are not exposed here. Documented so nobody assumes they are missing by accident.
- **N-central custom-property writes stay Write with an escalation rule.** `ncentral_update_device_custom_property` can silently move a device into a different automation policy (Patch Ring, Maintenance Group) and cause patches to be pushed to a deliberately-excluded server. Blanket-classifying every property write as destructive would dilute the tier, so the doc classifies them Write and requires direct-task-grade approval whenever the property is policy-keyed or its purpose is unknown. Flagging in case you want them promoted outright.

### Gateway framing — one honesty adjustment

`ncentral` and `immybot` genuinely route through the gateway with no local secrets, and their docs say so plainly. **`atera`, `superops`, `syncro`, and `liongard` currently ship READMEs documenting a direct mode** where the API key lives in the technician's Claude settings (`ATERA_API_KEY`, `LIONGARD_API_KEY`, …). Writing "no key is stored on the technician's machine" unqualified would be false for the deployment those READMEs describe, and the template's audience is an MSP owner making a trust decision. Those four docs lead with the Conduit framing as the supported path, then state in one short paragraph what the direct mode gives up (key on the endpoint, per-technician rotation, single shared identity in the vendor audit log, tiers advisory rather than enforced). Happy to drop that paragraph if the intent is that the READMEs get corrected instead.

## Other judgement calls

- **Plugin manifests patch-bumped** (`atera` 0.2.3→0.2.4, `superops` 0.2.4→0.2.5, `syncro` 0.2.4→0.2.5, `immybot` 1.1.3→1.1.4, `liongard` 0.2.3→0.2.4, `ncentral` 1.0.2→1.0.3). Not in the brief, but `scripts/check-marketplace-drift.mjs` hard-fails any PR touching a plugin directory without one, and without it installed users never receive the change. Patch, following the precedent set by the #158 restructure ("all 72 touched plugins patch-bumped").
- **Root `CHANGELOG.md` deliberately not touched.** Six parallel batch PRs editing one file is a guaranteed conflict; this needs one entry written once at the coordination layer. Flagging so it does not get lost.
- **Four skills sit over the ~350-line guideline** after the addition, all of which were already at or over it before: `syncro-invoices` 396→409, `atera-customers` 384→396, `atera-devices` 371→383, `syncro-assets` 339→354. Splitting them into `references/*.md` is a rewrite, not an additive change, so it is out of scope here — worth a follow-up.
- **No `triggers:` frontmatter added** (banned, #158) and no frontmatter touched at all. `npm run generate` not run.
- Files touched are confined to the six batch directories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
