### PR TITLE
fix(kaseya): retier governance tables to Conduit's real permission model

### DIFF
--- a/msp-claude-plugins/kaseya/autotask/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/kaseya/autotask/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autotask",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Claude plugins for Kaseya Autotask PSA - tickets, CRM, projects, contracts, expenses, quotes, quote builder",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/kaseya/autotask/GOVERNANCE.md
+++ b/msp-claude-plugins/kaseya/autotask/GOVERNANCE.md
@@ -16,40 +16,95 @@ operator is authorised for.
 - Every call carries operator identity, so the gateway audit log answers
   "who raised this charge" — Autotask's own audit trail records only the
   API user.
-- Revoking gateway access revokes Autotask access with it, immediately.
+- Removing a technician's Conduit org membership stops their Autotask
+  access on their next call, because membership is re-read per request.
+  It does **not** revoke an already-issued token, and it does not touch
+  credentials they connected personally. Full offboarding is more than
+  one step — see `wyre-gateway/GOVERNANCE.md`, *Revocation*.
 
-## Tool permission tiers
+## Tool permission groups
 
-| Tier | What it can do | Tools |
-|---|---|---|
-| **Read** | Cannot change Autotask state. Safe for autonomous agents. | All `autotask_search_*` (29), `autotask_get_*` (19), and `autotask_list_*` (6) tools, plus `autotask_test_connection` and `autotask_router`. Enumerated below. |
-| **Write** | Creates or modifies records. Reversible, but visible to the customer. | `autotask_create_company`, `autotask_create_company_note`, `autotask_create_contact`, `autotask_create_opportunity`, `autotask_create_phase`, `autotask_create_project`, `autotask_create_project_note`, `autotask_create_quote`, `autotask_create_quote_item`, `autotask_create_service_call`, `autotask_create_service_call_ticket`, `autotask_create_service_call_ticket_resource`, `autotask_create_task`, `autotask_create_ticket`, `autotask_create_ticket_attachment`, `autotask_create_ticket_checklist_item`, `autotask_create_ticket_note`, `autotask_create_time_entry`, `autotask_create_expense_item`, `autotask_create_expense_report`, `autotask_update_company`, `autotask_update_company_site_configuration`, `autotask_update_contact`, `autotask_update_project`, `autotask_update_quote_item`, `autotask_update_service_call`, `autotask_update_ticket`, `autotask_update_ticket_checklist_item` |
-| **Destructive** | Deletes records, changes what the customer is billed, or executes an unbounded call. Requires explicit per-call human approval. | `autotask_delete_quote_item`, `autotask_delete_service_call`, `autotask_delete_service_call_ticket`, `autotask_delete_service_call_ticket_resource`, `autotask_delete_ticket_charge`, `autotask_delete_ticket_checklist_item`, `autotask_create_ticket_charge`, `autotask_update_ticket_charge`, `autotask_create_contract`, `autotask_update_contract`, `autotask_create_contract_service`, `autotask_update_contract_service`, `autotask_execute_tool`, `autotask_raw_request` |
+Autotask is classified in Conduit's `VENDOR_TOOL_CONFIG`
+(`src/proxy/result-cache.ts`), so the tiers below are the ones actually
+enforced. All 98 tools are classified; none fall through to the
+unclassified-means-`admin` rule.
 
-### Why some non-delete tools sit in the destructive tier
+| Group | What it can do | Enforcement tier | Tools |
+|---|---|---|---|
+| **Read** | Cannot change Autotask state. Safe for autonomous agents. | `read` | All `autotask_search_*` (29), `autotask_get_*` (19), and `autotask_list_*` (6) tools, plus `autotask_test_connection`. Enumerated below. |
+| **Write** | Creates or modifies records. Reversible, but visible to the customer — and includes the billing and contract tools. | `write` | `autotask_create_company`, `autotask_create_company_note`, `autotask_create_contact`, `autotask_create_contract`, `autotask_create_contract_service`, `autotask_create_expense_item`, `autotask_create_expense_report`, `autotask_create_opportunity`, `autotask_create_phase`, `autotask_create_project`, `autotask_create_project_note`, `autotask_create_quote`, `autotask_create_quote_item`, `autotask_create_service_call`, `autotask_create_service_call_ticket`, `autotask_create_service_call_ticket_resource`, `autotask_create_task`, `autotask_create_ticket`, `autotask_create_ticket_attachment`, `autotask_create_ticket_charge`, `autotask_create_ticket_checklist_item`, `autotask_create_ticket_note`, `autotask_create_time_entry`, `autotask_update_company`, `autotask_update_contact`, `autotask_update_contract`, `autotask_update_contract_service`, `autotask_update_project`, `autotask_update_quote_item`, `autotask_update_service_call`, `autotask_update_ticket`, `autotask_update_ticket_charge`, `autotask_update_ticket_checklist_item` |
+| **Delete** | Removes a record. No recycle bin, no undo tool. | `write` — **not** a tier of its own | `autotask_delete_quote_item`, `autotask_delete_service_call`, `autotask_delete_service_call_ticket`, `autotask_delete_service_call_ticket_resource`, `autotask_delete_ticket_charge`, `autotask_delete_ticket_checklist_item` |
+| **Admin** | Unbounded passthrough, arbitrary tool dispatch, or a freeform request body. | `admin` | `autotask_raw_request`, `autotask_execute_tool`, `autotask_router`, `autotask_update_company_site_configuration` |
+
+**The Delete row is the one to read twice.** Conduit's enforcement tiers
+are only `read`, `write`, and `admin` (plus `none`, meaning deny) —
+`src/access/permission-tier.ts:27`. "Delete" is a presentation group in
+the access editor, and a delete-group tool compiles to and enforces at
+tier `write` (`src/access/tier-group-mapping.ts`, `GROUP_ENFORCEMENT_TIER`).
+So **granting a technician `write` on Autotask also grants all six
+`autotask_delete_*` tools.** There is no setting that separates them; the
+only way to admit some write tools but not the deletes is a granular
+per-tool grant, which compiles to an explicit `customTools` allowlist.
+
+Conduit compares tiers. It has no approval step, no per-call
+confirmation, and no interactive prompt — its source contains no
+elicitation handling at all. Per-call approval for anything below is a
+policy you impose on your agents, and it is only as good as the agent
+configuration that carries it.
+
+### Where the enforced tier is weaker than the risk
+
+The tools below enforce at `write`, which is the same tier as creating a
+ticket note. The mechanical tier is a function of `isWrite`/`isAdmin`;
+it is not a judgement about blast radius in a customer's tenant. These
+three groups deserve the care the tier does not give them:
 
 - **Ticket charges** (`autotask_create_ticket_charge`,
-  `autotask_update_ticket_charge`) post money directly onto a customer's
-  invoice. The API calls it a create; the customer calls it a bill.
-  Unlike time entries, charges do not pass through a submit/approve
-  workflow before they reach billing.
+  `autotask_update_ticket_charge`, `autotask_delete_ticket_charge`) post
+  money directly onto a customer's invoice. The API calls it a create;
+  the customer calls it a bill. Unlike time entries, charges do not pass
+  through a submit/approve workflow before they reach billing.
 - **Contract tools** (`autotask_create_contract`,
   `autotask_update_contract`, and the two contract-service tools) change
   the managed services agreement. A single edit changes the recurring
   amount the client pays every month until someone notices. The blast
   radius is the commercial relationship, not a record.
