### PR TITLE
feat(posthog): add read-only PostHog plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -377,6 +377,18 @@
       ]
     },
     {
+      "name": "posthog",
+      "source": "./msp-claude-plugins/posthog/posthog",
+      "description": "PostHog product analytics - insights, dashboards, feature flags, cohorts, events (read-only)",
+      "category": "productivity",
+      "tags": [
+        "posthog",
+        "analytics",
+        "productivity",
+        "read-only"
+      ]
+    },
+    {
       "name": "proofpoint",
       "source": "./msp-claude-plugins/email-security/proofpoint",
       "description": "Proofpoint Email Protection - TAP, quarantine, threat intel, forensics, URL defense, VAP reports",

--- a/msp-claude-plugins/posthog/posthog/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/posthog/posthog/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "posthog",
+  "version": "0.1.0",
+  "description": "Claude plugin for PostHog product analytics — insights, dashboards, feature flags, cohorts, events (read-only)",
+  "author": {
+    "name": "MSP Claude Plugins Community"
+  },
+  "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
+  "repository": "https://github.com/wyre-technology/msp-claude-plugins",
+  "license": "Apache-2.0"
+}

--- a/msp-claude-plugins/posthog/posthog/.mcp.json
+++ b/msp-claude-plugins/posthog/posthog/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "posthog": {
+      "type": "http",
+      "url": "https://conduit.wyre.ai/v1/posthog/mcp"
+    }
+  }
+}

