### PR TITLE
chore(docs): regenerate sharedSkills after shared plugin bump

### DIFF
--- a/msp-claude-plugins/docs/src/data/sharedSkills.ts
+++ b/msp-claude-plugins/docs/src/data/sharedSkills.ts
@@ -23,5 +23,5 @@ export const sharedSkills: SharedSkill[] = [
 export const sharedSkillsMeta = {
   installSlug: 'shared-skills',
   description: 'Vendor-agnostic MSP skills — terminology, ticket triage, incident correlation, and billing reconciliation',
-  version: '1.1.3',
+  version: '1.1.4',
 };


### PR DESCRIPTION
Mechanical regeneration. The 14-batch quality pass bumped `shared` to 1.1.4; `npm run generate` reflects that version into `sharedSkills.ts`.

Every batch agent was instructed not to run the generator, since 14 parallel PRs writing generated data would have conflicted on every one. This is that deferred step, run once now that all batches are merged. `plugins.ts` was unchanged (75 plugins, 339 skills).