-- **`autotask_execute_tool` and `autotask_raw_request`** have no fixed
-  blast radius: the first runs any tool by name, the second issues an
-  arbitrary REST call against the Autotask API. They inherit the
-  privileges of whatever they wrap, so the tier model only holds if they
-  are governed at the highest tier.
+- **The six `autotask_delete_*` tools** remove the record outright. They
+  are in the Delete presentation group, which still enforces at `write`.
 
-`autotask_create_time_entry` deliberately stays in the write tier.
+If you need any of these held back from a technician who otherwise needs
+`write`, that has to be a per-tool `customTools` allowlist. A tier
+cannot express it.
+
+`autotask_create_time_entry` is a genuine `write` in both senses.
 Entries land in DRAFT and must be submitted and approved before they
 reach an invoice, so a mistaken entry is caught by an existing human
 control.
 
-### Read tier in full
+### Where the enforced tier is stronger than the old table said
+
+- **`autotask_router` enforces at `admin`**, not `read`. It was
+  previously documented as a read tool. Conduit groups it with
+  `autotask_raw_request` and `autotask_execute_tool` under
+  *"Passthrough surfaces (arbitrary method/path/body, arbitrary tool
+  dispatch, NL routing) -> ADMIN"*. Plan around the tier as stated — a
+  technician with `read` or `write` on Autotask cannot call it — but be
+  aware this looks like an over-classification: the handler resolves an
+  intent string and returns `{ suggestedTool, ... }`, executing nothing
+  (`autotask-mcp`, `src/handlers/tool.handler.ts:1432`).
+  `wyre-gateway/GOVERNANCE.md` reached the same conclusion about the
+  router independently. The other two passthrough tools do dispatch, and
+  their `admin` tier is earned.
+- **`autotask_update_company_site_configuration` enforces at `admin`**,
+  not `write`. Its request body is freeform
+  (`additionalProperties: true`), so Conduit cannot bound what it
+  changes.
+- **`autotask_execute_tool` and `autotask_raw_request` enforce at
+  `admin`**, which matches the risk. Granting `admin` on Autotask is
+  equivalent to granting every tool in the table, because these two can
+  reach any of them.
+
+### Read group in full
 
 `autotask_search_billing_item_approval_levels`,
 `autotask_search_billing_items`, `autotask_search_companies`,
@@ -80,20 +135,28 @@ control.
 `autotask_list_categories`, `autotask_list_category_tools`,
 `autotask_list_phases`, `autotask_list_queues`,
 `autotask_list_ticket_priorities`, `autotask_list_ticket_statuses`,
-`autotask_test_connection`, `autotask_router`.
+`autotask_test_connection`.
 
 ## Recommended agent policy
 
 The safe default is **read autonomously, propose writes, never
-self-approve destructive calls.**
+self-approve deletes.**
 
 - Read tools: allow. Reporting, triage sweeps, and utilisation analysis
   are the intended autonomous use.
 - Write tools: agent drafts the exact call, human approves, then it runs.
-- Destructive tools: require a named human approver per invocation. Do
-  not grant these to scheduled or unattended agents. In particular, do
-  not grant `autotask_raw_request` or `autotask_execute_tool` to any
-  agent you would not also trust with every tool in the table.
+  Treat the charge and contract tools as a stricter class than the rest
+  of the group even though Conduit does not.
+- Delete tools: require a named human approver per invocation. Do not
+  grant these to scheduled or unattended agents. Remember that Conduit
+  cannot enforce this separation for you — a `write` grant on Autotask
+  already admits all six — so it has to live in the agent's own
+  configuration, or in a per-tool `customTools` allowlist.
+- Admin tools: treat the grant as equivalent to full Autotask
+  administrator, because for `autotask_raw_request`, `autotask_router`,
+  and `autotask_execute_tool` that is exactly what it is. Do not grant
+  `admin` on Autotask to any agent you would not also trust with every
+  tool in the table.
 
 ## What it cannot reach
 

--- a/msp-claude-plugins/kaseya/datto-rmm/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/kaseya/datto-rmm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "datto-rmm",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Claude plugins for Datto RMM - devices, alerts, sites, jobs, remote monitoring",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/kaseya/datto-rmm/GOVERNANCE.md
+++ b/msp-claude-plugins/kaseya/datto-rmm/GOVERNANCE.md
@@ -16,42 +16,85 @@ operator is authorised for.
 - Every call carries operator identity, so the gateway audit log answers
   "who ran this script on the customer's server" — Datto RMM's job
   history records only the API account.
-- Revoking gateway access revokes Datto RMM access with it, immediately.
+- Removing a technician's Conduit org membership stops their Datto RMM
+  access on their next call, because membership is re-read per request.
+  It does **not** revoke an already-issued token, and it does not touch
+  credentials they connected personally. Full offboarding is more than
+  one step — see `wyre-gateway/GOVERNANCE.md`, *Revocation*.
 
