### PR TITLE
docs(connectwise-cpq): correct the delete-confirmation claim

### DIFF
--- a/msp-claude-plugins/connectwise/cpq/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/connectwise/cpq/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "connectwise-cpq",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Claude Code plugin for ConnectWise CPQ (formerly Sell / Quosal) - quotes, line items, templates, quote customers, and payment terms",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/connectwise/cpq/skills/quote-items/SKILL.md
+++ b/msp-claude-plugins/connectwise/cpq/skills/quote-items/SKILL.md
@@ -126,8 +126,10 @@ extended figures; writing `extendedPrice` directly fights the calculation engine
 
 ### Remove a line
 
-`cpq_delete_quote_item` with the item GUID. It confirms first, echoing the line's
-description or part number, and the delete is permanent. Setting `isPrinted: false` or
+`cpq_delete_quote_item` with the item GUID, and the delete is permanent. An interactive
+client is prompted first, echoing the line's description or part number; a non-interactive
+one — the gateway included — is refused until the call is re-invoked with
+`confirm_destructive_action: true`. Setting `isPrinted: false` or
 `isOptional: true` is the non-destructive way to take a line off a proposal.
 
 ## Gotchas

--- a/msp-claude-plugins/connectwise/cpq/skills/quotes/SKILL.md
+++ b/msp-claude-plugins/connectwise/cpq/skills/quotes/SKILL.md
@@ -152,8 +152,10 @@ those; renaming or setting a forecast date is routine.
 
 ### Delete
 
-`cpq_delete_quote` removes the quote **and every tab, line item and term on it**, and
-asks for confirmation first. `cpq_delete_quote_version` removes a single version by
+`cpq_delete_quote` removes the quote **and every tab, line item and term on it**.
+Confirmation depends on how you are connected: an interactive client is prompted, while
+a non-interactive one — the gateway included — is refused until the call is re-invoked
+with `confirm_destructive_action: true`. `cpq_delete_quote_version` removes a single version by
 `quoteNumber` + `quoteVersion`. Neither is recoverable — archive (`isArchive: True`) is
 almost always the right move for a dead deal instead.
 


### PR DESCRIPTION
Depends on **wyre-technology/connectwise-cpq-mcp#3** — merge that first.

Two CPQ skills promised a guarantee the server did not make:

- `skills/quotes/SKILL.md` — "asks for confirmation first"
- `skills/quote-items/SKILL.md` — "It confirms first, echoing the line's description or part number"

Both held only for **interactive** clients. `connectwise-cpq-mcp`'s elicitation returned `unavailable` for callers that don't declare form-elicitation capability, and `isRefusal()` treated that as consent — so the delete proceeded unprompted. The Conduit gateway is exactly such a caller, which meant the one path that matters in production was the unprompted one. A passing test (`elicitation-serving.test.ts:122`) had that behaviour locked in.

connectwise-cpq-mcp#3 makes destructive operations fail closed and adds `confirm_destructive_action` as the explicit non-interactive path. These sentences now state both behaviours rather than the interactive one only.

Found during the governance-documentation pass (#161–#174) — the CPQ `GOVERNANCE.md` from #172 flagged the discrepancy under *Known sharp edges*, and this closes it. Same class as wyre-technology/meraki-mcp#3, where four tools carried `destructiveHint: true` without ever requiring confirmation.

`check-marketplace-drift.mjs` passes; `connectwise-cpq` bumped 1.1.0 → 1.1.1.