### PR TITLE
fix(governance): state the admin-tier reality for 14 unclassified vendors

### DIFF
--- a/msp-claude-plugins/abnormal/abnormal-security/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/abnormal/abnormal-security/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "abnormal-security",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Claude plugins for Abnormal Security - AI-powered email security, threat detection, abuse mailbox cases, account takeover protection, vendor risk assessment, and message analysis for MSPs",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/abnormal/abnormal-security/GOVERNANCE.md
+++ b/msp-claude-plugins/abnormal/abnormal-security/GOVERNANCE.md
@@ -20,11 +20,30 @@ tenant the operator is authorised for.
 
 ## Tool permission tiers
 
+> **Not classified in Conduit — every tool in the table below requires
+> tier `admin` today.** Conduit derives each tool's tier from
+> `VENDOR_TOOL_CONFIG` (`src/proxy/result-cache.ts`) and fails closed for
+> anything absent from it:
+> `const requiredTier: PermissionTier = classified ?? 'admin';`
+> (`src/access/access-enforcement.ts:63`). `abnormal-security` has no
+> entry, so the grouping below carries no enforcement weight right now —
+> read tools require `admin` exactly as the rest do, and there is no
+> narrower grant that admits them. The grouping is still the right *risk*
+> reading, and it becomes the enforcement reading on the day this vendor
+> is classified. The list of unclassified vendors moves whenever one of
+> them is classified, so it is stated in one place only:
+> `wyre-gateway/GOVERNANCE.md`, *Fail-closed, and the vendors Conduit has
+> not classified*.
+>
+> *This blockquote is the whole of the not-classified caveat. When
+> `abnormal-security` appears in `VENDOR_TOOL_CONFIG`, delete this
+> blockquote and change nothing else.*
+
 | Tier | What it can do | Tools |
 |---|---|---|
 | **Read** | Cannot change mailbox or Abnormal state. Safe for autonomous agents. | `abnormal_threats_list`, `abnormal_threats_get`, `abnormal_messages_list`, `abnormal_messages_get`, `abnormal_cases_list`, `abnormal_cases_get`, `abnormal_abuse_list`, `abnormal_navigate`, `abnormal_status` |
 | **Write** | Empty. Abnormal exposes no reversible bookkeeping write — the only mutating tool acts directly on customer mailboxes. | — |
-| **Destructive** | Moves real mail into or out of a user's mailbox. Requires explicit per-call human approval. | `abnormal_remediation_manage` |
+| **Destructive** | Moves real mail into or out of a user's mailbox. | `abnormal_remediation_manage` |
 
 `abnormal_remediation_manage` is a single tool carrying three actions of
 very different blast radius: `status` reads, `remediate` pulls a message
@@ -37,6 +56,12 @@ agent that can call it for `status` can call it for `unremediate`.
 what it actually does is deliver a message Abnormal classified as an
 attack into a user's inbox. Treat it as a delivery decision, not a
 correction.
+
+Conduit does not enforce any of that as an approval requirement. It
+compares tiers — it has no approval step, no per-call confirmation, and
+no interactive prompt. Per-call approval is a workflow you impose on your
+agents, and it is only as good as the agent configuration that carries
+it.
 
 ## Recommended agent policy
 

--- a/msp-claude-plugins/atera/atera/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/atera/atera/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "atera",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Claude Code plugin for Atera RMM/PSA - tickets, agents, customers, alerts",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/atera/atera/GOVERNANCE.md
+++ b/msp-claude-plugins/atera/atera/GOVERNANCE.md
@@ -30,6 +30,25 @@ rather than enforced.
 
 Grouped by blast radius, not HTTP verb.
 
+> **Not classified in Conduit — every tool in the table below requires
+> tier `admin` today.** Conduit derives each tool's tier from
+> `VENDOR_TOOL_CONFIG` (`src/proxy/result-cache.ts`) and fails closed for
+> anything absent from it:
+> `const requiredTier: PermissionTier = classified ?? 'admin';`
+> (`src/access/access-enforcement.ts:63`). `atera` has no entry, so the
+> grouping below carries no enforcement weight right now — read tools
+> require `admin` exactly as the rest do, and there is no narrower grant
+> that admits them. The grouping is still the right *risk* reading, and it
+> becomes the enforcement reading on the day this vendor is classified.
+> The list of unclassified vendors moves whenever one of them is
+> classified, so it is stated in one place only:
+> `wyre-gateway/GOVERNANCE.md`, *Fail-closed, and the vendors Conduit has
+> not classified*.
+>
+> *This blockquote is the whole of the not-classified caveat. When `atera`
+> appears in `VENDOR_TOOL_CONFIG`, delete this blockquote and change
+> nothing else.*
+
 | Tier | What it can do | Tools |
 |---|---|---|
 | **Read** | Cannot change Atera or endpoint state. Safe for autonomous agents. | `atera_navigate`, `atera_back`, `atera_agents_list`, `atera_agents_get`, `atera_agents_get_by_machine`, `atera_alerts_list`, `atera_alerts_get`, `atera_alerts_by_agent`, `atera_alerts_by_device`, `atera_customers_list`, `atera_customers_get`, `atera_contacts_list`, `atera_contacts_get`, `atera_contacts_by_customer`, `atera_tickets_list`, `atera_tickets_get` |

--- a/msp-claude-plugins/betterstack/betterstack/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/betterstack/betterstack/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "betterstack",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Claude plugins for Better Stack - uptime monitoring, incident management, status pages, on-call schedules, and log management (Logtail) for MSPs",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/betterstack/betterstack/GOVERNANCE.md
+++ b/msp-claude-plugins/betterstack/betterstack/GOVERNANCE.md
@@ -21,11 +21,30 @@ the operator is authorised for.
 
 ## Tool permission tiers
 