-## Tool permission tiers
+## Tool permission groups
 
-| Tier | What it can do | Tools |
-|---|---|---|
-| **Read** | Cannot change Datto RMM or endpoint state. Safe for autonomous agents. | `datto_list_devices`, `datto_get_device`, `datto_find_device`, `datto_get_device_audit`, `datto_list_sites`, `datto_get_site`, `datto_list_alerts`, `datto_get_alert` |
-| **Write** | Changes Datto RMM records. Reversible, but suppresses signal. | `datto_resolve_alert` |
-| **Destructive** | Executes code on a customer endpoint. Requires explicit per-call human approval. | `datto_run_quickjob` |
+Datto RMM is classified in Conduit's `VENDOR_TOOL_CONFIG`
+(`src/proxy/result-cache.ts`) under the slug `datto-rmm`. All ten tools
+are classified; none fall through to the unclassified-means-`admin`
+rule.
 
-`datto_run_quickjob` is the only tool here that leaves the Datto RMM
-platform and touches the customer's machine. It executes a component
-script on a named device with whatever privileges the Datto agent holds
-— which is SYSTEM on Windows. The component decides what happens;
-"install this update" and "wipe this directory" are the same tool call
-with a different `componentUid`. Blast radius is a production endpoint,
-so it is destructive regardless of which component is chosen.
+| Group | What it can do | Enforcement tier | Tools |
+|---|---|---|---|
+| **Read** | Cannot change Datto RMM or endpoint state. Safe for autonomous agents. | `read` | `datto_list_devices`, `datto_get_device`, `datto_find_device`, `datto_list_sites`, `datto_get_site`, `datto_list_alerts`, `datto_get_alert` |
+| **Write** | Changes Datto RMM records. Reversible, but suppresses signal. | `write` | `datto_resolve_alert` |
+| **Delete** | — | — | **None.** This plugin exposes no delete-group tool, so the usual "a `write` grant also admits the deletes" trap does not apply here. |
+| **Admin** | Executes code on a customer endpoint, or reads forensics-class inventory. | `admin` | `datto_run_quickjob`, `datto_get_device_audit` |
 
-`datto_resolve_alert` is a write rather than a read because closing an
-alert removes it from the queue the on-call technician is watching. It
-does not fix the underlying condition — the monitor will re-fire — but
-an agent that resolves alerts in bulk can hide a live outage.
+Conduit compares tiers. It has no approval step, no per-call
+confirmation, and no interactive prompt — its source contains no
+elicitation handling at all. Per-call approval for anything below is a
+policy you impose on your agents, and it is only as good as the agent
+configuration that carries it.
+
+### `datto_run_quickjob` enforces at `admin`, and should
+
+It is the only tool here that leaves the Datto RMM platform and touches
+the customer's machine. It executes a component script on a named device
+with whatever privileges the Datto agent holds — which is SYSTEM on
+Windows. The component decides what happens; "install this update" and
+"wipe this directory" are the same tool call with a different
+`componentUid`. Blast radius is a production endpoint, so it is
+dangerous regardless of which component is chosen.
+
+Conduit classifies it `admin` rather than `write` for exactly that
+reason — its own comment puts it in the same class as
+`autotask_execute_tool`, on the grounds that the blast radius is bounded
+by execution scope rather than by the verb in the name. A technician
+with `write` on Datto RMM **cannot** call it. That is a real control,
+and it is stronger than the per-call approval this document used to
+claim.
+
+### `datto_get_device_audit` enforces at `admin`, which may surprise you
+
+It reads like a `get_*` tool and it changes nothing, but Conduit
+classifies it `isAdmin` because a device audit is forensics-class
+sensitive data: full hardware and software inventory for a customer
+endpoint. **A read-only agent cannot call it.** If your fleet-audit or
+patch-coverage workflow depends on this tool, it needs an `admin` grant
+on Datto RMM — which also admits `datto_run_quickjob`. There is no tier
+between them; separating the two requires a per-tool `customTools`
+allowlist.
+
+### `datto_resolve_alert` is the whole Write group
+
+It is a write rather than a read because closing an alert removes it
+from the queue the on-call technician is watching. It does not fix the
+underlying condition — the monitor will re-fire — but an agent that
+resolves alerts in bulk can hide a live outage. Granting `write` on
+Datto RMM grants exactly this one tool plus the reads.
 
 ## Recommended agent policy
 
-The safe default is **read autonomously, propose writes, never
-self-approve destructive calls.**
+The safe default is **read autonomously, propose writes, never let an
+agent hold `admin` on this vendor.**
 
 - Read tools: allow. Fleet audits, patch-coverage reporting, and alert
-  triage summaries are the intended autonomous use.
+  triage summaries are the intended autonomous use — noting that
+  `datto_get_device_audit` is not in this group.
 - Write tools: agent drafts the exact call, human approves, then it runs.
   Never allow bulk alert resolution without a human reading the list.
-- Destructive tools: require a named human approver per invocation, and
-  require the approver to be told which component is being run against
-  which device. Do not grant `datto_run_quickjob` to scheduled or
-  unattended agents.
+- Admin tools: treat an `admin` grant on Datto RMM as arbitrary remote
+  code execution on every managed endpoint, because
+  `datto_run_quickjob` is exactly that. Do not grant it to scheduled or
+  unattended agents. For an interactive operator, require that they be
+  told which component is being run against which device — Conduit will
+  not ask.
 
 ## What it cannot reach
 
@@ -70,7 +113,7 @@ self-approve destructive calls.**
 
 The skills in this plugin document device, site, and variable
 create/update/delete operations that exist in the Datto RMM REST API but
-are **not exposed as MCP tools**. The nine tools above are the complete
+are **not exposed as MCP tools**. The ten tools above are the complete
 callable surface. Treat the skills' coverage of write operations as API
 reference, not as something an agent can invoke here.
 