--- a/msp-claude-plugins/posthog/posthog/GOVERNANCE.md
+++ b/msp-claude-plugins/posthog/posthog/GOVERNANCE.md
@@ -1,0 +1,221 @@
+# PostHog plugin — governance and safety model
+
+Unofficial. Community-built plugin for the PostHog product-analytics API.
+Not affiliated with, endorsed by, or sponsored by the vendor.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches PostHog through the WYRE
+Conduit gateway (`https://conduit.wyre.ai/v1/posthog/mcp`), which brokers
+authentication centrally and scopes every call to the PostHog project the
+operator is authorised for.
+
+- No PostHog personal API key is stored on the technician's machine, in this
+  repo, or in the model's context. The key is entered once in Conduit's
+  connect page and injected server-side per request; this plugin's `.mcp.json`
+  declares no headers and no environment variables for the client to set.
+- The org's PostHog credential is stored once at the gateway, so replacing it
+  is one edit rather than a change on every technician's machine. PostHog
+  personal API keys don't expire on a schedule and Conduit has no rotate
+  action for any vendor — rotation means minting a new key in PostHog and
+  re-submitting Conduit's connect form, which overwrites the stored
+  credential in place. Nothing tracks its age or prompts you.
+- Every call carries operator identity, so the gateway audit log answers "who
+  pulled this dashboard." PostHog's own activity log attributes API calls to
+  the personal API key's owner, which is fine for a single technician's key
+  but says nothing about which agent or session made the call once a key is
+  shared.
+- Removing someone from the organisation clears their per-vendor grants and
+  revokes their gateway refresh tokens at once; a user deactivated in your
+  identity provider is refused on their very next request. A user only
+  removed from the org keeps an already-issued access token for up to an
+  hour, but it reaches only a personal PostHog connection made with their own
+  key — never the org's. See `wyre-gateway/GOVERNANCE.md`.
+
+### The scope decision happens outside Conduit, at key creation
+
+PostHog personal API keys carry their own permission model, independent of
+Conduit: each key can be scoped to specific `resource:action` pairs —
+`insight:read`, `feature_flag:read`, `dashboard:read`, and so on — at the
+moment it is minted in the PostHog UI. **This is the primary control for
+this plugin's read-only posture.** A key scoped only to `:read` actions
+cannot be used to write, no matter what a caller asks it to do — PostHog's
+own API rejects the write call before it reaches any Conduit or plugin
+logic.
+
+That control lives entirely on the customer's side of the connection.
+Conduit stores whatever key it is given; it does not inspect, mint, or
+verify the key's scopes. **If whoever connects PostHog to Conduit pastes in
+a key that was minted with full read/write access — the PostHog default
+when scopes aren't explicitly narrowed — this plugin's read-only posture
+depends entirely on the second layer below, not on the key.** Setup
+instructions for this plugin must tell the connecting operator, explicitly,
+to scope the key to read-only resources before pasting it into Conduit.
+Verifying that instruction was followed is a manual step today; PostHog
+does not expose a way to introspect a key's granted scopes after the fact
+from outside its own settings UI.
+
+## Tool permission tiers
+
+> **`posthog` has no entry in `VENDOR_TOOL_CONFIG` — this is a new vendor
+> connector.** Conduit derives a tool's tier from `VENDOR_TOOL_CONFIG`
+> (`src/proxy/result-cache.ts`) and fails closed:
+> `const requiredTier: PermissionTier = classified ?? 'admin';`
+> (`src/access/access-enforcement.ts:63`). Until `posthog` is classified
+> there, the grouping below carries no tier-enforcement meaning at all — a
+> `read` or `write` grant on this vendor admits nothing, and an `admin`
+> grant admits every tool the upstream MCP server exposes, including the
+> write tools this plugin deliberately does not document or recommend. For
+> the live list of unclassified vendors see `wyre-gateway/GOVERNANCE.md`,
+> *Fail-closed, and the vendors Conduit has not classified*. Classifying a
+> vendor is always a privilege *reduction*, never an expansion.
+>
+> Because tiering does nothing for this vendor yet, the operational
+> enforcement for "read-only at v1" is a **gateway-side tool allowlist**
+> (a `customTools` grant naming only the read-tool families below), not a
+> tier grant. Configure that allowlist when connecting this plugin — an
+> `admin` grant with no allowlist restores the full upstream surface,
+> including every tool this document excludes.
+
+PostHog's own MCP server exposes a very large tool surface — north of 200
+tools spanning nearly every product area, with substantial create/update/
+delete coverage on most of them: feature flags, insights, dashboards,
+cohorts, canvas, business knowledge, data warehouse, early-access features,
+support conversations, and AI-observability/LLM-cost tooling. That is not a
+gap in this plugin's documentation; it is the actual shape of PostHog's API.
+
+**This plugin ships read-only at v1 by explicit decision (Aaron/founder
+sign-off, 2026-08-12) — not because PostHog lacks write tools, but because
+the tool surface is unusually large and write-heavy for a "productivity"
+catalog addition, and several of those write tools have real external side
+effects:**
+
+- `conversations-tickets-reply-create` posts an **actual reply on a
+  customer support ticket** — the same hazard class as Freshdesk's
+  `freshdesk_tickets_reply` (see `freshdesk/GOVERNANCE.md`): there is no
+  unsend, and it goes out under the operator's identity.
+- Feature-flag mutation tools — `early-access-feature-create`,
+  `early-access-feature-destroy`, `early-access-feature-partial-update`,
+  and flag create/update/delete generally — change what code path a **live
+  client's production application** executes for some or all of its users,
+  immediately and with no built-in dry run.
+- `alert-simulate` and the `llma-*` (AI-observability) job- and
+  eval-creation tools can **incur real spend** — simulating an alert or
+  kicking off an LLM evaluation/observability job is a billable action
+  against the connected PostHog project, not a read.
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change PostHog state. The only tier this plugin grants, documents, or recommends. | See the family table below. |
+| **Write / Delete / Admin** | **Not shipped in v1.** Every create, update, delete, and destroy tool across every family — including `conversations-tickets-reply-create` and other ticket-write tools, feature-flag/early-access-feature CRUD, `alert-simulate`, the `llma-*` job/eval-creation tools, and `canvas-publish-*`. | Deliberately excluded. Not granted, not documented per-call, not part of any bundled command or skill. |
+
+### The read-only tool families this plugin grants
+
+Grouped by product area, matching PostHog's own tool naming. This is not the
+exhaustive list — PostHog documents the full 200+-tool catalog at
+[posthog.com/docs/model-context-protocol/tools](https://posthog.com/docs/model-context-protocol/tools);
+this table names the read-side families this plugin's skills and commands
+are built against.
+
+| Family | Read tools |
+|---|---|
+| Actions | get, list |
+| Insights | `dashboard-get`, `dashboards-get-all`, insight run/read |
+| Feature Flags | `early-access-feature-list`, `early-access-feature-retrieve` (read only — create/destroy/partial-update excluded, see above) |
+| Experiments | list, get |
+| Cohorts | list, retrieve |
+| Events / Annotations | list, retrieve |
+| Dashboards | `dashboard-get`, `dashboards-get-all` |
+| Data Warehouse | view-get/list, schema reads |
+| Search | `docs-search`, entity search |
+| Alerts | get, list (**not** `alert-simulate`) |
+| Business Knowledge | search, retrieve |
+
+**Conduit does not enforce per-call approval.** It compares tiers and, where
+configured, checks the tool allowlist — there is no approval step, no
+per-call confirmation, and no interactive prompt anywhere in its enforcement
+path. The read-only posture above is a combination of (1) the key's own
+scopes and (2) the gateway allowlist; nothing in Conduit stops a
+misconfigured grant from reaching a write tool if either of those is set up
+wrong.
+
+## Recommended agent policy
+
+Because this plugin ships no write surface, **read tools are safe to grant
+to autonomous and scheduled agents** — insight review, dashboard pulls for
+QBRs, feature-flag status checks, and cohort/event lookups are the intended
+unattended use. Grant them through the gateway allowlist naming the read
+families above; do not grant `admin` on this vendor, because `admin` reaches
+the full upstream surface including everything this document excludes.
+
+There is no write tier to propose-then-approve here, unlike Xero or
+Freshdesk. If a future version of this plugin adds write tools, that
+version needs its own agent-policy section — do not assume the read-only
+recommendation above still holds once this document is updated to grant a
+write or destructive tier.
+
+## What it cannot reach
+
+- Only the PostHog project(s) the connected personal API key can see.
+  PostHog keys are scoped per-organization at creation; a key minted under
+  the wrong PostHog organization returns another team's analytics, not an
+  error.
+- Only the `resource:action` scopes the key was minted with — **if the key
+  was over-scoped at creation, this plugin's read-only posture is not a
+  hard boundary, it is a documentation and allowlist convention.** See
+  *The scope decision happens outside Conduit* above.
+- No write path of any kind, in the tools this plugin grants or documents —
+  see *Tool permission tiers*.
+- No filesystem, no shell, no other vendor's data.
+- No session-replay video or raw session-recording playback; this plugin's
+  skills cover insights, dashboards, feature flags, experiments, cohorts,
+  events, annotations, and business knowledge only.
+
+## Data handling
+
+Responses pass through the gateway into model context for the session and
+are not persisted by this plugin.
+
+- **Product usage and business metrics.** Insights and dashboards can
+  surface conversion rates, retention curves, revenue-adjacent metrics, and
+  error-rate trends — commercially sensitive about the client's business,
+  not just about their software.
+- **Potential end-user PII in events and cohorts.** Whether an event or
+  cohort record contains personally identifying data (email addresses, user
+  IDs, free-text properties) depends entirely on what the client's own
+  application sends to PostHog. This plugin has no way to know in advance
+  whether a given project's event stream is PII-clean; treat event and
+  cohort output as potentially sensitive by default.
+- **Feature-flag and experiment state** can reveal unreleased features,
+  internal rollout percentages, and which customers are in a beta —
+  information a client may not want surfaced outside their own team.
+- **Business Knowledge search** returns whatever the connected team has
+  written into PostHog's business-knowledge store, which may include
+  internal notes not meant for a support or MSP audience.
+
+Restrict the insight, dashboard, and business-knowledge tools specifically
+if agents run unattended or render output where anyone outside the client's
+own team could see it.
+
+## Known sharp edges
+
+- **The tool surface is bigger than this document, on purpose.** This
+  plugin covers a deliberate subset. An operator who grants `admin` instead
+  of using the allowlist gets the entire upstream catalog — including tools
+  no skill or command here was written against.
+- **A key minted without explicit read-only scopes is read-write by
+  default.** PostHog does not force an operator to narrow scopes at key
+  creation; the read-only posture this document describes depends on the
+  connecting operator having done that deliberately.
+- **Feature-flag and early-access-feature reads are two different families
+  with overlapping vocabulary.** `early-access-feature-list` /
+  `early-access-feature-retrieve` is the confirmed read surface for
+  early-access features specifically; PostHog's broader feature-flag API
+  has its own read and write tools documented at the link above. Don't
+  assume every "feature flag" question routes through the early-access
+  tools — check `skills/feature-flags-and-experiments/SKILL.md`.
+- **Not yet classified means not yet safely grantable at a coarse tier.**
+  Until `posthog` gets a `VENDOR_TOOL_CONFIG` entry, there is no `read`
+  grant that admits only the families above — it is allowlist or `admin`,
+  nothing in between. Classifying the vendor, when it happens, is what
+  turns the family table above into an actual `read` tier.

--- a/msp-claude-plugins/posthog/posthog/GOVERNANCE.md
+++ b/msp-claude-plugins/posthog/posthog/GOVERNANCE.md
@@ -197,6 +197,32 @@ Restrict the insight, dashboard, and business-knowledge tools specifically
 if agents run unattended or render output where anyone outside the client's
 own team could see it.
 
+## Open enforcement gap (tracked, not resolved by this plugin)
+
+**"Read-only" for this vendor rests on two operator-configured layers, and
+neither is enforced automatically today:**
+
+1. The PostHog personal API key must be scoped to read-only `resource:action`
+   pairs at creation (see *The scope decision happens outside Conduit*
+   above) — Conduit does not inspect or verify this.
+2. The connection must use a gateway-side `customTools` allowlist naming
+   only the read families in this document, not an `admin` grant — Conduit
+   has no `VENDOR_TOOL_CONFIG` entry for `posthog` yet, so there is no
+   coarse `read` tier to fall back on if the allowlist is skipped or
+   misconfigured.
+
+**Neither layer is a hard boundary — both are instructions the connecting
+operator has to follow correctly.** An operator who pastes in a
+full-access key AND grants `admin` gets the complete, unrestricted
+upstream PostHog tool surface, including every write tool this document
+excludes, with nothing in Conduit stopping it. This is a real gap between
+what this document calls "read-only" and what Conduit actually enforces
+for a first adopt-vendor plugin — flagged to Aaron (2026-08-12) as an open
+question: whether adopt-vendor plugins like this one need a default-deny
+`VENDOR_TOOL_CONFIG` entry (or equivalent enforced default) shipped
+alongside the plugin itself, rather than relying on setup instructions
+alone. Not resolved by this PR; tracking here so it isn't lost.
+
 ## Known sharp edges
 
 - **The tool surface is bigger than this document, on purpose.** This
@@ -206,7 +232,8 @@ own team could see it.
 - **A key minted without explicit read-only scopes is read-write by
   default.** PostHog does not force an operator to narrow scopes at key
   creation; the read-only posture this document describes depends on the
-  connecting operator having done that deliberately.
+  connecting operator having done that deliberately. See *Open enforcement
+  gap* above — this is not a hypothetical, it's the actual current state.
 - **Feature-flag and early-access-feature reads are two different families
   with overlapping vocabulary.** `early-access-feature-list` /
   `early-access-feature-retrieve` is the confirmed read surface for

--- a/msp-claude-plugins/posthog/posthog/README.md
+++ b/msp-claude-plugins/posthog/posthog/README.md
@@ -1,0 +1,183 @@
+# PostHog Plugin
+
+Claude Code plugin for PostHog product analytics — read-only at v1.
+
+*Internal fast-track build, 2026-08-12 — not run through the standard
+community PRD process.*
+
+## Overview
+
+This plugin gives Claude working knowledge of PostHog so MSP technicians and
+analysts can review a client's product analytics without leaving the chat:
+
+- **Insights & Dashboards** — Read saved insights (trends, funnels,
+  retention, and similar analytics queries) and the dashboards that group
+  them
+- **Feature Flags & Experiments** — Look up early-access feature status and
+  experiment configuration (read-only — no flag or experiment mutation)
+- **Cohorts & Events** — Look up saved user/group segments, raw analytics
+  events, and timeline annotations
+- **API Patterns** — Auth model, `resource:action` key scoping, and error
+  handling for the PostHog MCP surface
+
+**This plugin is read-only by design.** PostHog's own MCP server exposes a
+very large tool catalog with extensive write coverage; this plugin grants
+and documents only the read-side tool families. See
+[GOVERNANCE.md](GOVERNANCE.md) for the full reasoning and the exact list of
+what is excluded.
+
+## Prerequisites
+
+### PostHog Personal API Key
+
+You need a PostHog **personal API key scoped to read-only resources**:
+
+1. Log into PostHog and open **Settings → Personal API keys**
+2. Click **Create personal API key**
+3. Under **Scopes**, select only read-side `resource:action` pairs relevant
+   to this plugin — for example `insight:read`, `feature_flag:read`,
+   `dashboard:read`, `cohort:read`, `event:read`, `annotation:read`,
+   `experiment:read`. **Do not grant write scopes.** PostHog does not narrow
+   this for you by default — an unscoped key is read-write.
+4. Copy the key
+
+### Connecting through Conduit
+
+This plugin does not accept a local API key. Connect the key from the step
+above once in the WYRE Conduit web UI (**Connections → PostHog**). Conduit
+stores it and injects it into every call server-side.
+
+There are **no environment variables and no headers to configure on the
+client** — `.mcp.json` declares only the gateway URL:
+
+```json
+{
+  "mcpServers": {
+    "posthog": {
+      "type": "http",
+      "url": "https://conduit.wyre.ai/v1/posthog/mcp"
+    }
+  }
+}
+```
+
+## Installation
+
+```
+/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin install posthog
+```
+
+## Available Skills
+
+| Skill | Description |
+|-------|-------------|
+| `insights-and-dashboards` | Querying insights, running saved insight queries, dashboard retrieval |
+| `feature-flags-and-experiments` | Read-only feature-flag and experiment lookups |
+| `cohorts-and-events` | Cohort lookups, event and annotation queries |
+| `api-patterns` | Auth model, key scoping, rate limits, and error handling |
+
+## Available Commands
+
+| Command | Description |
+|---------|-------------|
+| `/check-insight` | Look up a saved insight by ID or name and report its current result |
+| `/list-feature-flags` | List early-access feature flags and their current status |
+| `/list-dashboards` | List a project's dashboards, or retrieve one by ID |
+
+## Quick Start
+
+### Check an Insight
+
+```
+/check-insight "Weekly Active Users"
+```
+
+### List Feature Flags
+
+```
+/list-feature-flags
+```
+
+### List Dashboards
+
+```
+/list-dashboards
+```
+
+### Retrieve a Specific Dashboard
+
+```
+/list-dashboards --dashboard_id 12345
+```
+
+## Security Considerations
+
+- **Read-only is a two-layer control, not one.** It depends on (1) the
+  PostHog personal API key being scoped to read-only resources at creation,
+  and (2) Conduit's gateway-side tool allowlist for this vendor excluding
+  write tool names. See [GOVERNANCE.md](GOVERNANCE.md) — neither layer is
+  automatic, and this document does not control Conduit's actual per-tool
+  permission-tier enforcement.
+- Never paste a PostHog personal API key into a technician's local
+  environment, a `.env` file, or this repo. It is entered once, in Conduit's
+  connect UI, and stored server-side.
+- Review who has access to the connected PostHog project regularly — the
+  key inherits whatever the connecting user's PostHog account can see.
+
+## Troubleshooting
+
+### Authentication Errors
+
+If a call fails with an authentication or permission error:
+1. Confirm the PostHog personal API key is still valid in PostHog's
+   **Settings → Personal API keys** — a revoked or deleted key fails silently
+   from this plugin's point of view until the next call.
+2. Confirm the key's `resource:action` scopes actually cover the tool being
+   called — a key scoped only to `insight:read` will be refused by
+   `feature_flag:read` calls even though both are reads.
+3. Re-connect PostHog in Conduit (**Connections → PostHog**) if the stored
+   key was rotated or revoked outside Conduit.
+
+### Empty or Unexpected Results
+
+1. Confirm the connected key belongs to the correct PostHog organization and
+   project — PostHog keys are scoped per-organization, and a key from the
+   wrong org returns that org's (empty, from your perspective) data rather
+   than an error naming the mismatch.
+2. Confirm the insight, dashboard, flag, or cohort actually exists in that
+   project — this plugin cannot create any of them, so a missing record has
+   to be created in the PostHog UI first.
+
+### Rate Limiting
+
+If you see a `429` response:
+1. Wait before retrying — PostHog returns standard rate-limit responses;
+   consult [PostHog's API documentation](https://posthog.com/docs/api) for
+   current thresholds, which this plugin does not hardcode.
+2. Reduce request frequency, and prefer bounded date ranges over unbounded
+   pulls for event and insight queries.
+
+## API Documentation
+
+- [PostHog API Documentation](https://posthog.com/docs/api)
+- [PostHog Model Context Protocol tools](https://posthog.com/docs/model-context-protocol/tools)
+- [PostHog Personal API Keys](https://posthog.com/docs/api#authentication)
+
+## Contributing
+
+See the main [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+
+This plugin shipped as an Aaron-approved internal fast-track build and did
+not go through the standard community PRD process. Contributions that
+extend it (including any future write-tool tier) should follow the normal
+process and must update [GOVERNANCE.md](GOVERNANCE.md) accordingly.
+
+## Changelog
+
+### 0.1.0 (2026-08-12)
+
+- Initial release — read-only at v1
+- 4 skills: insights-and-dashboards, feature-flags-and-experiments,
+  cohorts-and-events, api-patterns
+- 3 commands: check-insight, list-feature-flags, list-dashboards

--- a/msp-claude-plugins/posthog/posthog/commands/check-insight.md
+++ b/msp-claude-plugins/posthog/posthog/commands/check-insight.md
@@ -1,0 +1,57 @@
+---
+description: Look up a PostHog insight by ID or name and report its current result
+argument-hint: "<insight>"
+arguments: [insight]
+---
+
+# Check PostHog Insight
+
+Look up a saved PostHog insight and report its current computed result.
+
+## Arguments
+
+- `insight` (required) — Insight ID or name to look up
+
+## Prerequisites
+
+- PostHog connected in Conduit with a personal API key scoped at least to
+  `insight:read`
+
+## Steps
+
+1. If `insight` looks like an ID, retrieve it directly; otherwise search
+   dashboards and insights by name first (see
+   `skills/insights-and-dashboards/SKILL.md` for the confirmed read tool
+   family — insight run/read)
+2. Run or retrieve the insight's current result
+3. Report the result with its "as of" / computed timestamp — insight
+   results can be served from cache, so surface the timestamp rather than
+   implying the number is live right now
+4. If nothing matches, say so plainly rather than guessing at a similarly
+   named insight
+
+## Examples
+
+### Look up by name
+
+```
+/check-insight "Weekly Active Users"
+```
+
+### Look up by ID
+
+```
+/check-insight 48213
+```
+
+## Error Handling
+
+| Error | Resolution |
+|-------|------------|
+| 404 Not Found | The insight doesn't exist in this project, or the name doesn't match anything — confirm spelling or list dashboards to find it |
+| 403 Forbidden | The connected key isn't scoped for `insight:read`, or belongs to the wrong PostHog organization |
+| 429 Rate Limited | Back off and retry — see `skills/api-patterns/SKILL.md` |
+
+## Related Commands
+
+- `/list-dashboards` — Find which dashboard an insight lives on

--- a/msp-claude-plugins/posthog/posthog/commands/list-dashboards.md
+++ b/msp-claude-plugins/posthog/posthog/commands/list-dashboards.md
@@ -1,0 +1,56 @@
+---
+description: List a PostHog project's dashboards, or retrieve one by ID
+argument-hint: "[dashboard_id]"
+arguments: [dashboard_id]
+---
+
+# List PostHog Dashboards
+
+List dashboards in the connected PostHog project, or retrieve a specific
+one with its insight tiles.
+
+## Arguments
+
+- `dashboard_id` (optional) — Retrieve a single dashboard by ID; omit to
+  list all dashboards
+
+## Prerequisites
+
+- PostHog connected in Conduit with a personal API key scoped at least to
+  `dashboard:read`
+
+## Steps
+
+1. If `dashboard_id` is given, call `dashboard-get` for that ID
+2. Otherwise, call `dashboards-get-all` to list every dashboard in the
+   project
+3. Report dashboard name, ID, and (when retrieving a single dashboard) its
+   insight tiles
+4. Note each insight tile's "as of" timestamp rather than presenting the
+   numbers as live — see `skills/insights-and-dashboards/SKILL.md`
+
+## Examples
+
+### List all dashboards
+
+```
+/list-dashboards
+```
+
+### Retrieve a specific dashboard
+
+```
+/list-dashboards 12345
+```
+
+## Error Handling
+
+| Error | Resolution |
+|-------|------------|
+| 404 Not Found | No dashboard exists with that ID in this project |
+| 403 Forbidden | The connected key isn't scoped for `dashboard:read` |
+| 429 Rate Limited | Back off and retry — see `skills/api-patterns/SKILL.md` |
+
+## Related Commands
+
+- `/check-insight` — Look up a single insight's result directly

--- a/msp-claude-plugins/posthog/posthog/commands/list-feature-flags.md
+++ b/msp-claude-plugins/posthog/posthog/commands/list-feature-flags.md
@@ -1,0 +1,56 @@
+---
+description: List PostHog early-access feature flags and their current status
+argument-hint: "[query]"
+arguments: [query]
+---
+
+# List PostHog Feature Flags
+
+List early-access feature flags in the connected PostHog project, with an
+optional name filter.
+
+## Arguments
+
+- `query` (optional) — Filter by feature name; omit to list all
+
+## Prerequisites
+
+- PostHog connected in Conduit with a personal API key scoped at least to
+  `feature_flag:read`
+
+## Steps
+
+1. Call `early-access-feature-list`, filtering by `query` if provided
+2. For each match, call `early-access-feature-retrieve` if targeting or
+   status detail is needed beyond the list view
+3. Report name, status, and targeting/rollout summary for each result
+4. This command is read-only — it never calls `early-access-feature-create`,
+   `early-access-feature-destroy`, or `early-access-feature-partial-update`.
+   If the user asks to change a flag's status, say that this plugin can't do
+   that and point to `GOVERNANCE.md` for why
+
+## Examples
+
+### List all early-access features
+
+```
+/list-feature-flags
+```
+
+### Filter by name
+
+```
+/list-feature-flags "dark mode"
+```
+
+## Error Handling
+
+| Error | Resolution |
+|-------|------------|
+| 403 Forbidden | The connected key isn't scoped for `feature_flag:read` |
+| 404 Not Found | No feature matches the given query — confirm spelling or list without a filter |
+| 429 Rate Limited | Back off and retry — see `skills/api-patterns/SKILL.md` |
+
+## Related Commands
+
+- `/check-insight` — Look up the metric an experiment is measuring

--- a/msp-claude-plugins/posthog/posthog/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/posthog/posthog/skills/api-patterns/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: "PostHog API Patterns"
+description: >
+  PostHog API fundamentals for this plugin: personal API key auth brokered
+  through Conduit (no local key), the resource:action scope model, generic
+  REST error handling, and why this plugin's read-only posture is a
+  two-layer control rather than a single enforced boundary.
+when_to_use: >-
+  When authenticating to PostHog, reasoning about key scopes, or debugging
+  errors or rate limiting from the PostHog MCP server. Use when: posthog
+  api, posthog auth, posthog authentication, posthog personal api key,
+  posthog scope, posthog rate limit, or posthog error.
+---
+
+# PostHog API Patterns
+
+## Overview
+
+PostHog's API is REST/JSON, reached here through PostHog's own MCP server
+via the WYRE Conduit gateway. This skill covers the mechanics that aren't
+guessable from the resource names: how auth is brokered, how PostHog's key
+scoping actually enforces (or fails to enforce) this plugin's read-only
+posture, and generic error handling.
+
+## Anti-triggers
+
+- **What a specific resource's fields or tool names are** — use
+  `insights-and-dashboards`, `feature-flags-and-experiments`, or
+  `cohorts-and-events`.
+- **Why this plugin excludes write tools** — that's a governance question,
+  not an API-mechanics one; see
+  [GOVERNANCE.md](../../GOVERNANCE.md).
+
+## Connection & Authentication
+
+This plugin does not accept a local PostHog credential. The operator
+connects a PostHog **personal API key** once, in Conduit's connect UI
+(**Connections → PostHog**); Conduit stores it and injects it into every
+upstream request server-side. This plugin's `.mcp.json` declares no headers
+and no environment variables — there is nothing to configure on the client.
+
+```json
+{
+  "mcpServers": {
+    "posthog": {
+      "type": "http",
+      "url": "https://conduit.wyre.ai/v1/posthog/mcp"
+    }
+  }
+}
+```
+
+## The resource:action Scope Model
+
+PostHog personal API keys carry their own permission model, independent of
+whatever Conduit grants. Each key is scoped to specific `resource:action`
+pairs at creation — for example `insight:read`, `feature_flag:read`,
+`dashboard:read`. A key minted with only read-side scopes cannot be used
+for a write call; PostHog's own API rejects it before the request reaches
+this plugin's logic at all.
+
+**This is the primary reason this plugin can claim to be read-only**, and
+it is also the primary gap: PostHog does not narrow a key's scopes by
+default, so a key minted without deliberately restricting scopes is
+read-write. Setup for this plugin depends on whoever connects PostHog to
+Conduit having scoped the key correctly — see
+[GOVERNANCE.md](../../GOVERNANCE.md), *The scope decision happens outside
+Conduit, at key creation*.
+
+The second, independent layer is Conduit's own gateway-side tool allowlist
+for this vendor, which should also exclude write/mutating tool names as
+defense-in-depth — but that allowlist is a Conduit configuration, not
+something the PostHog key itself enforces. Neither layer alone is a hard
+guarantee; both together are how this plugin's read-only claim actually
+holds.
+
+## Error Handling
+
+Standard REST conventions apply; PostHog does not layer a nonstandard error
+shape on top of them for the tool families this plugin uses:
+
+| Code | Meaning | Action |
+|------|---------|--------|
+| 400 | Bad request | Check the tool's arguments against the target resource |
+| 401 | Unauthorized | The connected personal API key is invalid or was revoked — reconnect in Conduit |
+| 403 | Forbidden | The key's scopes don't cover the tool being called, or it belongs to the wrong PostHog organization |
+| 404 | Not found | The referenced insight, dashboard, flag, cohort, or event doesn't exist in this project |
+| 429 | Rate limited | Back off and retry; see *Rate Limiting* below |
+| 5xx | Server error | Retry with backoff |
+
+## Rate Limiting
+
+This plugin does not hardcode PostHog's rate-limit thresholds — they are
+not part of the confirmed facts behind this plugin and are subject to
+change on PostHog's side. Consult
+[PostHog's API documentation](https://posthog.com/docs/api) for current
+limits. Treat a `429` the same as any REST API: honor a `Retry-After`
+header if present, back off, and prefer bounded, targeted queries (a named
+insight or dashboard, a date-bounded event query) over broad unbounded
+pulls, which are the fastest way to hit a limit during a sweep across
+multiple clients.
+
+## Gotchas
+
+- **Read-only here is a two-layer convention, not a single enforced
+  boundary.** Both the key's scopes and Conduit's tool allowlist have to be
+  configured correctly for this plugin's read-only posture to actually
+  hold. See [GOVERNANCE.md](../../GOVERNANCE.md).
+- **`posthog` is not yet classified in Conduit's `VENDOR_TOOL_CONFIG`.**
+  Until it is, there is no coarse `read` tier grant that admits only this
+  plugin's read families — access has to go through the gateway allowlist.
+  See [GOVERNANCE.md](../../GOVERNANCE.md), *Tool permission tiers*, and
+  `wyre-gateway/GOVERNANCE.md` for the mechanism this depends on.
+- **A key from the wrong PostHog organization doesn't error — it just
+  returns that org's data.** If results look implausibly empty or
+  unfamiliar, check which organization the connected key actually belongs
+  to before assuming the resource doesn't exist.
+
+## Related Skills
+
+- [Insights & Dashboards](../insights-and-dashboards/SKILL.md) — Insight and dashboard retrieval
+- [Feature Flags & Experiments](../feature-flags-and-experiments/SKILL.md) — Flag and experiment status
+- [Cohorts & Events](../cohorts-and-events/SKILL.md) — Segment and event lookups

--- a/msp-claude-plugins/posthog/posthog/skills/cohorts-and-events/SKILL.md
+++ b/msp-claude-plugins/posthog/posthog/skills/cohorts-and-events/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: "PostHog Cohorts & Events"
+description: >
+  PostHog cohorts (saved user/group segments), raw analytics events, and
+  timeline annotations. Read-only lookups — listing and retrieving existing
+  records, not defining new segments or emitting events.
+when_to_use: >-
+  When looking up a saved user segment, raw event activity, or a timeline
+  annotation in PostHog. Use when: posthog cohort, posthog event, posthog
+  annotation, user segment, event query, cohort membership, or deploy
+  marker.
+---
+
+# PostHog Cohorts & Events
+
+## Overview
+
+A cohort is a saved segment of users or groups — static (a fixed list) or
+dynamic (defined by a rule that PostHog re-evaluates). Events are the raw
+analytics stream: every tracked interaction, tied to a person or
+`distinct_id`, carrying whatever properties the client's application sent.
+Annotations are timestamped notes on a project's timeline — deploys,
+incidents, config changes — used to explain a shift in a metric. This skill
+covers looking these up, not defining them.
+
+## Anti-triggers
+
+- **Aggregated trend or funnel analysis** — don't hand-aggregate raw events
+  into a trend; use `insights-and-dashboards`, which is what PostHog's own
+  computed insights are for.
+- **Feature-flag targeting rules** — a cohort can target a flag, but this
+  skill only covers listing and retrieving cohorts and events themselves;
+  use `feature-flags-and-experiments` for what a flag or experiment is
+  configured to target.
+- **Auth, scopes, or rate-limit behavior** — use `api-patterns`.
+
+## Core Concepts
+
+Cohorts group people or groups by shared property or behavior. Events carry
+an event name, a `distinct_id`, a timestamp, and a properties payload whose
+shape depends entirely on what the client's application instruments —
+PostHog imposes no fixed schema on event properties. Annotations are
+lightweight, timestamped, and scoped to a project (or a specific insight),
+and exist specifically so a human reviewing a metric later can see "what
+changed here."
+
+## API Patterns
+
+The confirmed read tool family for this domain:
+
+- Cohorts: list, retrieve
+- Events / Annotations: list, retrieve
+
+This plugin exposes only these read tools; there is no cohort-definition,
+event-ingestion, or annotation-authoring tool in this plugin's surface.
+PostHog's own docs carry the exhaustive tool catalog:
+[posthog.com/docs/model-context-protocol/tools](https://posthog.com/docs/model-context-protocol/tools).
+
+## Common Workflows
+
+### SOC analyst checking recent error events for a client's app
+
+1. List events scoped to the relevant event name (e.g. an error or
+   exception event the client's app emits) and a bounded, recent date range
+2. Retrieve individual events for detail if a pattern needs closer
+   inspection
+3. Cross-reference against `insights-and-dashboards` if the client already
+   has an error-tracking dashboard — don't re-derive a trend PostHog has
+   already computed
+
+### vCIO correlating a reported slowdown with a recent deploy
+
+1. List annotations on the relevant project or insight for the reported
+   time window
+2. Match a deploy or config-change annotation against the metric shift the
+   client is asking about
+3. Report the correlation, not a causal claim — this skill surfaces
+   timeline markers, it doesn't establish root cause
+
+### Confirming a specific user's cohort membership before escalating a bug
+
+1. Retrieve the cohort in question
+2. Check whether the reported user/`distinct_id` matches the cohort's
+   current membership
+3. Note that dynamic cohorts re-evaluate — membership can have changed
+   since the client last checked
+
+## Gotchas
+
+- **Event properties may carry PII.** Whether an event contains emails,
+  user IDs, or other identifying data depends entirely on what the client's
+  application sends — this plugin has no way to know in advance. Treat
+  event and cohort output as potentially sensitive by default; see
+  [GOVERNANCE.md](../../GOVERNANCE.md), *Data handling*.
+- **Bound event queries by date.** Event volume in an active project can be
+  large; an unbounded pull is a way to exhaust rate limits and return more
+  data than the question needs.
+- **Dynamic cohort membership is a moving target.** A cohort defined by a
+  rule re-evaluates over time — "who's in this cohort" answered now may not
+  match what it was when an incident happened.
+
+## Related Skills
+
+- [Insights & Dashboards](../insights-and-dashboards/SKILL.md) — Computed trends and funnels
+- [Feature Flags & Experiments](../feature-flags-and-experiments/SKILL.md) — What a cohort targets
+- [API Patterns](../api-patterns/SKILL.md) — Auth, scopes, and error handling

--- a/msp-claude-plugins/posthog/posthog/skills/feature-flags-and-experiments/SKILL.md
+++ b/msp-claude-plugins/posthog/posthog/skills/feature-flags-and-experiments/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: "PostHog Feature Flags & Experiments"
+description: >
+  Read-only lookups of PostHog early-access feature flags and experiments —
+  rollout status, targeting, and configuration. Does not create, update, or
+  delete flags or experiments.
+when_to_use: >-
+  When checking whether a feature flag or early-access feature is live for
+  a client, or reviewing an experiment's configuration. Use when: posthog
+  feature flag, posthog experiment, early access feature, rollout
+  percentage, flag status, feature flag targeting, or a/b test status.
+---
+
+# PostHog Feature Flags & Experiments
+
+## Overview
+
+Feature flags gate whether a piece of code runs for a given user or
+percentage of traffic. Early-access features are PostHog's primitive for
+managing a beta opt-in program — customers who've asked to try something
+before general availability. Experiments run a controlled comparison
+between variants of a flag against a primary metric. For an MSP, the
+recurring question this skill answers is "is this feature actually live
+for this client" or "what is this experiment currently testing" — not
+turning either on or off.
+
+## Anti-triggers
+
+- **Creating, updating, or deleting a feature flag, early-access feature,
+  or experiment** — this skill and this plugin are read-only. See
+  [GOVERNANCE.md](../../GOVERNANCE.md), *Tool permission tiers*: feature-flag
+  mutations change what code path a live client's production application
+  executes, immediately and with no built-in dry run, which is exactly why
+  this plugin excludes them at v1. Make the change directly in the PostHog
+  UI, with the same care you'd give any production config change.
+- **Product usage or error-rate trends** — use `insights-and-dashboards`.
+- **Which users are in a targeting cohort** — the cohort itself lives in
+  `cohorts-and-events`; this skill only reports what a flag or experiment
+  is configured to target.
+
+## Core Concepts
+
+A feature flag has a key, a rollout condition (percentage, specific users,
+or property-based targeting), and an enabled/disabled state per condition
+group. Early-access features are a distinct PostHog primitive layered on
+top of flags, purpose-built for beta programs — a user opts in, and that
+opt-in maps to a flag being active for them. Experiments attach two or more
+flag variants to a primary metric and report which variant is winning.
+
+## API Patterns
+
+The confirmed read tool family for this domain:
+
+- `early-access-feature-list` — list early-access features and their status
+- `early-access-feature-retrieve` — retrieve a single early-access feature
+
+Both are read-only; the corresponding write tools
+(`early-access-feature-create`, `early-access-feature-destroy`,
+`early-access-feature-partial-update`) and general feature-flag CRUD are
+excluded from this plugin — see
+[GOVERNANCE.md](../../GOVERNANCE.md). Experiment lookups (list/get) follow
+the same read-only pattern. PostHog's own docs carry the exhaustive tool
+catalog, including the broader feature-flag API this plugin does not
+expose:
+[posthog.com/docs/model-context-protocol/tools](https://posthog.com/docs/model-context-protocol/tools).
+
+## Common Workflows
+
+### Confirming a feature is live before a client escalation
+
+A client asks why a beta feature isn't showing up for one of their users:
+
+1. `early-access-feature-list` to find the feature by name
+2. `early-access-feature-retrieve` to check its current status and
+   targeting configuration
+3. Report what's configured — if the fix requires changing rollout
+   percentage or targeting, that's a write action outside this plugin's
+   surface; hand it to a human with the appropriate PostHog access
+
+### Reviewing active experiments ahead of a QBR
+
+1. List current experiments and their status
+2. Pull each experiment's configuration (variants, primary metric) via the
+   read tool
+3. Summarize what's actively being tested for the client-facing report —
+   experiment results themselves are analytics data, so cross-reference
+   with `insights-and-dashboards` if the QBR needs the metric outcome, not
+   just the configuration
+
+## Gotchas
+
+- **Read-only surface, no exceptions.** Even an emergency flag toggle
+  (killing a broken feature) is outside this plugin. Escalate to a human
+  with direct PostHog access rather than looking for a workaround tool.
+- **"Feature flags" and "early-access features" overlap in name, not in
+  tool surface.** The confirmed read tools here are specifically the
+  early-access-feature family. PostHog's general feature-flag API has its
+  own tools, documented separately — don't assume a flag question is
+  automatically answerable through the early-access tools.
+- **A flag or experiment's targeting rules don't tell you who's actually in
+  them right now** — that's a cohort or event-level question; see
+  `cohorts-and-events`.
+
+## Related Skills
+
+- [Insights & Dashboards](../insights-and-dashboards/SKILL.md) — Metric outcomes, including experiment results
+- [Cohorts & Events](../cohorts-and-events/SKILL.md) — Who is actually targeted
+- [API Patterns](../api-patterns/SKILL.md) — Auth, scopes, and error handling

--- a/msp-claude-plugins/posthog/posthog/skills/insights-and-dashboards/SKILL.md
+++ b/msp-claude-plugins/posthog/posthog/skills/insights-and-dashboards/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: "PostHog Insights & Dashboards"
+description: >
+  PostHog saved insights (trends, funnels, retention, and similar analytics
+  queries) and the dashboards that group them into a single view. Read-only:
+  running and retrieving existing insights and dashboards, not authoring
+  them.
+when_to_use: >-
+  When looking up product-analytics results, usage trends, error-rate
+  trends, or dashboard contents in PostHog. Use when: posthog insight,
+  posthog dashboard, product analytics, usage trends, error tracking,
+  weekly active users, funnel, retention, QBR dashboard, or analytics
+  review.
+---
+
+# PostHog Insights & Dashboards
+
+## Overview
+
+An insight is a saved analytics query in PostHog — a trend, funnel,
+retention curve, or similar chart — that PostHog computes on demand. A
+dashboard groups several insights into one view, typically the thing a
+client-facing analyst screenshots for a report. For an MSP, this is the
+surface for answering "how is the client's product actually being used" and
+"is the error rate climbing" without opening PostHog directly.
+
+This skill is read-only: it retrieves insights and dashboards that already
+exist. It cannot create, edit, or delete either.
+
+## Anti-triggers
+
+- **Creating, editing, or deleting an insight or dashboard** — this plugin
+  ships read-only at v1 by design; see
+  [GOVERNANCE.md](../../GOVERNANCE.md), *Tool permission tiers*, for why.
+  Build or change the insight in the PostHog UI directly.
+- **Feature flag or experiment status** — use
+  `feature-flags-and-experiments`.
+- **Raw event or cohort lookups** — use `cohorts-and-events`.
+- **Auth, key scopes, or rate-limit behavior** — use `api-patterns`.
+
+## Core Concepts
+
+Insights come in several types — trends (metrics over time), funnels
+(step-by-step conversion), retention (cohort return behavior), paths, and
+others — each computed against the project's event stream. A dashboard is
+an ordered collection of insights with its own name and description; the
+same insight can appear on more than one dashboard.
+
+Insight results can be served from a cached computation rather than
+recomputed on every request. Treat a result's timestamp as "as of," not as
+"live right now" — for a fast-moving metric during an incident, re-run the
+underlying query rather than trusting a cached dashboard tile.
+
+## API Patterns
+
+The confirmed read tool family for this domain:
+
+- `dashboard-get` — retrieve a single dashboard by ID
+- `dashboards-get-all` — list dashboards in the connected project
+- Insight run/read — execute or retrieve the result of a saved insight
+
+This plugin exposes only these read tools. PostHog's own docs carry the
+exhaustive, versioned tool catalog:
+[posthog.com/docs/model-context-protocol/tools](https://posthog.com/docs/model-context-protocol/tools).
+
+## Common Workflows
+
+### SOC analyst checking error-tracking before an escalation
+
+A client reports intermittent failures. Before opening an incident:
+
+1. `dashboards-get-all` to find the client's error-tracking or
+   observability dashboard
+2. `dashboard-get` on that dashboard to pull its current insight tiles
+3. Run the relevant error-rate insight directly if the dashboard tile looks
+   stale, and compare against the incident's reported timeframe
+
+### vCIO pulling usage trends for a QBR
+
+Ahead of a quarterly business review, pull the metrics that support a
+renewal or expansion conversation:
+
+1. `dashboards-get-all` to locate the client's product-usage or adoption
+   dashboard
+2. `dashboard-get` to retrieve its insights
+3. Summarize month-over-month trend direction for the metrics the QBR deck
+   needs — active users, feature adoption, retention — rather than dumping
+   raw numbers
+
+### Post-deployment health check
+
+After a client ships a release, confirm nothing regressed:
+
+1. Retrieve the insight or dashboard tracking the release's target metric
+   (error rate, conversion, latency-adjacent proxy metrics PostHog tracks)
+2. Compare the post-release window against the prior period
+3. Flag anything outside the client's normal variance for human follow-up
+   — this skill reports, it does not remediate
+
+## Gotchas
+
+- **Read-only surface.** There is no tool here to create or update an
+  insight or dashboard, even to fix an obviously broken one.
+- **Cached results can lag.** A dashboard tile's "last computed" time may
+  be older than the question being asked; re-run the insight directly when
+  recency matters.
+- **Large projects have many dashboards.** Prefer a targeted lookup by name
+  or ID over listing everything and scanning — `dashboards-get-all` returns
+  every dashboard in the project, not just the relevant one.
+
+## Related Skills
+
+- [Feature Flags & Experiments](../feature-flags-and-experiments/SKILL.md) — Flag and experiment status
+- [Cohorts & Events](../cohorts-and-events/SKILL.md) — Raw event and segment lookups
+- [API Patterns](../api-patterns/SKILL.md) — Auth, scopes, and error handling


### PR DESCRIPTION
## Summary
- Packages PostHog product analytics as a Conduit-routed plugin: insights, dashboards, feature-flag/experiment status (read-only), cohorts, events, business-knowledge search.
- Companion to `wyre-technology/conduit#1353` (PostHog vendor wiring) — per `deliverables/2026-08-12-productivity-mcp-eval.md` and `deliverables/2026-08-12-posthog-netsuite-mcp-scoping.md` in the forge agent repo (Aaron-approved 2026-08-12).
- **Read-only at v1 by explicit decision, not API limitation** — PostHog's official MCP exposes 200+ tools with extensive write coverage, including tools with real external side effects (`conversations-tickets-reply-create` posts an actual support-ticket reply; feature-flag mutations affect a live client's production app; `alert-simulate`/`llma-*` job-creation tools can incur real spend).
- `GOVERNANCE.md` documents the two-layer read-only control honestly: the customer's PostHog personal API key should be scoped read-only at creation (PostHog's own `resource:action` model), with Conduit's gateway-side tool allowlist as defense-in-depth — and states plainly that Conduit doesn't verify key scopes today, so the read-only posture isn't a hard boundary if either layer is misconfigured. Matches the existing not-yet-classified-in-`VENDOR_TOOL_CONFIG` honesty pattern from Xero/Freshdesk/N-central's docs.
- `.mcp.json` routes through Conduit's own gateway (`v1/posthog/mcp`), matching the newer-vendor plugin pattern (not the older direct-vendor pattern some finance plugins use).
- Registered under the existing `productivity` category — no new category invented.
- Internal fast-track build (Aaron directive), not run through the standard Tier-3 community PRD process — noted explicitly in the README.

## Test plan
- [x] `node scripts/check-marketplace-drift.mjs` — passes (77 entries)
- [x] `node scripts/check-doc-references.mjs` — passes (1526 references resolve)
- [x] `python3 -m json.tool` on `marketplace.json` and `.mcp.json` — valid
- [x] `claude plugin validate .` (marketplace root) and `claude plugin validate msp-claude-plugins/posthog/posthog` — both pass
- [x] All 4 `SKILL.md` files under the ~350-line quality-checklist ceiling (106–123 lines each)
- [ ] Live end-to-end verification (a real read-only PostHog key connected through Conduit, tool calls actually returning data) — blocked on `conduit#1353` merging and deploying first

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/msp-claude-plugins/pr/214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->