### PR TITLE
chore(docs): regenerate sharedSkills after shared plugin bump

### DIFF
--- a/msp-claude-plugins/docs/src/data/sharedSkills.ts
+++ b/msp-claude-plugins/docs/src/data/sharedSkills.ts
@@ -23,5 +23,5 @@ export const sharedSkills: SharedSkill[] = [
 export const sharedSkillsMeta = {
   installSlug: 'shared-skills',
   description: 'Vendor-agnostic MSP skills — terminology, ticket triage, incident correlation, and billing reconciliation',
-  version: '1.1.4',
+  version: '1.1.5',
 };


### PR DESCRIPTION
Mechanical. The unclassified-vendor governance pass bumped `shared` to 1.1.5; `npm run generate` reflects that into `sharedSkills.ts`.

Batch agents are instructed not to run the generator — parallel PRs writing generated data conflict on every one — so this is the deferred step run once now that all batches are merged. `plugins.ts` unchanged (75 plugins, 339 skills).