@@ -80,7 +123,8 @@ reference, not as something an agent can invoke here.
   and are not persisted by this plugin.
 - `datto_get_device_audit` returns full hardware and software inventory
   for a customer endpoint, including installed application names and
-  versions — useful to an attacker profiling the estate.
+  versions — useful to an attacker profiling the estate. This is why
+  Conduit enforces it at `admin` rather than `read`.
 - `datto_list_devices` and `datto_get_device` return internal and
   external IP addresses, hostnames, MAC addresses, and logged-in user
   names.

--- a/msp-claude-plugins/kaseya/datto-saas-protection/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/kaseya/datto-saas-protection/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "datto-saas-protection",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Claude plugins for Datto SaaS Protection (Backupify) - M365 / Google Workspace backup status, restore, seat management",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/kaseya/datto-saas-protection/GOVERNANCE.md
+++ b/msp-claude-plugins/kaseya/datto-saas-protection/GOVERNANCE.md
@@ -16,21 +16,68 @@ tenant the operator is authorised for.
 - Credential rotation happens once at the gateway, not per technician.
 - Every call carries operator identity, so the gateway audit log answers
   "who restored data into this customer's mailbox".
-- Revoking gateway access revokes SaaS Protection access with it,
-  immediately.
+- Removing a technician's Conduit org membership stops their SaaS
+  Protection access on their next call, because membership is re-read
+  per request. It does **not** revoke an already-issued token, and it
+  does not touch credentials they connected personally. Full offboarding
+  is more than one step — see `wyre-gateway/GOVERNANCE.md`,
+  *Revocation*.
 
-## Tool permission tiers
+## Tool permission groups
 
-| Tier | What it can do | Tools |
-|---|---|---|
-| **Read** | Cannot change backup or tenant state. Safe for autonomous agents. | `datto_saas_list_clients`, `datto_saas_list_domains`, `datto_saas_list_seats`, `datto_saas_get_seat`, `datto_saas_list_backups`, `datto_saas_get_restore_status`, `datto_saas_list_activity`, `datto_saas_get_license_usage` |
-| **Write** | — | None. |
-| **Destructive** | Writes data back into a live customer Microsoft 365 or Google Workspace tenant. Requires explicit per-call human approval. | `datto_saas_queue_restore` |
+**Read this section before granting anything.** Datto SaaS Protection
+has an entry in Conduit's `VENDOR_TOOL_CONFIG`
+(`src/proxy/result-cache.ts`), but that entry classifies only **three**
+of the plugin's nine tools. The other six — including the restore — are
+not in the table.
 
-`datto_saas_queue_restore` is the only mutating tool, and it does not
-mutate the backup — it mutates **production**. A restore injects
-messages, files, or an entire seat back into the customer's live cloud
-tenant. Consequences an approver needs to understand:
+Conduit is fail-closed. An unclassified tool is coerced to the *highest*
+tier at the enforcement gate:
+
+```ts
+const requiredTier: PermissionTier = classified ?? 'admin'; // UNCLASSIFIED -> ADMIN
+```
+— `src/access/access-enforcement.ts:63`. So the six unclassified tools
+below require tier `admin` to invoke, no matter what they do.
+
+| Group | What it can do | Enforcement tier | Tools |
+|---|---|---|---|
+| **Read** | Cannot change backup or tenant state. Safe for autonomous agents. | `read` | `datto_saas_list_clients`, `datto_saas_list_domains`, `datto_saas_get_license_usage` |
+| **Write** | — | — | **None.** No tool in this plugin is classified `isWrite`. |
+| **Delete** | — | — | **None.** |
+| **Admin** | Everything Conduit has not classified — read tools and the restore alike. | `admin` (by fail-closed coercion, not by classification) | `datto_saas_list_seats`, `datto_saas_get_seat`, `datto_saas_list_backups`, `datto_saas_get_restore_status`, `datto_saas_list_activity`, `datto_saas_queue_restore` |
+
+Conduit compares tiers. It has no approval step, no per-call
+confirmation, and no interactive prompt — its source contains no
+elicitation handling at all. Per-call approval for anything below is a
+policy you impose on your agents, and it is only as good as the agent
+configuration that carries it.
+
+### What the classification gap means in practice
+
+1. **A read-only agent cannot do the plugin's main job.** Seat listing,
+   backup listing, and restore-status polling are all in the coerced
+   `admin` bucket. Backup-failure sweeps and seat coverage checks — the
+   intended autonomous uses — need `admin` on this vendor today.
+2. **`admin` is the only grant that reaches the restore.** Because the
+   same grant is the only one that reaches the seat and backup readers,
+   **you cannot currently grant the read work without also granting
+   `datto_saas_queue_restore`.** There is no tier between them. The only
+   mechanism that separates them is a per-tool `customTools` allowlist.
+3. **This is drift, not design.** The three classified tools are
+   presumably the ones that existed when the entry was written. Report
+   the gap rather than working around it; classifying the remaining six
+   is a privilege *reduction*, because it would move the read tools down
+   from `admin` to `read`.
+
+Verify the table above against the deployed gateway before relying on it
+for an access-control decision.
+
+### `datto_saas_queue_restore` mutates production, not the backup
+
+A restore injects messages, files, or an entire seat back into the
+customer's live cloud tenant. Consequences an approver needs to
+understand:
 
 - Restored mail lands in the user's actual mailbox. Users see it,
   respond to it, and cannot tell it from new mail.
@@ -40,21 +87,37 @@ tenant. Consequences an approver needs to understand:
 - There is no undo tool. Nothing in this plugin removes what a restore
   put back.
 
-The MCP server marks this tool DESTRUCTIVE and prompts for confirmation.
-Do not treat that prompt as the control — an agent granted the tool can
-answer it.
+The MCP server marks this tool DESTRUCTIVE in its description and calls
+`elicitInput` to ask for confirmation before queueing
+(`src/mcp-server.ts:422`). **That prompt does not survive the gateway.**
+Conduit initialises its upstream vendor session with `capabilities: {}`
+(`src/proxy/mcp-session-pool.ts:109`) and advertises no elicitation
+capability downstream either, so the server's confirmation request has
+nobody to reach. The server's own fallback then applies: the helper
+returns `null` and the tool refuses with *"Restore cancelled: client
+does not support confirmation prompts."*
+
+Two things follow, and they point in opposite directions. The prompt is
+not a control you can rely on — but neither is the restore reliably
+callable through Conduit. Test it before you build a recovery runbook on
+it.
 
 ## Recommended agent policy
 
 The safe default is **read autonomously, never self-approve the
