### PR TITLE
docs(autotask/contracts): document contract management tools from autotask-mcp#238

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "$schema": "https://www.schemastore.org/claude-code-marketplace.json",
   "name": "msp-claude-plugins",
   "description": "Community-driven Claude Code plugins for Managed Service Providers. Integrates with PSA, RMM, and documentation tools.",
-  "version": "1.27.1",
+  "version": "1.28.0",
   "owner": {
     "name": "WYRE Technology",
     "email": "aaron@sachshaus.net"

--- a/msp-claude-plugins/kaseya/autotask/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/kaseya/autotask/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autotask",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Claude plugins for Kaseya Autotask PSA - tickets, CRM, projects, contracts, expenses, quotes, quote builder",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/kaseya/autotask/agents/contract-renewal-tracker.md
+++ b/msp-claude-plugins/kaseya/autotask/agents/contract-renewal-tracker.md
@@ -17,7 +17,7 @@ You are an expert contract renewal tracking agent for MSP environments using Aut
 
 You understand Autotask's contract model in depth. Contracts have types (Recurring Services, Block Hours, Time & Materials, Fixed Price, Retainer), statuses (Active = 1, Inactive = 2, Cancelled = 3), start dates, and end dates. Recurring Services contracts are the core managed services agreements that generate predictable MRR — these are the most important to track for renewal. Block Hours contracts need attention when hours are running low, not just when the contract end date approaches. Fixed Price and Retainer contracts have defined end dates that may not have obvious billing signals ahead of expiry.
 
-You know that Autotask's contract query API uses a filter syntax, and you query for contracts expiring within defined windows (30 days, 60 days, 90 days) by filtering on `endDate` range while requiring `status = 1` (active). You understand the important nuance: a contract that expires and is not renewed does not automatically become Inactive in Autotask — it continues to appear as Active with an endDate in the past. This means tickets continue to flow against it, time continues to be billable to it, and the client may be receiving managed services with no current contract in place. You treat active contracts with expired end dates as a billing and legal risk that requires urgent account manager attention.
+You reach for the dedicated autotask-mcp contract tools first. `autotask_list_expiring_contracts` is purpose-built for your core loop: pass `daysAhead` (30/60/90) with `status: 1` to pull each expiry window, and `includeExpired: true` to surface contracts already past their end date. `autotask_search_contracts` covers ad-hoc slices (`companyID`, `contractType`, `endDateFrom`/`endDateTo`), and `autotask_get_contract` fetches a single contract header by ID. You understand the important nuance: a contract that expires and is not renewed does not automatically become Inactive in Autotask — it continues to appear as Active with an endDate in the past. This means tickets continue to flow against it, time continues to be billable to it, and the client may be receiving managed services with no current contract in place. You treat active contracts with expired end dates as a billing and legal risk that requires urgent account manager attention.
 
 You think about MRR/ARR in terms of services attached to contracts. Each ContractService has a `unitPrice`, `quantity`, and `periodType` (monthly, quarterly, annual). You can approximate MRR by summing monthly-normalized service fees across all active Recurring Services contracts. When you see the renewal pipeline alongside the MRR at risk, you give account managers the business context they need to prioritize their outreach: a $3,000/month contract expiring in 30 days is a more urgent renewal call than a $150/month contract expiring in 60 days.
 
@@ -25,8 +25,8 @@ You also track auto-renewal gaps. Some MSPs configure contracts with no end date
 
 ## Capabilities
 
-- Query all active Autotask contracts and segment by expiry: expiring in 0–30 days, 31–60 days, 61–90 days, and 91+ days
-- Identify expired contracts (endDate in the past, status still Active) that are still receiving ticket activity — clients on expired paper
+- Query all active Autotask contracts and segment by expiry: expiring in 0–30 days, 31–60 days, 61–90 days, and 91+ days (`autotask_list_expiring_contracts` with per-window `daysAhead`)
+- Identify expired contracts (endDate in the past, status still Active) that are still receiving ticket activity — clients on expired paper (`autotask_list_expiring_contracts` with `includeExpired: true, status: 1`, cross-referenced against `autotask_search_tickets`)
 - Pull ContractServices to calculate approximate MRR per contract and aggregate portfolio MRR/ARR
 - Identify contracts with no end date or with end dates more than 12 months in the past — auto-renewal gap candidates
 - Flag block hours contracts where the remaining balance is low relative to the remaining contract term
@@ -40,11 +40,11 @@ You also track auto-renewal gaps. Some MSPs configure contracts with no end date
 
 Begin every contract review with the most urgent category — expired contracts still in active service:
 
-1. **Find expired active contracts** — Query for contracts where `status = 1` (Active) and `endDate` is before today. For each, check whether the associated company has had tickets created against this contract in the past 30 days. Any company receiving billable service on an expired contract is a compliance risk. List them first, regardless of their MRR value.
+1. **Find expired active contracts** — `autotask_list_expiring_contracts` with `{ "daysAhead": 0, "includeExpired": true, "status": 1 }` returns every Active contract whose endDate is today or earlier. For each, check whether the associated company has had tickets created against this contract in the past 30 days. Any company receiving billable service on an expired contract is a compliance risk. List them first, regardless of their MRR value.
 
-2. **Find contracts expiring in 0–30 days** — Query active contracts with `endDate` within the next 30 days. For each, pull associated ContractServices to calculate MRR. Flag any without a renewal ticket or opportunity record in Autotask as requiring immediate account manager outreach. A contract expiring in 30 days with no renewal in progress is a drop-everything situation.
+2. **Find contracts expiring in 0–30 days** — `autotask_list_expiring_contracts` with `{ "daysAhead": 30, "status": 1 }`. For each, pull associated ContractServices to calculate MRR. Flag any without a renewal ticket or opportunity record in Autotask as requiring immediate account manager outreach. A contract expiring in 30 days with no renewal in progress is a drop-everything situation.
 
-3. **Find contracts expiring in 31–60 days** — Same query for the 31–60 day window. Calculate MRR at risk. These should be in active renewal conversation already — flag any that appear to have no recent account activity.
+3. **Find contracts expiring in 31–60 days** — `daysAhead: 60` minus the 0–30 set (or `autotask_search_contracts` with `endDateFrom`/`endDateTo` bounding the window exactly). Calculate MRR at risk. These should be in active renewal conversation already — flag any that appear to have no recent account activity.
 
 4. **Find contracts expiring in 61–90 days** — The advance warning window. These contracts should at minimum have an outreach scheduled. Surface them with MRR values so account managers can prioritize.
 

--- a/msp-claude-plugins/kaseya/autotask/commands/check-contract.md
+++ b/msp-claude-plugins/kaseya/autotask/commands/check-contract.md
@@ -22,8 +22,8 @@ View contract status, entitlements, and remaining hours for a company or specifi
 
 2. **Query contracts**
    - If company_id: Use `autotask-mcp/autotask_search_contracts` to find all contracts
-   - If contract_id: Fetch specific contract details
-   - Apply expired filter as specified
+   - If contract_id: Use `autotask-mcp/autotask_get_contract` to fetch that contract's header
+   - If include_expired: add `autotask-mcp/autotask_list_expiring_contracts` with `includeExpired: true` scoped to the company
 
 3. **Get contract details**
    - Fetch contract type and terms
@@ -281,7 +281,9 @@ Contact your Autotask administrator for access.
 ## MCP Tool Usage
 
 This command uses the following autotask-mcp tools:
-- `autotask_search_contracts` - Search contracts by company
+- `autotask_search_contracts` - Search contracts by company (supports `contractType` and `endDateFrom`/`endDateTo` filters)
+- `autotask_get_contract` - Fetch a single contract by ID
+- `autotask_list_expiring_contracts` - Expiring/expired contracts report (used for `include_expired`)
 - `autotask_search_companies` - Verify company exists
 
 ## Related Commands

--- a/msp-claude-plugins/kaseya/autotask/skills/contracts/SKILL.md
+++ b/msp-claude-plugins/kaseya/autotask/skills/contracts/SKILL.md
@@ -78,7 +78,103 @@ Services define what's included in a contract:
 | `periodType` | Monthly, Quarterly, Annual |
 | `isOptional` | Required vs optional |
 
+## MCP Tool Reference
+
+The autotask-mcp server exposes typed contract tools — prefer these over
+`autotask_raw_request`. Read tools return contract **header fields only**
+(no service lines), keeping responses light.
+
+### Search Contracts
+
+```
+Tool: autotask_search_contracts
+Args: {
+  "companyID": 12345,
+  "status": 1,
+  "contractType": 7,
+  "endDateFrom": "2026-01-01",
+  "endDateTo": "2026-12-31",
+  "searchTerm": "Managed",
+  "pageSize": 25
+}
+```
+
+All filters optional: `searchTerm` (contains-match on contract name), `companyID`, `status`, `contractType` (picklist ID), `endDateFrom`/`endDateTo` (ISO dates bounding the end date), `pageSize` (default 25, max 500).
+
+### Get a Single Contract
+
+```
+Tool: autotask_get_contract
+Args: { "id": 54321 }
+```
+
+### Expiring / Expired Contracts Report
+
+The renewal-pipeline tool. Lists contracts whose `endDate` falls within the next `daysAhead` days (default 60), org-wide or scoped to one company:
+
+```
+Tool: autotask_list_expiring_contracts
+Args: {
+  "daysAhead": 90,
+  "companyID": 12345,
+  "includeExpired": true,
+  "status": 1,
+  "pageSize": 100
+}
+```
+
+- Pair with `status: 1` to get "in effect but lapsing" contracts — the renewal call list.
+- `includeExpired: true` drops the today lower bound, surfacing contracts already past their end date. Autotask does **not** auto-deactivate expired contracts, so `status: 1` + `includeExpired: true` finds clients still receiving service on expired paper — the compliance-risk case.
+
+### Create a Contract
+
+```
+Tool: autotask_create_contract
+Args: {
+  "companyID": 12345,
+  "contractName": "Acme Corp - Managed Services",
+  "contractType": 1,
+  "contractCategory": 3,
+  "startDate": "2026-01-01",
+  "endDate": "2026-12-31",
+  "status": 1
+}
+```
+
+**Required:** `companyID`, `contractName`, `contractType`, `contractCategory`, `startDate`, `endDate`
+
+### Create Contract Shells in Bulk
+
+For multi-contract onboarding (e.g. one contract per client location), pass up to 50 shells in one call — same fields per item as `autotask_create_contract`:
+
+```
+Tool: autotask_create_contracts_bulk
+Args: {
+  "contracts": [
+    { "companyID": 12345, "contractName": "Acme - HQ", "contractType": 1, "contractCategory": 3, "startDate": "2026-01-01", "endDate": "2026-12-31" },
+    { "companyID": 12345, "contractName": "Acme - Branch", "contractType": 1, "contractCategory": 3, "startDate": "2026-01-01", "endDate": "2026-12-31" }
+  ]
+}
+```
+
+Shells are created sequentially (Autotask has no batch endpoint); a failure on one shell does **not** abort the rest. Each item reports `{index, contractName, success, id | error}` — retry only the failures.
+
+### Update a Contract
+
+```
+Tool: autotask_update_contract
+Args: { "id": 54321, "endDate": "2027-12-31", "status": 1 }
+```
+
+Only fields provided change — the typical renewal move is extending `endDate`.
+
+### Contract Service Lines
+
+`autotask_create_contract_service` (required: `contractID`, `serviceID`, `unitPrice`) and `autotask_update_contract_service` (required: `id`, `contractID`) manage the ContractServices line items on a contract.
+
 ## API Patterns
+
+Raw REST shapes for reference — the typed tools above cover these; reach for `autotask_raw_request` only for entities without typed tools (ContractBlocks, ContractRetainers, etc.).
 
 ### Creating a Contract
 
@@ -216,8 +312,8 @@ Calculate remaining hours:
 ### Contract Renewal
 
 1. **Identify expiring contracts**
-   - Query contracts by endDate
-   - Generate renewal report
+   - `autotask_list_expiring_contracts` with `daysAhead` 30/60/90 windows
+   - Add `includeExpired: true` to catch already-lapsed contracts still marked active
 
 2. **Review contract performance**
    - Compare budgeted vs actual hours

--- a/scripts/unanchored-docs.json
+++ b/scripts/unanchored-docs.json
@@ -33,7 +33,6 @@
     "autotask:commands/time-entry.md": "names no MCP tool; 1 HTTP endpoint(s), 6 CLI flag(s) — first at commands/time-entry.md:50 POST /v1.0/TimeEntries",
     "autotask:skills/api-patterns": "names no MCP tool; 12 HTTP endpoint(s), 0 CLI flag(s) — first at skills/api-patterns/SKILL.md:39 GET /v1.0/Tickets",
     "autotask:skills/configuration-items": "names no MCP tool; 6 HTTP endpoint(s), 0 CLI flag(s) — first at skills/configuration-items/SKILL.md:84 POST /v1.0/ConfigurationItemTypes/query",
-    "autotask:skills/contracts": "names no MCP tool; 5 HTTP endpoint(s), 0 CLI flag(s) — first at skills/contracts/SKILL.md:86 POST /v1.0/Contracts",
     "autotask:skills/crm": "names no MCP tool; 5 HTTP endpoint(s), 0 CLI flag(s) — first at skills/crm/SKILL.md:98 POST /v1.0/Companies",
     "autotask:skills/time-entries": "names no MCP tool; 6 HTTP endpoint(s), 0 CLI flag(s) — first at skills/time-entries/SKILL.md:140 POST /TimeEntries",
     "azure-mcp:agents/azure-ops-analyst.md": "names no MCP tool; 0 HTTP endpoint(s), 1 CLI flag(s) — first at agents/azure-ops-analyst.md:12 --read-only",


### PR DESCRIPTION
Companion to wyre-technology/autotask-mcp#238 (closes the docs side of autotask-mcp#237), which shipped `autotask_get_contract`, `autotask_list_expiring_contracts`, `autotask_create_contracts_bulk`, and `contractType`/`endDateFrom`/`endDateTo` filters on `autotask_search_contracts`.

## Changes

- **`skills/contracts/SKILL.md`** — new **MCP Tool Reference** section covering all 8 contract tools (search/get/expiring-report/create/bulk-create/update/service lines), placed ahead of the raw REST patterns, which are now explicitly marked as `autotask_raw_request`-only fallback for entities without typed tools (ContractBlocks etc.). The renewal workflow now names `autotask_list_expiring_contracts`, including the `includeExpired: true, status: 1` recipe for finding clients still receiving service on expired paper.
- **`agents/contract-renewal-tracker.md`** — the agent's expiry-window loop, expired-but-active detection, and ad-hoc slicing now name the exact tools/args to call instead of describing raw filter syntax.
- **`commands/check-contract.md`** — `contract_id` path uses `autotask_get_contract`; `include_expired` maps to `autotask_list_expiring_contracts`.
- **Bookkeeping** — kaseya-autotask plugin `0.5.3 → 0.6.0`, marketplace `1.27.1 → 1.28.0`, and the contracts skill leaves `scripts/unanchored-docs.json` (un-anchored debt 158 → 157, it now names MCP tools).

## Verification

Ran locally: `claude plugin validate .` ✔, `check-marketplace-drift --base origin/main` ✔ (bump gate: 1 plugin touched, version bumped), `check-doc-references` ✔, `check-tool-anchoring` ✔ after `--update`. Regenerated docs data — `plugins.ts` unchanged (body-only edits don't flow into it), so no site-data diff.

Note: the new tools go live when autotask-mcp#238 merges and the container redeploys — merge that first (it's green) so `tool-drift-audit` ground truth matches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/msp-claude-plugins/pr/212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->