### PR TITLE
fix(skills): repoint two anti-triggers at skills that still exist

### DIFF
--- a/msp-claude-plugins/betterstack/betterstack/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/betterstack/betterstack/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "betterstack",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Claude plugins for Better Stack - uptime monitoring, incident management, status pages, on-call schedules, and log management (Logtail) for MSPs",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/betterstack/betterstack/skills/monitors/SKILL.md
+++ b/msp-claude-plugins/betterstack/betterstack/skills/monitors/SKILL.md
@@ -19,8 +19,11 @@ Uptime monitors are the core of Better Stack's monitoring platform. They periodi
 ## Anti-triggers
 
 - **An internal or RFC1918 target** — checks run from Better Stack's
-  public regions and cannot reach a private LAN. Internal service
-  checks run from a collector inside the site; use `domotz-eyes`.
+  public regions and cannot reach a private LAN. Reachability from
+  inside the site is `domotz-network`, which polls from a collector on
+  the LAN. Note it answers a different question: Domotz reports device
+  and interface state, not synthetic HTTP/TCP probes, so there is no
+  in-LAN equivalent of a Better Stack check.
 - **Azure Monitor** — same word, different product. Azure metrics, KQL,
   and alert rules are `azure-mcp-observability`.
 - **Whether a piece of infrastructure is up** — SNMP and ICMP polling

--- a/msp-claude-plugins/secops-pack/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/secops-pack/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "secops-pack",
   "displayName": "Security Operations",
   "description": "Cross-vendor security alert triage and incident response \u2014 normalizes severity, runs containment playbooks, and builds incident timelines across whatever EDR/MDR/SIEM stack you have connected.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": {
     "name": "MSP Claude Plugins Community"
   },

--- a/msp-claude-plugins/secops-pack/skills/bec-response/SKILL.md
+++ b/msp-claude-plugins/secops-pack/skills/bec-response/SKILL.md
@@ -31,9 +31,11 @@ confirmed or strongly suspected.
 
 ## Anti-triggers
 
-- **A vendor's own account-takeover case** — Abnormal models ATO as a case
-  type with its own investigation and remediation actions; use
-  `abnormal-security-account-takeover` when working inside it.
+- **A vendor's own case record** — Abnormal tracks investigations as
+  cases with their own remediation actions; use
+  `abnormal-security-cases` when working inside one. It has no separate
+  account-takeover case type — ATO is a threat classification, not an
+  object, so an ATO investigation is an ordinary case.
 - **The inbound phishing message itself** — quarantine, release, and
   message-level forensics are the email-security connector's surface; use
   `checkpoint-avanan-quarantine`, `ironscales-incidents`,


### PR DESCRIPTION
#201 deleted `domotz-eyes` and `abnormal-security-account-takeover` because neither surface exists on its server. Two anti-triggers still routed readers to them — the third instance of deletions leaving dangling routing edges (see #196).

**Both are reworded, not substituted**, because in each case the deletion exposed a wrong premise rather than a moved skill:

- `betterstack-monitors` implied an in-LAN equivalent of a synthetic HTTP/TCP check exists. It doesn't. Domotz's API has an `/eye/snmp` path but the server surfaces only the SNMP-sensor slice, already covered by `domotz-network` — which reports device and interface state, a different question. The bullet now routes there *and says so*.
- `secops-pack-bec-response` asserted Abnormal models account-takeover as its own case type with its own remediation actions. It doesn't — the server has abuse, cases, messages, remediation and threats. ATO is a **threat classification, not an object**, so an ATO investigation is an ordinary case.

A mechanical substitution would have produced confidently wrong routing in both spots, which is the failure mode this pass exists to remove.

`check-marketplace-drift.mjs` passes; `betterstack` 0.2.5 → 0.2.6, `secops-pack` 0.1.2 → 0.1.3.