-restore.**
+restore** — which today requires a per-tool grant, because the tier
+model cannot express it.
 
-- Read tools: allow. Backup-failure sweeps, seat coverage checks, and
-  licence reconciliation are the intended autonomous use.
-- Destructive tool: require a named human approver per invocation, and
-  require the approver to be shown the seat, the item count, and
-  explicitly whether the item list is empty. Do not grant
+- Read tools: allow the three classified ones. The other five reads sit
+  behind `admin`; grant them per-tool rather than granting `admin` on
+  the vendor.
+- Restore: require a named human approver per invocation, and require
+  the approver to be shown the seat, the item count, and explicitly
+  whether the item list is empty. Conduit will not ask any of this — it
+  compares tiers and passes the call through. Do not grant
   `datto_saas_queue_restore` to scheduled or unattended agents.
+- Do not hand an agent blanket `admin` on this vendor as a shortcut to
+  the seat and backup readers. That grant includes the restore.
 
 ## What it cannot reach
 
@@ -74,8 +137,10 @@ restore.**
 
 The skill for this plugin is marked in-development reference
 documentation. The nine tools above are the current callable surface of
-`datto-saas-protection-mcp`. Verify against the deployed gateway before
-relying on this table for an access-control decision.
+`datto-saas-protection-mcp`. Six of the nine are absent from Conduit's
+`VENDOR_TOOL_CONFIG` and therefore coerce to `admin` — see *Tool
+permission groups*. Verify against the deployed gateway before relying
+on this table for an access-control decision.
 
 ## Data handling
 

--- a/msp-claude-plugins/kaseya/it-glue/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/kaseya/it-glue/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "it-glue",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Claude plugins for IT Glue documentation platform - organizations, assets, passwords, documents",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/kaseya/it-glue/GOVERNANCE.md
+++ b/msp-claude-plugins/kaseya/it-glue/GOVERNANCE.md
@@ -15,54 +15,109 @@ operator is authorised for.
 - Credential rotation happens once at the gateway, not per technician.
 - Every call carries operator identity, so the gateway audit log answers
   "who read this password" — IT Glue's own log records only the API key.
-- Revoking gateway access revokes IT Glue access with it, immediately.
+- Removing a technician's Conduit org membership stops their IT Glue
+  access on their next call, because membership is re-read per request.
+  It does **not** revoke an already-issued token, and it does not touch
+  credentials they connected personally. Full offboarding is more than
+  one step — see `wyre-gateway/GOVERNANCE.md`, *Revocation*.
 
-## Tool permission tiers
+## Tool permission groups
 
-| Tier | What it can do | Tools |
-|---|---|---|
-| **Read** | Cannot change IT Glue state. Safe for autonomous agents — with the password exception below. | `search_organizations`, `get_organization`, `search_configurations`, `get_configuration`, `search_documents`, `get_document`, `list_document_folders`, `list_document_sections`, `list_flexible_asset_types`, `search_flexible_assets`, `search_locations`, `get_location`, `search_passwords`, `get_password`, `itglue_health_check` |
-| **Write** | Creates or modifies documentation. Reversible, visible to everyone with tenant access. | `create_document`, `create_document_section`, `update_document_section`, `publish_document`, `create_location`, `update_location`, `unarchive_document` |
-| **Destructive** | Removes documentation, irreversibly or near-irreversibly. Requires explicit per-call human approval. | `delete_document_section`, `archive_document` |
+IT Glue is classified in Conduit's `VENDOR_TOOL_CONFIG`
+(`src/proxy/result-cache.ts`) under the slug **`itglue`** — no hyphen,
+unlike the plugin directory name. All 24 tools are classified; none fall
+through to the unclassified-means-`admin` rule.
 
-`archive_document` sits in the destructive tier despite being a soft
-delete. Archiving hides a document from search and from normal views, so
-the practical effect during an incident is that the runbook is gone —
-and nobody discovers this until they need it at 2am. It is reversible
-via `unarchive_document`, but only by someone who knows the document
-existed and what it was called.
+| Group | What it can do | Enforcement tier | Tools |
+|---|---|---|---|
+| **Read** | Cannot change IT Glue state. Safe for autonomous agents — but see the flexible-asset caveat below. | `read` | `search_organizations`, `get_organization`, `search_configurations`, `get_configuration`, `search_documents`, `get_document`, `list_document_folders`, `list_document_sections`, `list_flexible_asset_types`, `search_flexible_assets`, `search_locations`, `get_location`, `itglue_health_check` |
+| **Write** | Creates or modifies documentation. Reversible, visible to everyone with tenant access. | `write` | `create_document`, `create_document_section`, `update_document_section`, `publish_document`, `create_location`, `update_location`, `unarchive_document` |
+| **Delete** | Removes documentation, irreversibly or near-irreversibly. | `write` — **not** a tier of its own | `delete_document_section`, `archive_document` |
+| **Admin** | Reads stored credentials, or the list of them. | `admin` | `get_password`, `search_passwords` |
 
-`delete_document_section` is flagged irreversible by the server itself.
-There is no undo.
+**The Delete row is the one to read twice.** Conduit's enforcement tiers
+are only `read`, `write`, and `admin` (plus `none`, meaning deny) —
+`src/access/permission-tier.ts:27`. "Delete" is a presentation group in
+the access editor, and a delete-group tool compiles to and enforces at
+tier `write` (`src/access/tier-group-mapping.ts`, `GROUP_ENFORCEMENT_TIER`).
+So **granting a technician `write` on IT Glue also grants
+`archive_document` and `delete_document_section`.** There is no setting
+that separates them; the only way to admit the document-editing tools
+but not the removals is a granular per-tool grant, which compiles to an
+explicit `customTools` allowlist.
 
