### PR TITLE
fix(huntress): repoint an anti-trigger at a skill that still exists

### DIFF
--- a/msp-claude-plugins/huntress/huntress/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/huntress/huntress/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "huntress",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Claude plugins for Huntress - managed threat detection, incident response, endpoint agent management, escalations, and billing reports for MSPs",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/huntress/huntress/skills/incidents/SKILL.md
+++ b/msp-claude-plugins/huntress/huntress/skills/incidents/SKILL.md
@@ -21,11 +21,13 @@ Manage Huntress SOC-confirmed security incidents across client organizations. Qu
   `huntress-escalations`.
 - **Endpoint health, deployment, or coverage questions** — use
   `huntress-agents`.
-- **An incident that is not a security finding** — uptime, paging, and
-  email-security platforms each use the word for their own object with
-  its own lifecycle. Use `betterstack-incidents` for a service outage,
-  `pagerduty-incidents` or `rootly-incidents` for a paged response,
-  and `checkpoint-avanan-incidents` for a mail-borne threat.
+- **An incident that is not a security finding** — uptime and paging
+  platforms each use the word for their own object with its own
+  lifecycle. Use `betterstack-incidents` for a service outage, and
+  `pagerduty-incidents` or `rootly-incidents` for a paged response.
+- **A mail-borne threat** — Harmony Email has no incident object at all;
+  its detections are events, not cases. Use
+  `checkpoint-avanan-threats`.
 
 ## API Tools
 


### PR DESCRIPTION
#195 deleted `checkpoint-avanan-incidents` — Harmony Email has no incident object, so that skill documented an API that does not exist. Three plugins had anti-triggers routing readers *to* it. This is the one in `huntress`; the other two (`proofpoint`, `ironscales`) are being handled in the tool-name-drift PR that owns those files.

Worth noting the shape of the defect: the phantom-tool problem had already **leaked outward**. Anti-triggers exist to route a reader to the right skill, and three of them were confidently routing people to a skill describing a nonexistent API — so the routing layer was propagating the error rather than containing it.

Repointed at `checkpoint-avanan-threats` rather than mechanically substituting, because the distinction is the substance: Harmony Email detections are **events, not cases**. "The Avanan equivalent of an incident" is a category error, not a rename, and the bullet now says so.

`check-marketplace-drift.mjs` passes; `huntress` 0.3.2 → 0.3.3.