### PR TITLE
fix(marketplace): wyre-gateway entry said it connects to mcp.wyre.ai

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://www.schemastore.org/claude-code-marketplace.json",
   "name": "msp-claude-plugins",
   "description": "Community-driven Claude Code plugins for Managed Service Providers. Integrates with PSA, RMM, and documentation tools.",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "owner": {
     "name": "WYRE Technology",
     "email": "aaron@sachshaus.net"
@@ -761,7 +761,7 @@
     {
       "name": "wyre-gateway",
       "source": "./msp-claude-plugins/wyre-gateway",
-      "description": "WYRE MSP Gateway client - cross-vendor orchestration agents (client-360, QBR prep, renewal-risk analysis, security-posture scoring, technician-performance coaching, incident war-room coordination, compliance evidence packaging, onboarding QA, gateway ops). Connects to mcp.wyre.ai.",
+      "description": "WYRE MSP Gateway client - cross-vendor orchestration agents (client-360, QBR prep, renewal-risk analysis, security-posture scoring, technician-performance coaching, incident war-room coordination, compliance evidence packaging, onboarding QA, gateway ops). Connects to conduit.wyre.ai.",
       "category": "productivity",
       "tags": [
         "wyre",

--- a/msp-claude-plugins/docs/src/data/plugins.ts
+++ b/msp-claude-plugins/docs/src/data/plugins.ts
@@ -2205,7 +2205,7 @@ export const plugins: Plugin[] = [
     id: 'wyre-gateway',
     name: 'Wyre Gateway',
     vendor: 'Wyre-gateway',
-    description: 'WYRE MSP Gateway client - cross-vendor orchestration agents (client-360, QBR prep, renewal-risk analysis, security-posture scoring, technician-performance coaching, incident war-room coordination, compliance evidence packaging, onboarding QA, gateway ops). Connects to mcp.wyre.ai.',
+    description: 'WYRE MSP Gateway client - cross-vendor orchestration agents (client-360, QBR prep, renewal-risk analysis, security-posture scoring, technician-performance coaching, incident war-room coordination, compliance evidence packaging, onboarding QA, gateway ops). Connects to conduit.wyre.ai.',
     category: 'productivity',
     maturity: 'alpha',
     features: [],

--- a/msp-claude-plugins/docs/src/data/sharedSkills.ts
+++ b/msp-claude-plugins/docs/src/data/sharedSkills.ts
@@ -23,5 +23,5 @@ export const sharedSkills: SharedSkill[] = [
 export const sharedSkillsMeta = {
   installSlug: 'shared-skills',
   description: 'Vendor-agnostic MSP skills — terminology, ticket triage, incident correlation, and billing reconciliation',
-  version: '1.1.5',
+  version: '1.1.6',
 };


### PR DESCRIPTION
The last reader-facing `mcp.wyre.ai` reference #206 couldn't reach — its scope barred `marketplace.json` and generated docs data.

It matters more than its size suggests: this is the **description an installer reads when choosing the plugin**, and it named the system the plugin no longer connects to. #194 repointed its `.mcp.json` to `conduit.wyre.ai/v1/mcp`, so the entry has been contradicting the config since then.

Regenerated `plugins.ts`; **zero `mcp.wyre.ai` references remain in generated data.**

Every surviving occurrence elsewhere in the repo is now deliberate and justified — release history, a PRD, dated plan/spec documents, the docs site's own identity (it genuinely is served at `mcp.wyre.ai`), the nine self-hosting links that really do point at the other repo, the `Sign in` link kept on the gateway for existing customers, `wyre-gateway/GOVERNANCE.md`'s naming-split section, and `warmly`, which has no Conduit slug at all.