-## `get_password` is a read tool that returns secrets
+Conduit compares tiers. It has no approval step, no per-call
+confirmation, and no interactive prompt — its source contains no
+elicitation handling at all. Per-call approval for anything below is a
+policy you impose on your agents, and it is only as good as the agent
+configuration that carries it.
 
-This is the sharpest edge in the plugin and it does not fit the tier
-model cleanly:
+### The delete group, and why its two members are unequal
+
+`archive_document` enforces at `write` and is a soft delete — the tier
+is arguably right. But archiving hides a document from search and from
+normal views, so the practical effect during an incident is that the
+runbook is gone, and nobody discovers this until they need it at 2am. It
+is reversible via `unarchive_document`, but only by someone who knows
+the document existed and what it was called. (`unarchive_document` sits
+in the Write group, not Delete, because its name carries no delete-ish
+verb token — a naming artefact, not a judgement.)
+
+`delete_document_section` also enforces at `write`, and it is flagged
+irreversible by the server itself. There is no undo. A `write` grant on
+IT Glue admits it.
+
+## The password tools enforce at `admin`
+
+Both password tools are read-only against IT Glue, so an
+`isWrite`-based reading would put them in the Read group. Conduit
+overrides that and classifies both `isAdmin`, because a credential read
+is a credential read:
 
 - `search_passwords` returns **metadata only** — names, categories,
-  usernames, and IDs. No secret values.
-- `get_password` returns **the actual password value** for the record.
+  usernames, and IDs. No secret values. It is still `admin`: the
+  username-plus-system list is a complete target list on its own.
+- `get_password` returns **the actual password value**. Conduit also
+  pins its cache TTL to zero so the plaintext is never held in the
+  result cache.
 
-Both are technically read-only against IT Glue, so both sit in the read
-tier. But `get_password` pulls a live production credential into model
-context. Treat it as its own tier:
+This is the one place the mechanical tier is *stricter* than a naive
+read/write reading, and it is the right call. The consequence for
+operators: a technician granted `read` or even `write` on IT Glue cannot
+call either password tool. Granting `admin` to reach them also grants
+every other tool on this vendor, including the deletes. If you want the
+password tools without the deletes, that is a per-tool `customTools`
+allowlist.
 
-- Do not grant `get_password` to autonomous, scheduled, or unattended
-  agents.
-- Grant it per-session to an interactive operator who is already
-  entitled to that credential.
-- Assume anything it returns is exposed for the life of the session.
+Regardless of tier, assume anything `get_password` returns is exposed
+for the life of the session, and do not grant it to scheduled or
+unattended agents.
+
+### The credential path the tiering does not close
+
+`search_flexible_assets` enforces at `read`. Flexible assets frequently
+carry credentials in password-type fields, and those values come back
+through that tool without passing through the password tools or their
+`admin` gate. A read-only agent on IT Glue can reach secrets this way.
+If that matters to you, restrict `search_flexible_assets` explicitly —
+the tier model will not do it for you.
 
 ## Recommended agent policy
 
 The safe default is **read autonomously, propose writes, never
-self-approve destructive calls** — plus the `get_password` carve-out
-above.
+self-approve deletes.**
 
-- Read tools: allow, except `get_password`.
+- Read tools: allow, with `search_flexible_assets` reviewed separately
+  for the reason above.
 - Write tools: agent drafts the exact call, human approves, then it runs.
-- Destructive tools: require a named human approver per invocation.
+- Delete tools: require a named human approver per invocation. Remember
+  that Conduit cannot enforce this separation for you — a `write` grant
+  already admits both — so it has to live in the agent's own
+  configuration, or in a per-tool `customTools` allowlist.
+- Admin tools: `get_password` and `search_passwords` sit here, and
+  granting `admin` to reach them grants everything else on the vendor
+  too. Prefer a per-tool grant to an interactive operator who is already
+  entitled to that credential.
 
 ## What it cannot reach
 
@@ -75,13 +130,19 @@ above.
   return.
 - No filesystem, no shell, no other vendor's data.
 
-## Tool names are unprefixed
+## Tool names are unprefixed, and the vendor slug is not the plugin name
 
 Unlike every sibling plugin in this family, IT Glue's tools carry no
 vendor prefix — `create_document`, not `itglue_create_document`. When
 writing allowlists, denylists, or audit queries, match on the exact
 names above; a rule keyed on an `itglue_` prefix will match only
-`itglue_health_check` and silently permit everything else.
+`itglue_health_check` and silently permit everything else. This matters
+most for a per-tool `customTools` allowlist, which is the only mechanism
+that can separate the delete tools from the rest of the write group.
+
+Two names are in play and they differ. The marketplace plugin is
+`it-glue`; Conduit's vendor slug in `VENDOR_TOOL_CONFIG` is `itglue`.
+Look the vendor up under `itglue` when checking classification.
 
 ## Tool surface is narrower than the skills
 
@@ -93,14 +154,15 @@ queries. The skill is API reference; treat it as such.
 
 - Responses pass through the gateway into model context for the session
   and are not persisted by this plugin.
-- `get_password` returns live credentials. See above.
-- `search_passwords` returns usernames and the systems they belong to —
-  a complete target list even without the secrets.
+- `get_password` returns live credentials; `search_passwords` returns
+  usernames and the systems they belong to, a complete target list even
+  without the secrets. Both enforce at `admin` — see above.
 - `search_organizations` and the document tools surface client PII
   wherever it was written into the documentation.
 - Flexible assets frequently contain credentials in password-type
-  fields. Those values come back through `search_flexible_assets`
-  without passing through the password tools or their access controls.
+  fields. Those values come back through `search_flexible_assets`, which
+  enforces at `read`, without passing through the password tools or
+  their `admin` gate.
 
 ## Known sharp edges
 