+> **Not classified in Conduit — every tool in the table below requires
+> tier `admin` today.** Conduit derives each tool's tier from
+> `VENDOR_TOOL_CONFIG` (`src/proxy/result-cache.ts`) and fails closed for
+> anything absent from it:
+> `const requiredTier: PermissionTier = classified ?? 'admin';`
+> (`src/access/access-enforcement.ts:63`). `betterstack` has no entry, so
+> the grouping below carries no enforcement weight right now — read tools
+> require `admin` exactly as the rest do, and there is no narrower grant
+> that admits them. The grouping is still the right *risk* reading, and it
+> becomes the enforcement reading on the day this vendor is classified.
+> The list of unclassified vendors moves whenever one of them is
+> classified, so it is stated in one place only:
+> `wyre-gateway/GOVERNANCE.md`, *Fail-closed, and the vendors Conduit has
+> not classified*.
+>
+> *This blockquote is the whole of the not-classified caveat. When
+> `betterstack` appears in `VENDOR_TOOL_CONFIG`, delete this blockquote
+> and change nothing else.*
+
 | Tier | What it can do | Tools |
 |---|---|---|
 | **Read** | Cannot change Better Stack state or notify anyone. Safe for autonomous agents. | `list_monitors`, `get_monitor`, `list_heartbeats`, `get_heartbeat`, `list_incidents`, `get_incident`, `list_on_call_schedules`, `get_on_call_schedule`, `list_schedule_policies`, `list_status_pages`, `get_status_page`, `list_status_page_sections`, `execute_query`, `list_saved_queries`, `get_saved_query`, `list_dashboards`, `get_dashboard`, `list_dashboard_panels`, `list_applications`, `get_application`, `list_releases` |
 | **Write** | Creates or modifies records. Reversible, but may page a human on the way. | `create_monitor`, `update_monitor`, `resume_monitor`, `create_heartbeat`, `update_heartbeat`, `create_incident`, `acknowledge_incident`, `resolve_incident`, `create_on_call_schedule`, `update_on_call_schedule`, `create_status_page`, `update_status_page`, `create_dashboard`, `create_release` |
-| **Destructive** | Removes monitoring coverage, breaks paging, or publishes to the public. Requires explicit per-call human approval. | `delete_monitor`, `delete_heartbeat`, `delete_on_call_schedule`, `pause_monitor`, `create_status_page_incident` |
+| **Destructive** | Removes monitoring coverage, breaks paging, or publishes to the public. | `delete_monitor`, `delete_heartbeat`, `delete_on_call_schedule`, `pause_monitor`, `create_status_page_incident` |
 
 ### Why two non-delete tools sit in the destructive tier
 
@@ -49,6 +68,12 @@ the operator is authorised for.
 notification policy that referenced the deleted schedule is left with
 a step that resolves to nobody, so pages route into the void. The
 failure shows up at the worst possible moment.
+
+Conduit does not enforce any of that as an approval requirement. It
+compares tiers — it has no approval step, no per-call confirmation, and
+no interactive prompt. Per-call approval is a workflow you impose on your
+agents, and it is only as good as the agent configuration that carries
+it.
 
 ## Recommended agent policy
 

--- a/msp-claude-plugins/blumira/blumira/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/blumira/blumira/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "blumira",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Claude plugins for Blumira - SIEM findings management, device inventory, MSP multi-tenant operations, and security posture analysis",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/blumira/blumira/GOVERNANCE.md
+++ b/msp-claude-plugins/blumira/blumira/GOVERNANCE.md
@@ -21,6 +21,25 @@ authorised for.
 
 ## Tool permission tiers
 
+> **Not classified in Conduit — every tool in the table below requires
+> tier `admin` today.** Conduit derives each tool's tier from
+> `VENDOR_TOOL_CONFIG` (`src/proxy/result-cache.ts`) and fails closed for
+> anything absent from it:
+> `const requiredTier: PermissionTier = classified ?? 'admin';`
+> (`src/access/access-enforcement.ts:63`). `blumira` has no entry, so the
+> grouping below carries no enforcement weight right now — read tools
+> require `admin` exactly as the rest do, and there is no narrower grant
+> that admits them. The grouping is still the right *risk* reading, and it
+> becomes the enforcement reading on the day this vendor is classified.
+> The list of unclassified vendors moves whenever one of them is
+> classified, so it is stated in one place only:
+> `wyre-gateway/GOVERNANCE.md`, *Fail-closed, and the vendors Conduit has
+> not classified*.
+>
+> *This blockquote is the whole of the not-classified caveat. When
+> `blumira` appears in `VENDOR_TOOL_CONFIG`, delete this blockquote and
+> change nothing else.*
+
 | Tier | What it can do | Tools |
 |---|---|---|
 | **Read** | Cannot change Blumira state. Safe for autonomous agents. | `blumira_status`, `blumira_navigate`, `blumira_back`, `blumira_findings_list`, `blumira_findings_get`, `blumira_findings_details`, `blumira_findings_comments_list`, `blumira_resolutions_list`, `blumira_users_list`, `blumira_agents_devices_list`, `blumira_agents_devices_get`, `blumira_agents_keys_list`, `blumira_agents_keys_get`, `blumira_msp_accounts_list`, `blumira_msp_accounts_get`, `blumira_msp_findings_all`, `blumira_msp_findings_list`, `blumira_msp_findings_get`, `blumira_msp_findings_comments_list`, `blumira_msp_devices_list`, `blumira_msp_devices_get`, `blumira_msp_keys_list`, `blumira_msp_keys_get`, `blumira_msp_users_list` |

--- a/msp-claude-plugins/email-security/knowbe4/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/email-security/knowbe4/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "knowbe4",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Claude plugins for KnowBe4 - security awareness training, phishing simulation, user risk management",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/email-security/knowbe4/GOVERNANCE.md
+++ b/msp-claude-plugins/email-security/knowbe4/GOVERNANCE.md
@@ -23,6 +23,25 @@ operator is authorised for.
 
 ## Tool permission tiers
 
+> **Not classified in Conduit — every tool in the table below requires
+> tier `admin` today.** Conduit derives each tool's tier from
+> `VENDOR_TOOL_CONFIG` (`src/proxy/result-cache.ts`) and fails closed for
+> anything absent from it:
+> `const requiredTier: PermissionTier = classified ?? 'admin';`
+> (`src/access/access-enforcement.ts:63`). `knowbe4` has no entry, so the
+> grouping below carries no enforcement weight right now — read tools
+> require `admin` exactly as the rest do, and there is no narrower grant
+> that admits them. The grouping is still the right *risk* reading, and it
+> becomes the enforcement reading on the day this vendor is classified.
+> The list of unclassified vendors moves whenever one of them is
+> classified, so it is stated in one place only:
+> `wyre-gateway/GOVERNANCE.md`, *Fail-closed, and the vendors Conduit has
+> not classified*.
+>
+> *This blockquote is the whole of the not-classified caveat. When
+> `knowbe4` appears in `VENDOR_TOOL_CONFIG`, delete this blockquote and
+> change nothing else.*
+
 | Tier | What it can do | Tools |
 |---|---|---|
 | **Read** | Cannot change KnowBe4 state. Safe for autonomous agents. | `knowbe4_phishing_list_campaigns`, `knowbe4_phishing_get_campaign`, `knowbe4_phishing_list_security_tests`, `knowbe4_phishing_get_security_test`, `knowbe4_phishing_list_recipients`, `knowbe4_phishing_get_recipient`, `knowbe4_phishing_list_templates`, `knowbe4_phishing_get_template`, `knowbe4_training_list_campaigns`, `knowbe4_training_get_campaign`, `knowbe4_training_list_enrollments`, `knowbe4_training_get_enrollment`, `knowbe4_training_list_modules`, `knowbe4_training_get_module`, `knowbe4_training_list_store_purchases`, `knowbe4_training_get_store_purchase`, `knowbe4_users_list`, `knowbe4_users_get`, `knowbe4_users_risk_score_history`, `knowbe4_users_list_events`, `knowbe4_groups_list`, `knowbe4_groups_get`, `knowbe4_groups_list_members`, `knowbe4_groups_risk_score_history`, `knowbe4_reporting_account_summary`, `knowbe4_reporting_phishing_summary`, `knowbe4_reporting_training_summary`, `knowbe4_reporting_risk_overview`, `knowbe4_reporting_ppp_trend`, `knowbe4_reporting_department_breakdown` |