--- a/msp-claude-plugins/kaseya/rocketcyber/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/kaseya/rocketcyber/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rocketcyber",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Claude plugins for RocketCyber managed SOC - incidents, agents, accounts, threat detection",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/kaseya/rocketcyber/GOVERNANCE.md
+++ b/msp-claude-plugins/kaseya/rocketcyber/GOVERNANCE.md
@@ -16,30 +16,63 @@ operator is authorised for.
 - Every call carries operator identity, so the gateway audit log answers
   "who pulled this customer's incident data" — RocketCyber's own log
   records only the provider API key.
-- Revoking gateway access revokes RocketCyber access with it,
-  immediately.
+- Removing a technician's Conduit org membership stops their RocketCyber
+  access on their next call, because membership is re-read per request.
+  It does **not** revoke an already-issued token, and it does not touch
+  credentials they connected personally. Full offboarding is more than
+  one step — see `wyre-gateway/GOVERNANCE.md`, *Revocation*.
 
-## Tool permission tiers
+## Tool permission groups
 
-| Tier | What it can do | Tools |
-|---|---|---|
-| **Read** | Cannot change RocketCyber or endpoint state. | `rocketcyber_get_account`, `rocketcyber_list_agents`, `rocketcyber_list_incidents`, `rocketcyber_list_events`, `rocketcyber_get_event_summary`, `rocketcyber_list_apps`, `rocketcyber_list_firewalls`, `rocketcyber_get_defender`, `rocketcyber_get_office`, `rocketcyber_test_connection` |
-| **Write** | — | None. |
-| **Destructive** | — | None. |
+RocketCyber is classified in Conduit's `VENDOR_TOOL_CONFIG`
+(`src/proxy/result-cache.ts`), but the entry covers only **eight** of
+the plugin's ten tools. Conduit is fail-closed, and the enforcement gate
+coerces an unclassified tool to the *highest* tier:
 
-**This plugin is read-only.** Every tool it exposes is an observation.
-An agent granted the full surface cannot resolve an incident, change an
-account, deploy or remove an agent, or alter a security policy. For an
-MSP owner deciding what to allow, that is the whole answer: the worst
-case is disclosure, not damage.
+```ts
+const requiredTier: PermissionTier = classified ?? 'admin'; // UNCLASSIFIED -> ADMIN
+```
+— `src/access/access-enforcement.ts:63`. So two read-only tools require
+tier `admin` to invoke.
+
+| Group | What it can do | Enforcement tier | Tools |
+|---|---|---|---|
+| **Read** | Cannot change RocketCyber or endpoint state. | `read` | `rocketcyber_get_account`, `rocketcyber_list_agents`, `rocketcyber_list_incidents`, `rocketcyber_list_events`, `rocketcyber_get_event_summary`, `rocketcyber_get_defender`, `rocketcyber_get_office`, `rocketcyber_test_connection` |
+| **Write** | — | — | **None.** No tool in this plugin is classified `isWrite`. |
+| **Delete** | — | — | **None.** |
+| **Admin** | Nothing dangerous — these are reads Conduit has not classified. | `admin` (by fail-closed coercion, not by classification) | `rocketcyber_list_apps`, `rocketcyber_list_firewalls` |
+
+**This plugin is still read-only in blast-radius terms.** Every tool it
+exposes is an observation. An agent granted the full surface cannot
+resolve an incident, change an account, deploy or remove an agent, or
+alter a security policy. For an MSP owner deciding what to allow, that
+remains the main answer: the worst case is disclosure, not damage.
+
+But read-only is not the same as reachable at tier `read`.
+`rocketcyber_list_apps` and `rocketcyber_list_firewalls` are absent from
+`VENDOR_TOOL_CONFIG`, so a technician granted `read` on RocketCyber will
+be denied on both. Getting them requires `admin` on this vendor — which,
+here, admits nothing worse, because there is nothing worse to admit.
+This is classification drift rather than a security decision, and
+classifying the two tools would be a privilege *reduction*: it would
+move them down from `admin` to `read`.
+
+Conduit compares tiers. It has no approval step, no per-call
+confirmation, and no interactive prompt — its source contains no
+elicitation handling at all. There is nothing here to approve anyway.
 
 ## Recommended agent policy
 
 - Read tools: allow, subject to the disclosure considerations below.
   Cross-tenant threat sweeps, coverage reporting, and incident
   summarisation are the intended autonomous use.
-- Write and destructive policies are not applicable — do not configure
+- Write and delete policies are not applicable — do not configure
   approval workflows for tools that do not exist.
+- If a workflow needs `rocketcyber_list_apps` or
+  `rocketcyber_list_firewalls`, prefer a per-tool `customTools` grant
+  over a blanket `admin` grant on the vendor. The blanket grant is
+  harmless today only because this plugin has no mutating tool; a future
+  one would inherit it.
 
 Because the whole surface is read-only, the governance question shifts
 from "what can it break" to "who should see this". Incident and event
@@ -79,7 +112,7 @@ invoke through this plugin.
 - `rocketcyber_list_agents` returns endpoint hostnames and coverage
   gaps — effectively a map of which customer machines are unmonitored.
 - `rocketcyber_list_apps` returns installed software inventory per
-  endpoint.
+  endpoint. It is one of the two tools currently gated at `admin`.
 
 Restrict this plugin to operators who are already entitled to see
 customer incident data. Read-only does not mean low-sensitivity.


### PR DESCRIPTION
Realigns the five Kaseya-family `GOVERNANCE.md` files to Conduit's real permission model. Follows `_templates/governance-template.md` (#182), which is the target shape.

## What was wrong

All five used a **Read / Write / Destructive** tier table. That matches neither of Conduit's models:

- Enforcement tiers are `none | read | write | admin` — `src/access/permission-tier.ts:27`
- The access editor presents four groups `read | write | delete | admin`, and a delete-group tool **enforces at `write`** — `src/access/tier-group-mapping.ts`, `GROUP_ENFORCEMENT_TIER`

Four of the five also promised that destructive tools "require explicit per-call human approval." **Conduit has no approval step, no confirmation, and no elicitation** — `grep -c elicit conduit/src` returns 0. It compares tiers. Those sentences were false.

## What changed

Every documented tool re-tiered by joining against `VENDOR_TOOL_CONFIG` (`src/proxy/result-cache.ts`), using the declared convention `isAdmin → admin` (outranks), `isWrite → write`, neither → `read`. Delete group = write-classified tools carrying a delete-ish verb token per `src/access/tool-naming.ts` `DELETE_TOKENS` (`delete`, `remove`, `dismiss`, `archive`).

Each file now carries an `Enforcement tier` column, four groups, and states the load-bearing consequence outright: **granting `write` on the vendor also grants every delete tool on it**, with only a per-tool `customTools` allowlist able to separate them.

Risk commentary is kept as prose, not deleted. Where an author called a tool destructive and it enforces at `write`, both facts are stated — see the *"Where the enforced tier is weaker than the risk"* section in `autotask`.

| Plugin | Conduit slug | Tools re-tiered | Approval promises removed |
|---|---|---|---|
| `autotask` | `autotask` | 98 | 2 |
| `it-glue` | **`itglue`** | 24 | 2 |
| `datto-rmm` | `datto-rmm` | 10 | 2 |
| `datto-saas-protection` | `datto-saas-protection` | 9 (3 classified + 6 coerced) | 2 |
| `rocketcyber` | `rocketcyber` | 10 (8 classified + 2 coerced) | 0 (was already read-only) |

Group membership for every classified tool was verified programmatically against `VENDOR_TOOL_CONFIG`; all four groups match exactly in all five files.

## Tier moves a reviewer should question

**Author called it destructive → enforces at `write`:**

- `autotask_create_ticket_charge`, `autotask_update_ticket_charge`, `autotask_delete_ticket_charge` — posts money onto a customer invoice with no submit/approve workflow.
- `autotask_create_contract`, `autotask_update_contract`, `autotask_create_contract_service`, `autotask_update_contract_service` — changes the recurring amount the client pays.
- All six `autotask_delete_*` — Delete presentation group, `write` enforcement.
- `it-glue` `archive_document`, `delete_document_section` — same.

Consequence: a technician with `write` on Autotask can bill a customer and delete records. That is not expressible as a tier.

**Moved *up*, which the old tables understated:**

- **`autotask_router`: `read` → `admin`.** Conduit groups it with the passthrough surfaces. Documented as enforced, **but flagged in-file as a probable over-classification** — the handler resolves an intent and returns `{ suggestedTool, … }`, executing nothing (`autotask-mcp` `src/handlers/tool.handler.ts:1432`). `wyre-gateway/GOVERNANCE.md` independently reached the same conclusion. Worth a Conduit-side issue.
- **`autotask_update_company_site_configuration`: `write` → `admin`** — freeform body (`additionalProperties: true`).
- **`datto_get_device_audit`: `read` → `admin`.** Reads like a getter, classified `isAdmin` as forensics-class data. **A read-only agent cannot run a fleet audit or patch-coverage report**, and the only grant that reaches it also grants `datto_run_quickjob` (arbitrary RCE on managed endpoints). Operationally the most surprising row in this PR.
- **`it-glue` `get_password` *and* `search_passwords`: `read` → `admin`.** Both are read-only against IT Glue; Conduit overrides on credential-read grounds. Correct call, and stricter than the old doc.
- `datto_run_quickjob`: destructive → `admin` — a real control, stronger than the per-call approval the doc used to claim.

## Documented tools missing from `VENDOR_TOOL_CONFIG`

Reported, not invented around. These coerce to `admin` via `const requiredTier: PermissionTier = classified ?? 'admin'` (`src/access/access-enforcement.ts:63`).

**`datto-saas-protection` — 6 of 9 tools:** `datto_saas_list_seats`, `datto_saas_get_seat`, `datto_saas_list_backups`, `datto_saas_get_restore_status`, `datto_saas_list_activity`, `datto_saas_queue_restore`.

The vendor has an entry but it classifies only three tools. The practical result is bad: seat listing, backup listing and restore-status polling all sit in the coerced `admin` bucket **alongside the restore**, so *you cannot currently grant the read work without also granting `datto_saas_queue_restore`.* Classifying the other six would be a privilege reduction.

**`rocketcyber` — 2 of 10 tools:** `rocketcyber_list_apps`, `rocketcyber_list_firewalls`. Harmless today (nothing on this vendor mutates), but a technician granted `read` is denied on both.

## Also corrected

Each file's *"Revoking gateway access revokes vendor access with it, immediately"* bullet is replaced with the template's accurate framing (membership is re-read per request; an already-issued token is not revoked; personal credentials are untouched). This is correction #4 in `wyre-gateway/GOVERNANCE.md` → *Corrections to the per-vendor documents*. Flagging it because other batches in this pass may not have made the same call.

`datto-rmm` said "the nine tools above" over a ten-tool table — fixed.

The `datto-saas-protection` claim that "the MCP server marks this tool DESTRUCTIVE and prompts for confirmation" is now traced end to end: the server does call `elicitInput` (`src/mcp-server.ts:422`), but Conduit initialises upstream sessions with `capabilities: {}` (`src/proxy/mcp-session-pool.ts:109`) and advertises no elicitation downstream, so the prompt cannot be relayed and the server's own fallback refuses the restore. Documented as "test this before building a recovery runbook on it."

## Verification

```
$ node scripts/check-marketplace-drift.mjs --base origin/main
bump gate: compared HEAD against merge base 5ebce5062b33 (10 changed files, 5 plugins touched)
✔ marketplace drift check passed (76 entries)
```

Versions bumped: `autotask` 0.5.1→0.5.2, `datto-rmm` 1.2.1→1.2.2, `it-glue` 1.2.0→1.2.1, `datto-saas-protection` 0.2.0→0.2.1, `rocketcyber` 0.3.0→0.3.1.

## Not touched

`_templates/`, `_standards/`, `wyre-gateway/`, `.claude-plugin/marketplace.json`, `docs/src/data/*` — parallel batches own other plugins. **`CHANGELOG.md` is deliberately untouched** to avoid conflicting with the other batches in this pass; the fleet-wide entry should be written once when they land.