--- a/msp-claude-plugins/freshdesk/freshdesk/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/freshdesk/freshdesk/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "freshdesk",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Freshdesk - cloud helpdesk/PSA ticketing for MSPs: tickets, conversations, contacts, companies, knowledge base, SLA policies, and business hours",
   "author": {
     "name": "WYRE AI"

--- a/msp-claude-plugins/freshdesk/freshdesk/GOVERNANCE.md
+++ b/msp-claude-plugins/freshdesk/freshdesk/GOVERNANCE.md
@@ -23,11 +23,30 @@ operator is authorised for.
 
 ## Tool permission tiers
 
+> **Not classified in Conduit — every tool in the table below requires
+> tier `admin` today.** Conduit derives each tool's tier from
+> `VENDOR_TOOL_CONFIG` (`src/proxy/result-cache.ts`) and fails closed for
+> anything absent from it:
+> `const requiredTier: PermissionTier = classified ?? 'admin';`
+> (`src/access/access-enforcement.ts:63`). `freshdesk` has no entry, so
+> the grouping below carries no enforcement weight right now — read tools
+> require `admin` exactly as the rest do, and there is no narrower grant
+> that admits them. The grouping is still the right *risk* reading, and it
+> becomes the enforcement reading on the day this vendor is classified.
+> The list of unclassified vendors moves whenever one of them is
+> classified, so it is stated in one place only:
+> `wyre-gateway/GOVERNANCE.md`, *Fail-closed, and the vendors Conduit has
+> not classified*.
+>
+> *This blockquote is the whole of the not-classified caveat. When
+> `freshdesk` appears in `VENDOR_TOOL_CONFIG`, delete this blockquote and
+> change nothing else.*
+
 | Tier | What it can do | Tools |
 |---|---|---|
 | **Read** | Cannot change Freshdesk state. Safe for autonomous agents. | `freshdesk_status`, `freshdesk_navigate`, `freshdesk_tickets_list`, `freshdesk_tickets_get`, `freshdesk_tickets_search`, `freshdesk_tickets_list_conversations`, `freshdesk_contacts_list`, `freshdesk_contacts_get`, `freshdesk_contacts_search`, `freshdesk_contacts_autocomplete`, `freshdesk_companies_list`, `freshdesk_companies_get`, `freshdesk_companies_search`, `freshdesk_companies_autocomplete`, `freshdesk_agents_list`, `freshdesk_agents_get`, `freshdesk_agents_me`, `freshdesk_groups_list`, `freshdesk_groups_get`, `freshdesk_sla_list`, `freshdesk_business_hours_list`, `freshdesk_business_hours_get`, `freshdesk_canned_responses_list_folders`, `freshdesk_canned_responses_get_folder`, `freshdesk_canned_responses_list_responses`, `freshdesk_solutions_categories_list`, `freshdesk_solutions_categories_get`, `freshdesk_solutions_folders_list`, `freshdesk_solutions_folders_get`, `freshdesk_solutions_articles_list`, `freshdesk_solutions_articles_get` |
 | **Write** | Creates or modifies records. Reversible, but visible to the customer. | `freshdesk_tickets_create`, `freshdesk_tickets_update`, `freshdesk_tickets_add_note`, `freshdesk_tickets_update_conversation`, `freshdesk_contacts_create`, `freshdesk_contacts_update`, `freshdesk_contacts_restore`, `freshdesk_companies_create`, `freshdesk_companies_update`, `freshdesk_groups_create`, `freshdesk_groups_update`, `freshdesk_agents_update`, `freshdesk_solutions_categories_create`, `freshdesk_solutions_categories_update`, `freshdesk_solutions_folders_create`, `freshdesk_solutions_folders_update`, `freshdesk_solutions_articles_create`, `freshdesk_solutions_articles_update` |
-| **Destructive** | Emails a customer, deletes data, grants access, or changes billing. Requires explicit per-call human approval. | `freshdesk_tickets_reply`, `freshdesk_contacts_send_invite`, `freshdesk_contacts_merge`, `freshdesk_contacts_make_agent`, `freshdesk_agents_create`, `freshdesk_agents_delete`, `freshdesk_sla_create`, `freshdesk_sla_update`, `freshdesk_tickets_delete`, `freshdesk_tickets_delete_conversation`, `freshdesk_contacts_soft_delete`, `freshdesk_contacts_hard_delete`, `freshdesk_companies_delete`, `freshdesk_groups_delete`, `freshdesk_solutions_categories_delete`, `freshdesk_solutions_folders_delete`, `freshdesk_solutions_articles_delete` |
+| **Destructive** | Emails a customer, deletes data, grants access, or changes billing. | `freshdesk_tickets_reply`, `freshdesk_contacts_send_invite`, `freshdesk_contacts_merge`, `freshdesk_contacts_make_agent`, `freshdesk_agents_create`, `freshdesk_agents_delete`, `freshdesk_sla_create`, `freshdesk_sla_update`, `freshdesk_tickets_delete`, `freshdesk_tickets_delete_conversation`, `freshdesk_contacts_soft_delete`, `freshdesk_contacts_hard_delete`, `freshdesk_companies_delete`, `freshdesk_groups_delete`, `freshdesk_solutions_categories_delete`, `freshdesk_solutions_folders_delete`, `freshdesk_solutions_articles_delete` |
 
 Four of those destructive entries look like ordinary writes in the API and
 are worth justifying:
@@ -48,6 +67,12 @@ are worth justifying:
   and `fr_due_by` across the live queue. A single policy edit can put
   tickets into breach retrospectively and change what your SLA reports —
   and any contractual credits derived from them — say.
+
+Conduit does not enforce any of that as an approval requirement. It
+compares tiers — it has no approval step, no per-call confirmation, and
+no interactive prompt. Per-call approval is a workflow you impose on your
+agents, and it is only as good as the agent configuration that carries
+it.
 
 ## Recommended agent policy
 

--- a/msp-claude-plugins/hubspot/hubspot/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/hubspot/hubspot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hubspot",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Claude plugins for HubSpot CRM - contacts, companies, deals, tickets, activities, and associations",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/hubspot/hubspot/GOVERNANCE.md
+++ b/msp-claude-plugins/hubspot/hubspot/GOVERNANCE.md
@@ -20,11 +20,30 @@ authorised for.
 
 ## Tool permission tiers
 
+> **Not classified in Conduit — every tool in the table below requires
+> tier `admin` today.** Conduit derives each tool's tier from
+> `VENDOR_TOOL_CONFIG` (`src/proxy/result-cache.ts`) and fails closed for
+> anything absent from it:
+> `const requiredTier: PermissionTier = classified ?? 'admin';`
+> (`src/access/access-enforcement.ts:63`). `hubspot` has no entry, so the
+> grouping below carries no enforcement weight right now — read tools
+> require `admin` exactly as the rest do, and there is no narrower grant
+> that admits them. The grouping is still the right *risk* reading, and it
+> becomes the enforcement reading on the day this vendor is classified.
+> The list of unclassified vendors moves whenever one of them is
+> classified, so it is stated in one place only:
+> `wyre-gateway/GOVERNANCE.md`, *Fail-closed, and the vendors Conduit has
+> not classified*.
+>
+> *This blockquote is the whole of the not-classified caveat. When
+> `hubspot` appears in `VENDOR_TOOL_CONFIG`, delete this blockquote and
+> change nothing else.*
+
 | Tier | What it can do | Tools |
 |---|---|---|
 | **Read** | Cannot change HubSpot state. Safe for autonomous agents. | `hubspot_retrieve_contact`, `hubspot_list_contacts`, `hubspot_list_contact_properties`, `hubspot_search_contacts`, `hubspot_retrieve_company`, `hubspot_list_company_properties`, `hubspot_search_companies`, `hubspot_retrieve_deal`, `hubspot_list_deal_properties`, `hubspot_search_deals`, `hubspot_retrieve_ticket`, `hubspot_access_associations`, `hubspot_get_user_details`, `hubspot_open_hubspot_ui` |
 | **Write** | Creates or modifies records. Reversible, internally visible. | `hubspot_create_company`, `hubspot_update_company`, `hubspot_create_deal`, `hubspot_update_deal`, `hubspot_create_ticket`, `hubspot_update_ticket`, `hubspot_create_task`, `hubspot_create_note`, `hubspot_create_association` |
-| **Destructive** | Can cause HubSpot to email a real person. Requires explicit per-call human approval. | `hubspot_create_contact`, `hubspot_update_contact` |
+| **Destructive** | Can cause HubSpot to email a real person. | `hubspot_create_contact`, `hubspot_update_contact` |
 
 There is no delete tool in this plugin, so the destructive tier is not defined
 by data loss — it is defined by outbound reach.
@@ -37,6 +56,11 @@ hands a real named prospect to a marketing sequence. The plugin sends nothing;
 HubSpot does, on the strength of the write — and a sent email cannot be
 recalled. Company, deal, and ticket objects carry no email address of their
 own, which is why they stay in the write tier.
+
+Conduit does not enforce any of that as an approval requirement. It compares
+tiers — it has no approval step, no per-call confirmation, and no interactive
+prompt. Per-call approval is a workflow you impose on your agents, and it is
+only as good as the agent configuration that carries it.
 
 ## Recommended agent policy
 

--- a/msp-claude-plugins/immybot/immybot/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/immybot/immybot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "immybot",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "ImmyBot - desired-state Windows software deployment, maintenance sessions, and script execution for MSPs (Entra ID OAuth)",
   "author": {
     "name": "WYRE AI"

--- a/msp-claude-plugins/immybot/immybot/GOVERNANCE.md
+++ b/msp-claude-plugins/immybot/immybot/GOVERNANCE.md
@@ -37,11 +37,30 @@ Grouped by blast radius, not HTTP verb. Several tools that look like
 reads or harmless writes are classified destructive below, with the
 reasoning stated.
 
+> **Not classified in Conduit — every tool in the table below requires
+> tier `admin` today.** Conduit derives each tool's tier from
+> `VENDOR_TOOL_CONFIG` (`src/proxy/result-cache.ts`) and fails closed for
+> anything absent from it:
+> `const requiredTier: PermissionTier = classified ?? 'admin';`
+> (`src/access/access-enforcement.ts:63`). `immybot` has no entry, so the
+> grouping below carries no enforcement weight right now — read tools
+> require `admin` exactly as the rest do, and there is no narrower grant
+> that admits them. The grouping is still the right *risk* reading, and it
+> becomes the enforcement reading on the day this vendor is classified.
+> The list of unclassified vendors moves whenever one of them is
+> classified, so it is stated in one place only:
+> `wyre-gateway/GOVERNANCE.md`, *Fail-closed, and the vendors Conduit has
+> not classified*.
+>
+> *This blockquote is the whole of the not-classified caveat. When
+> `immybot` appears in `VENDOR_TOOL_CONFIG`, delete this blockquote and
+> change nothing else.*
+
 | Tier | What it can do | Tools |
 |---|---|---|
 | **Read** | Cannot change ImmyBot or endpoint state. Safe for autonomous agents. | `immybot_navigate`, `immybot_back`, `immybot_status`, `immybot_computers_list`, `immybot_computers_get`, `immybot_computers_search`, `immybot_computers_inventory`, `immybot_computers_deployments`, `immybot_software_list`, `immybot_software_list_global`, `immybot_software_get`, `immybot_software_search`, `immybot_software_versions`, `immybot_software_latest_version`, `immybot_software_categories`, `immybot_software_publishers`, `immybot_software_stats`, `immybot_deployments_list`, `immybot_deployments_get`, `immybot_deployments_compliance`, `immybot_deployments_for_computer`, `immybot_deployments_for_software`, `immybot_scripts_list`, `immybot_scripts_get`, `immybot_scripts_search`, `immybot_scripts_categories`, `immybot_scripts_validate`, `immybot_scripts_execution_history`, `immybot_scripts_execution_result`, `immybot_tenants_list`, `immybot_tenants_get`, `immybot_tenants_search`, `immybot_tenants_stats`, `immybot_tenants_computers`, `immybot_tenants_deployments`, `immybot_tenants_compliance`, `immybot_tenants_software_inventory`, `immybot_maintenance_sessions_list`, `immybot_maintenance_sessions_get`, `immybot_maintenance_sessions_active`, `immybot_maintenance_sessions_summary`, `immybot_maintenance_sessions_logs`, `immybot_maintenance_sessions_results`, `immybot_tasks_list`, `immybot_tasks_get`, `immybot_tasks_logs`, `immybot_tasks_history`, `immybot_tasks_queued`, `immybot_tasks_running`, `immybot_tasks_failed`, `immybot_tasks_for_computer`, `immybot_tasks_for_tenant`, `immybot_tasks_by_type`, `immybot_tasks_child_tasks`, `immybot_tasks_dependencies`, `immybot_tasks_estimated_completion`, `immybot_tasks_queue_stats`, `immybot_tasks_metrics` |
 | **Write** | Changes ImmyBot-side records or session flow. Reversible. | `immybot_computers_create`, `immybot_maintenance_sessions_pause`, `immybot_maintenance_sessions_resume` |
-| **Destructive** | Acts on customer Windows endpoints, or arms an action that will. Requires explicit per-call human approval. | `immybot_scripts_run`, `immybot_software_install`, `immybot_deployments_trigger`, `immybot_deployments_create`, `immybot_maintenance_sessions_start`, `immybot_maintenance_sessions_cancel`, `immybot_computers_trigger_checkin` |
+| **Destructive** | Acts on customer Windows endpoints, or arms an action that will. | `immybot_scripts_run`, `immybot_software_install`, `immybot_deployments_trigger`, `immybot_deployments_create`, `immybot_maintenance_sessions_start`, `immybot_maintenance_sessions_cancel`, `immybot_computers_trigger_checkin` |
 
 ### Why each destructive tool is there
 
@@ -78,6 +97,12 @@ reasoning stated.
 `immybot_scripts_validate` is safe and belongs in Read: it checks
 PowerShell syntax without executing anything. Use it before every
 `immybot_scripts_run`.
+
+Conduit does not enforce any of that as an approval requirement. It
+compares tiers — it has no approval step, no per-call confirmation, and
+no interactive prompt. Per-call approval is a workflow you impose on your
+agents, and it is only as good as the agent configuration that carries
+it.
 
 ## Recommended agent policy
 

--- a/msp-claude-plugins/inforcer/inforcer/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/inforcer/inforcer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "inforcer",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Inforcer - read-only Microsoft 365 security baseline governance for MSPs: tenants, baselines, alignment/drift, secure scores, identity inventory, audit events, and assessments",
   "author": {
     "name": "WYRE AI"

--- a/msp-claude-plugins/inforcer/inforcer/GOVERNANCE.md
+++ b/msp-claude-plugins/inforcer/inforcer/GOVERNANCE.md
@@ -26,6 +26,25 @@ the operator is authorised for.
 
 ## Tool permission tiers
 
+> **Not classified in Conduit — every tool in the table below requires
+> tier `admin` today.** Conduit derives each tool's tier from
+> `VENDOR_TOOL_CONFIG` (`src/proxy/result-cache.ts`) and fails closed for
+> anything absent from it:
+> `const requiredTier: PermissionTier = classified ?? 'admin';`
+> (`src/access/access-enforcement.ts:63`). `inforcer` has no entry, so the
+> grouping below carries no enforcement weight right now — read tools
+> require `admin` exactly as the rest do, and there is no narrower grant
+> that admits them. The grouping is still the right *risk* reading, and it
+> becomes the enforcement reading on the day this vendor is classified.
+> The list of unclassified vendors moves whenever one of them is
+> classified, so it is stated in one place only:
+> `wyre-gateway/GOVERNANCE.md`, *Fail-closed, and the vendors Conduit has
+> not classified*.
+>
+> *This blockquote is the whole of the not-classified caveat. When
+> `inforcer` appears in `VENDOR_TOOL_CONFIG`, delete this blockquote and
+> change nothing else.*
+
 | Tier | What it can do | Tools |
 |---|---|---|
 | **Read** | Cannot change Inforcer or tenant state. Safe for autonomous agents. | `inforcer_status`, `inforcer_navigate`, `inforcer_tenants_list`, `inforcer_tenants_get`, `inforcer_tenants_resolve`, `inforcer_baselines_list`, `inforcer_alignment_scores`, `inforcer_alignment_details`, `inforcer_policies_list`, `inforcer_secure_scores_get`, `inforcer_users_list`, `inforcer_users_get`, `inforcer_groups_list`, `inforcer_groups_get`, `inforcer_roles_list`, `inforcer_audit_event_types`, `inforcer_audit_search`, `inforcer_assessments_list` |

--- a/msp-claude-plugins/ironscales/ironscales/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/ironscales/ironscales/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironscales",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Claude plugins for IRONSCALES - AI-powered anti-phishing, incident triage, email classification, and crowdsourced threat intelligence",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/ironscales/ironscales/GOVERNANCE.md
+++ b/msp-claude-plugins/ironscales/ironscales/GOVERNANCE.md
@@ -21,11 +21,30 @@ operator is authorised for.
 
 ## Tool permission tiers
 
+> **Not classified in Conduit — every tool in the table below requires
+> tier `admin` today.** Conduit derives each tool's tier from
+> `VENDOR_TOOL_CONFIG` (`src/proxy/result-cache.ts`) and fails closed for
+> anything absent from it:
+> `const requiredTier: PermissionTier = classified ?? 'admin';`
+> (`src/access/access-enforcement.ts:63`). `ironscales` has no entry, so
+> the grouping below carries no enforcement weight right now — read tools
+> require `admin` exactly as the rest do, and there is no narrower grant
+> that admits them. The grouping is still the right *risk* reading, and it
+> becomes the enforcement reading on the day this vendor is classified.
+> The list of unclassified vendors moves whenever one of them is
+> classified, so it is stated in one place only:
+> `wyre-gateway/GOVERNANCE.md`, *Fail-closed, and the vendors Conduit has
+> not classified*.
+>
+> *This blockquote is the whole of the not-classified caveat. When
+> `ironscales` appears in `VENDOR_TOOL_CONFIG`, delete this blockquote and
+> change nothing else.*
+
 | Tier | What it can do | Tools |
 |---|---|---|
 | **Read** | Cannot change mailbox, incident, or policy state. Safe for autonomous agents. | `ironscales_incidents_list`, `ironscales_incidents_get`, `ironscales_stats_company`, `ironscales_email_classify`, `ironscales_navigate`, `ironscales_status`, `ironscales_back` |
 | **Write** | Empty. Nothing here changes a record without also changing mail delivery or detection coverage. | — |
-| **Destructive** | Deletes mail, alters what the filter will catch in future, or notifies end users. Requires explicit per-call human approval. | `ironscales_remediation_act`, `ironscales_allowlist_manage` |
+| **Destructive** | Deletes mail, alters what the filter will catch in future, or notifies end users. | `ironscales_remediation_act`, `ironscales_allowlist_manage` |
 
 `ironscales_remediation_act` is destructive under every value of its
 `action` argument, not only `delete`:
@@ -50,6 +69,12 @@ reduction in the customer's protection that produces no alert and no
 visible change until an attacker spoofs the exempted sender. The verb is
 benign; the blast radius is not. Reasonable operators may argue this
 belongs in Write; we would rather it require an approver.
+
+Conduit does not enforce any of that as an approval requirement. It
+compares tiers — it has no approval step, no per-call confirmation, and
+no interactive prompt. Per-call approval is a workflow you impose on your
+agents, and it is only as good as the agent configuration that carries
+it.
 
 ## Recommended agent policy
 

--- a/msp-claude-plugins/kaseya/datto-bcdr/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/kaseya/datto-bcdr/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "datto-bcdr",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Claude plugins for Datto BCDR (SIRIS / Alto) - backup status, screenshot verification, virtualization, recovery point management",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/kaseya/datto-bcdr/GOVERNANCE.md
+++ b/msp-claude-plugins/kaseya/datto-bcdr/GOVERNANCE.md
@@ -23,6 +23,25 @@ for.
 
 ## Tool permission tiers
 
+> **Not classified in Conduit — every tool in the table below requires
+> tier `admin` today.** Conduit derives each tool's tier from
+> `VENDOR_TOOL_CONFIG` (`src/proxy/result-cache.ts`) and fails closed for
+> anything absent from it:
+> `const requiredTier: PermissionTier = classified ?? 'admin';`
+> (`src/access/access-enforcement.ts:63`). `datto-bcdr` has no entry, so
+> the grouping below carries no enforcement weight right now — read tools
+> require `admin` exactly as the rest do, and there is no narrower grant
+> that admits them. The grouping is still the right *risk* reading, and it
+> becomes the enforcement reading on the day this vendor is classified.
+> The list of unclassified vendors moves whenever one of them is
+> classified, so it is stated in one place only:
+> `wyre-gateway/GOVERNANCE.md`, *Fail-closed, and the vendors Conduit has
+> not classified*.
+>
+> *This blockquote is the whole of the not-classified caveat. When
+> `datto-bcdr` appears in `VENDOR_TOOL_CONFIG`, delete this blockquote and
+> change nothing else.*
+
 | Tier | What it can do | Tools |
 |---|---|---|
 | **Read** | Cannot change appliance, agent, or backup state. | `datto_bcdr_list_devices`, `datto_bcdr_get_device`, `datto_bcdr_list_assets`, `datto_bcdr_get_asset`, `datto_bcdr_list_backups`, `datto_bcdr_list_screenshots`, `datto_bcdr_get_screenshot`, `datto_bcdr_get_offsite_status`, `datto_bcdr_list_alerts`, `datto_bcdr_list_activity` |

--- a/msp-claude-plugins/kaseya/kaseya-bms/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/kaseya/kaseya-bms/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kaseya-bms",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Claude plugins for Kaseya BMS - tickets, accounts, contracts, time entries, billing (PSA)",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/kaseya/kaseya-bms/GOVERNANCE.md
+++ b/msp-claude-plugins/kaseya/kaseya-bms/GOVERNANCE.md
@@ -19,6 +19,25 @@ operator is authorised for.
 
 ## Tool permission tiers
 
+> **Not classified in Conduit — every tool in the table below requires
+> tier `admin` today.** Conduit derives each tool's tier from
+> `VENDOR_TOOL_CONFIG` (`src/proxy/result-cache.ts`) and fails closed for
+> anything absent from it:
+> `const requiredTier: PermissionTier = classified ?? 'admin';`
+> (`src/access/access-enforcement.ts:63`). `kaseya-bms` has no entry, so
+> the grouping below carries no enforcement weight right now — read tools
+> require `admin` exactly as the rest do, and there is no narrower grant
+> that admits them. The grouping is still the right *risk* reading, and it
+> becomes the enforcement reading on the day this vendor is classified.
+> The list of unclassified vendors moves whenever one of them is
+> classified, so it is stated in one place only:
+> `wyre-gateway/GOVERNANCE.md`, *Fail-closed, and the vendors Conduit has
+> not classified*.
+>
+> *This blockquote is the whole of the not-classified caveat. When
+> `kaseya-bms` appears in `VENDOR_TOOL_CONFIG`, delete this blockquote and
+> change nothing else.*
+
 | Tier | What it can do | Tools |
 |---|---|---|
 | **Read** | Cannot change BMS state. Safe for autonomous agents. | `kaseya_bms_list_tickets`, `kaseya_bms_get_ticket`, `kaseya_bms_list_time_entries`, `kaseya_bms_list_accounts`, `kaseya_bms_list_contacts`, `kaseya_bms_list_contracts`, `kaseya_bms_list_service_catalog`, `kaseya_bms_search_knowledge_base` |

--- a/msp-claude-plugins/kaseya/kaseya-vsa/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/kaseya/kaseya-vsa/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kaseya-vsa",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Claude plugins for Kaseya VSA - endpoint monitoring, patch management, agent procedures, remote control",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/kaseya/kaseya-vsa/GOVERNANCE.md
+++ b/msp-claude-plugins/kaseya/kaseya-vsa/GOVERNANCE.md
@@ -20,11 +20,30 @@ operator is authorised for.
 
 ## Tool permission tiers
 
+> **Not classified in Conduit — every tool in the table below requires
+> tier `admin` today.** Conduit derives each tool's tier from
+> `VENDOR_TOOL_CONFIG` (`src/proxy/result-cache.ts`) and fails closed for
+> anything absent from it:
+> `const requiredTier: PermissionTier = classified ?? 'admin';`
+> (`src/access/access-enforcement.ts:63`). `kaseya-vsa` has no entry, so
+> the grouping below carries no enforcement weight right now — read tools
+> require `admin` exactly as the rest do, and there is no narrower grant
+> that admits them. The grouping is still the right *risk* reading, and it
+> becomes the enforcement reading on the day this vendor is classified.
+> The list of unclassified vendors moves whenever one of them is
+> classified, so it is stated in one place only:
+> `wyre-gateway/GOVERNANCE.md`, *Fail-closed, and the vendors Conduit has
+> not classified*.
+>
+> *This blockquote is the whole of the not-classified caveat. When
+> `kaseya-vsa` appears in `VENDOR_TOOL_CONFIG`, delete this blockquote and
+> change nothing else.*
+
 | Tier | What it can do | Tools |
 |---|---|---|
 | **Read** | Cannot change VSA or endpoint state. Safe for autonomous agents. | `kaseya_vsa_list_agents`, `kaseya_vsa_get_agent`, `kaseya_vsa_get_software_inventory`, `kaseya_vsa_get_hardware_inventory`, `kaseya_vsa_get_patch_status`, `kaseya_vsa_list_procedures`, `kaseya_vsa_list_alarms`, `kaseya_vsa_list_tickets`, `kaseya_vsa_list_organizations`, `kaseya_vsa_list_machine_groups` |
 | **Write** | — | None. This plugin has no reversible-write tier. |
-| **Destructive** | Executes code or forces reboots on a customer endpoint. Requires explicit per-call human approval. | `kaseya_vsa_deploy_patches_now`, `kaseya_vsa_run_procedure` |
+| **Destructive** | Executes code or forces reboots on a customer endpoint. | `kaseya_vsa_deploy_patches_now`, `kaseya_vsa_run_procedure` |
 
 Both destructive tools are marked DESTRUCTIVE by the MCP server itself
 and prompt for confirmation before running. Do not treat that prompt as
@@ -43,6 +62,12 @@ There is no write tier because VSA exposes no reversible mutation here.
 Every tool either reads, or acts on a customer machine. That gap is
 worth stating plainly: with this plugin an agent is either observing or
 intervening, with nothing in between.
+
+Conduit does not enforce any of that as an approval requirement. It
+compares tiers — it has no approval step, no per-call confirmation, and
+no interactive prompt. Per-call approval is a workflow you impose on your
+agents, and it is only as good as the agent configuration that carries
+it.
 
 ## Recommended agent policy
 

--- a/msp-claude-plugins/mimecast/mimecast/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/mimecast/mimecast/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mimecast",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Claude plugins for Mimecast Email Security - message tracking, threat intelligence, queue management, and email security operations",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/mimecast/mimecast/GOVERNANCE.md
+++ b/msp-claude-plugins/mimecast/mimecast/GOVERNANCE.md
@@ -22,11 +22,30 @@ operator is authorised for.
 
 ## Tool permission tiers
 
+> **Not classified in Conduit — every tool in the table below requires
+> tier `admin` today.** Conduit derives each tool's tier from
+> `VENDOR_TOOL_CONFIG` (`src/proxy/result-cache.ts`) and fails closed for
+> anything absent from it:
+> `const requiredTier: PermissionTier = classified ?? 'admin';`
+> (`src/access/access-enforcement.ts:63`). `mimecast` has no entry, so the
+> grouping below carries no enforcement weight right now — read tools
+> require `admin` exactly as the rest do, and there is no narrower grant
+> that admits them. The grouping is still the right *risk* reading, and it
+> becomes the enforcement reading on the day this vendor is classified.
+> The list of unclassified vendors moves whenever one of them is
+> classified, so it is stated in one place only:
+> `wyre-gateway/GOVERNANCE.md`, *Fail-closed, and the vendors Conduit has
+> not classified*.
+>
+> *This blockquote is the whole of the not-classified caveat. When
+> `mimecast` appears in `VENDOR_TOOL_CONFIG`, delete this blockquote and
+> change nothing else.*
+
 | Tier | What it can do | Tools |
 |---|---|---|
 | **Read** | Cannot change mail flow or Mimecast state. Safe for autonomous agents. | `mimecast_find_message`, `mimecast_get_message_info`, `mimecast_get_queue_status`, `mimecast_get_threat_incidents`, `mimecast_get_ttp_logs`, `mimecast_get_audit_events`, `mimecast_navigate`, `mimecast_status` |
 | **Write** | Stops one message reaching one recipient. Reversible, and visible to the customer as a delayed email. | `mimecast_hold_message` |
-| **Destructive** | Delivers mail the platform decided not to deliver. Requires explicit per-call human approval. | `mimecast_release_message` |
+| **Destructive** | Delivers mail the platform decided not to deliver. | `mimecast_release_message` |
 
 `mimecast_release_message` is destructive despite doing nothing that
 looks like a deletion. A message is in the hold queue because a policy
@@ -41,6 +60,12 @@ not the HTTP verb.
 `mimecast_hold_message` is the mirror image and belongs one tier lower.
 It has a customer-visible cost — legitimate business mail stops moving —
 but release undoes it, and the reach is a single message.
+
+Conduit does not enforce any of that as an approval requirement. It
+compares tiers — it has no approval step, no per-call confirmation, and
+no interactive prompt. Per-call approval is a workflow you impose on your
+agents, and it is only as good as the agent configuration that carries
+it.
 
 ## Recommended agent policy
 


### PR DESCRIPTION
Fourteen vendor governance documents ship a Read / Write / Destructive tier
table that, for these vendors, has no enforcement meaning at all — and most of
them promise a per-call human approval step that Conduit does not have and
never had. This makes both claims accurate without pre-empting the re-tiering
work.

## What was wrong

**1. The tier table has no enforcement meaning for these vendors today.**
Conduit derives every tool's tier from `VENDOR_TOOL_CONFIG`
(`conduit/src/proxy/result-cache.ts`) and is fail-closed:

```ts
const requiredTier: PermissionTier = classified ?? 'admin';
```
— `conduit/src/access/access-enforcement.ts:63`

None of these 14 vendors has an entry in that table. So *every tool each of
them documents requires tier `admin`* — read tools included — no matter which
row it sits in. A read-only agent cannot use any of them without being granted
`admin`, which grants it everything else on that vendor too. There is no safe
middle setting. That fact appeared in none of the 14 documents.

**2. Eight of them promised "Requires explicit per-call human approval."**
Conduit has no approval step, no per-call confirmation, and no interactive
prompt. It compares tiers. Those sentences were false and always would be.

## What this PR does — deliberately minimal

**A scoped blockquote immediately above each tier table.** It states that the
vendor is not classified, that every tool below therefore requires `admin`,
and that the grouping becomes the enforcement grouping once the vendor is
classified. It points at `wyre-gateway/GOVERNANCE.md`, *Fail-closed, and the
vendors Conduit has not classified*, for the live list rather than restating
it — that list is a snapshot of one upstream table in one file in another
repository and must have exactly one downstream statement, or thirty copies
become thirty places to drift.

The block ends by naming itself as the whole of the caveat, so whoever
classifies a vendor deletes exactly that blockquote and touches nothing else:

> *This blockquote is the whole of the not-classified caveat. When `<slug>`
> appears in `VENDOR_TOOL_CONFIG`, delete this blockquote and change nothing
> else.*

**Removed every per-call-approval promise**, replaced with the template's
framing (`_templates/governance-template.md`, *Tool permission groups*):

> Conduit does not enforce any of that as an approval requirement. It compares
> tiers — it has no approval step, no per-call confirmation, and no interactive
> prompt. Per-call approval is a workflow you impose on your agents, and it is
> only as good as the agent configuration that carries it.

The *recommendations* in each document's "Recommended agent policy" section are
left standing — the template keeps those too. They are now unambiguously
recommendations, because the paragraph above them says Conduit enforces none of
it.

## What this PR deliberately does NOT do

**No re-tiering into Conduit's four presented groups.** A sibling effort is
re-tiering the 34 *classified* vendors. These 14 will need the same when they
are classified; doing it now means doing it twice.

**The tier grouping and all risk commentary are untouched.** "Destructive" in
these documents is a *risk* judgement about blast radius in a customer's
tenant — Better Stack putting `pause_monitor` there because a paused monitor
raises no incident and pages nobody, ImmyBot putting `immybot_deployments_create`
there because it arms a fleet-wide install with no delete tool to undo it,
IRONSCALES putting `ironscales_allowlist_manage` there because a permanent
detection exemption produces no alert. That is the most valuable content in
these files and it is still correct. Only the enforcement claim was wrong.

## Approval promises removed, per plugin

| Plugin | Table-row promises removed |
|---|---|
| `abnormal-security` | 1 |
| `betterstack` | 1 |
| `freshdesk` | 1 |
| `hubspot` | 1 |
| `immybot` | 1 |
| `ironscales` | 1 |
| `kaseya-vsa` | 1 |
| `mimecast` | 1 |
| `atera`, `blumira`, `datto-bcdr`, `inforcer`, `kaseya-bms`, `knowbe4` | 0 — Destructive tier is empty or the plugin is read-only, so no promise existed |

**8 removed across 14 plugins.** The six with none are the read-only and
empty-destructive-tier plugins; they got the unclassified notice only.

## Verification

```
$ node scripts/check-marketplace-drift.mjs --base origin/main
bump gate: compared HEAD against merge base 5ebce5062b33 (28 changed files, 14 plugins touched)
✔ marketplace drift check passed (76 entries)
```

All 14 patch-bumped. No files touched outside the 14 plugin directories —
`_templates/`, `_standards/`, `wyre-gateway/`, `marketplace.json` and
`docs/src/data/*` are untouched, and `npm run generate` was not run.

## Left for someone else

Three claims in these documents that neither correction covers, flagged rather
than fixed because each is a substantive change beyond this PR's scope:

1. **`immybot`, `freshdesk` and `inforcer` ship a `.mcp.json` pointing at
   `https://mcp.wyre.ai/...`**, not `conduit.wyre.ai` — the other gateway, the
   one `wyre-gateway/GOVERNANCE.md` explicitly does not describe. ImmyBot's
   prose says so too ("It reaches ImmyBot through the WYRE gateway
   (`https://mcp.wyre.ai/v1/immybot/mcp`)"), which now sits alongside a notice
   citing Conduit's source. The other 11 plugins ship no `.mcp.json` at all.
   Already noted in the CHANGELOG entry for #182; repeating it because it
   directly affects whether these notices apply to what the plugin connects to.

2. **All 14 claim "Revoking gateway access revokes <vendor> access with it,
   immediately."** `wyre-gateway/GOVERNANCE.md`, *Corrections to the per-vendor
   documents*, rates this **not accurate as an unqualified statement** — the
   access token stays valid up to an hour, refresh tokens 30 days with no
   offboarding path revoking them, `users.active` is never read on the auth
   path, and personal connections are unaffected. Same section rates
   "Credential rotation happens once at the gateway" **overstated** for
   API-key vendors, which is most of this batch.

3. **`kaseya-vsa` claims a confirmation prompt exists**: "Both destructive
   tools are marked DESTRUCTIVE by the MCP server itself and prompt for
   confirmation before running." That is a claim about the vendor MCP server,
   not Conduit, so the no-approval correction does not reach it. It is already
   correctly caveated in place ("Do not treat that prompt as the control — an
   agent granted the tool can answer it"), but it wants verifying against
   `kaseya-vsa-mcp` by someone who can read that server.

**No CHANGELOG entry here.** The task scope was "touch only your 14 plugins'
directories," and parallel batches all editing the same `## [Unreleased]` block
would conflict. One consolidated entry covering all the unclassified-vendor
batches would be better than four racing ones.

## The notice, verbatim

For reuse — substitute the marketplace slug in both places:

```markdown
> **Not classified in Conduit — every tool in the table below requires
> tier `admin` today.** Conduit derives each tool's tier from
> `VENDOR_TOOL_CONFIG` (`src/proxy/result-cache.ts`) and fails closed for
> anything absent from it:
> `const requiredTier: PermissionTier = classified ?? 'admin';`
> (`src/access/access-enforcement.ts:63`). `<slug>` has no entry, so the
> grouping below carries no enforcement weight right now — read tools
> require `admin` exactly as the rest do, and there is no narrower grant
> that admits them. The grouping is still the right *risk* reading, and it
> becomes the enforcement reading on the day this vendor is classified.
> The list of unclassified vendors moves whenever one of them is
> classified, so it is stated in one place only:
> `wyre-gateway/GOVERNANCE.md`, *Fail-closed, and the vendors Conduit has
> not classified*.
>
> *This blockquote is the whole of the not-classified caveat. When `<slug>`
> appears in `VENDOR_TOOL_CONFIG`, delete this blockquote and change
> nothing else.*
```
