### PR TITLE
feat(netsuite): add read-only NetSuite ERP plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -390,6 +390,19 @@
       ]
     },
     {
+      "name": "netsuite",
+      "source": "./msp-claude-plugins/netsuite/netsuite",
+      "description": "Oracle NetSuite ERP - records, reports, saved searches, and SuiteQL queries (read-only)",
+      "category": "accounting",
+      "tags": [
+        "netsuite",
+        "accounting",
+        "erp",
+        "read-only",
+        "msp"
+      ]
+    },
+    {
       "name": "quickbooks-online",
       "source": "./msp-claude-plugins/quickbooks/quickbooks-online",
       "description": "QuickBooks Online - customers, invoices, expenses, payments, reports",

--- a/msp-claude-plugins/netsuite/netsuite/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/netsuite/netsuite/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "netsuite",
+  "version": "0.1.0",
+  "description": "Claude plugin for Oracle NetSuite ERP — records, reports, saved searches, and SuiteQL queries (read-only)",
+  "author": {
+    "name": "MSP Claude Plugins Community"
+  },
+  "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
+  "repository": "https://github.com/wyre-technology/msp-claude-plugins",
+  "license": "Apache-2.0"
+}

--- a/msp-claude-plugins/netsuite/netsuite/.mcp.json
+++ b/msp-claude-plugins/netsuite/netsuite/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "netsuite": {
+      "type": "http",
+      "url": "https://conduit.wyre.ai/v1/netsuite/mcp"
+    }
+  }
+}

--- a/msp-claude-plugins/netsuite/netsuite/GOVERNANCE.md
+++ b/msp-claude-plugins/netsuite/netsuite/GOVERNANCE.md
@@ -1,0 +1,296 @@
+# NetSuite plugin — governance and safety model
+
+Unofficial. Community-built plugin for the Oracle NetSuite ERP platform.
+Not affiliated with, endorsed by, or sponsored by Oracle or NetSuite.
+
+## What it connects as
+
+This plugin does not hold credentials. It reaches NetSuite through the WYRE
+Conduit gateway (`https://conduit.wyre.ai/v1/netsuite/mcp`), which brokers
+authentication centrally, per NetSuite account.
+
+- **NetSuite is per-tenant, vendor-hosted MCP — not a central hosted
+  endpoint.** Unlike PostHog (one shared PostHog-operated MCP server for
+  every customer), each NetSuite customer's own NetSuite account runs its
+  own MCP endpoint via the installed **MCP Standard Tools SuiteApp**:
+  `https://<accountId>.suitetalk.api.netsuite.com/services/mcp/v1/suiteapp/com.netsuite.mcpstandardtools`.
+  Conduit resolves the correct per-tenant endpoint server-side; this
+  plugin's `.mcp.json` still just points at Conduit's own fixed gateway
+  URL, the same broker pattern as every other Conduit vendor.
+- **Auth is machine-to-machine, not interactive.** NetSuite is connected
+  via **OAuth 2.0 Client Credentials Grant with a JWT-bearer client
+  assertion** — no browser redirect or user-consent screen ever happens.
+  Conduit mints and caches the bearer token server-side per organization
+  (via a `bearerTokenCache`), the same way it already does for HaloPSA. The
+  token is obtained from
+  `https://<accountId>.suitetalk.api.netsuite.com/services/rest/auth/oauth2/v1/token`,
+  again resolved per-tenant by Conduit.
+- No NetSuite credential — not the Client ID, not the Certificate ID, not
+  the private key — is stored on the technician's machine, in this repo, or
+  in the model's context. All four are entered once in Conduit's connect
+  page and used server-side to mint tokens; this plugin's `.mcp.json`
+  declares no headers and no environment variables for the client to set.
+- The org's NetSuite credential is stored once at the gateway, so replacing
+  it (e.g. after a certificate rotation) is one edit rather than a change on
+  every technician's machine.
+- Every call carries operator identity, so the gateway audit log answers
+  "who pulled this record." NetSuite's own system notes/audit trail
+  attributes API activity to the integration role's user, which is fine for
+  a single dedicated integration user but says nothing about which agent or
+  session made the call.
+- Removing someone from the organisation clears their per-vendor grants and
+  revokes their gateway refresh tokens at once; a user deactivated in your
+  identity provider is refused on their very next request. See
+  `wyre-gateway/GOVERNANCE.md`.
+
+## Customer-side setup is heavier than a typical API-key vendor
+
+Before Conduit can connect a given client's NetSuite account, that client's
+NetSuite administrator has to do real configuration work inside NetSuite —
+this is not a "paste an API key" integration:
+
+1. Enable **Server SuiteScript**, **REST Web Services**, and the OAuth 2.0
+   feature (Setup > Company > Enable Features, SuiteCloud subtab).
+2. Install the **MCP Standard Tools SuiteApp** (SuiteApps tab > search "MCP
+   Standard Tools" > Install).
+3. Create a dedicated custom role carrying the **MCP Server Connection**
+   permission and the **Log in using OAuth 2.0 Access Tokens** permission
+   (Setup subtab on the role record) — **view-only**, per this plugin's
+   read-only decision (see *Tool permission tiers* below). Oracle
+   explicitly disallows using the Administrator role for this connection.
+4. Create an Integration record with **Client Credentials Grant** enabled,
+   which yields an OAuth 2.0 **Client ID**.
+5. Generate or upload a certificate under Setup > Integration > OAuth 2.0
+   Client Credentials Setup, mapping Entity (the dedicated integration
+   user) + Role (the custom role from step 3) + Application (the
+   integration record from step 4) + Certificate, which yields a
+   **Certificate ID** — keeping the matching **PKCS8 private key** (PEM).
+
+Conduit's connect step for this plugin needs exactly four values, matching
+its `netsuite` vendor-config fields: **NetSuite Account ID**, **OAuth 2.0
+Client ID**, **Certificate ID**, and the **PKCS8 private key (PEM)**. There
+is no fifth field and no simpler path — a NetSuite admin who has not done
+steps 1-5 above cannot be connected through this plugin.
+
+## Tool permission tiers
+
+> **`netsuite` has no entry in `VENDOR_TOOL_CONFIG` — this is a new vendor
+> connector.** Conduit derives a tool's tier from `VENDOR_TOOL_CONFIG`
+> (`src/proxy/result-cache.ts`) and fails closed:
+> `const requiredTier: PermissionTier = classified ?? 'admin';`
+> (`src/access/access-enforcement.ts:63`). Until `netsuite` is classified
+> there, the grouping below carries no tier-enforcement meaning at all on
+> the Conduit side — a `read` or `write` grant on this vendor admits
+> nothing, and an `admin` grant admits every tool the upstream MCP server
+> exposes, including the two write tools this plugin deliberately does not
+> document or recommend. For the live list of unclassified vendors see
+> `wyre-gateway/GOVERNANCE.md`, *Fail-closed, and the vendors Conduit has
+> not classified*. Classifying a vendor is always a privilege *reduction*,
+> never an expansion.
+>
+> Because tiering does nothing for this vendor yet on the Conduit side, the
+> operational enforcement for "read-only at v1" is **NetSuite's own native
+> role-based access control** (see below), reinforced by a gateway-side
+> tool allowlist (a `customTools` grant naming only the read-tool families
+> below) as defense-in-depth. Configure the allowlist when connecting this
+> plugin — an `admin` grant with no allowlist restores the full upstream
+> surface, including the two write tools this document excludes.
+
+The **MCP Standard Tools SuiteApp** exposes a confirmed catalog of 14
+tools, documented by Oracle at
+[Available Tools in the MCP Standard Tools SuiteApp](https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/article_0902023508.html).
+Twelve are read tools; two — `ns_createRecord` and `ns_updateRecord` — are
+write tools that create or modify NetSuite records.
+
+**This plugin ships read-only at v1 by explicit decision (Aaron/founder
+sign-off, 2026-08-12) — adopted alongside PostHog in the same review.**
+NetSuite's write surface is much smaller than PostHog's (2 tools, not
+200+), but the two write tools reach the same category of hazard: creating
+or updating a financial/ERP record (a customer, vendor, invoice, sales
+order, journal entry — whatever the connected role can reach) is a real,
+often hard-to-cleanly-reverse change to a client's books of record, made
+under the operator's or agent's identity with no built-in dry run.
+
+| Tier | What it can do | Tools |
+|---|---|---|
+| **Read** | Cannot change NetSuite state. The only tier this plugin grants, documents, or recommends. | See the family table below. |
+| **Write** | **Not shipped in v1.** Creates or updates NetSuite records. | `ns_createRecord`, `ns_updateRecord` — deliberately excluded. Not granted, not documented per-call, not part of any bundled command or skill. |
+
+### How read-only is actually enforced here — and how it differs from PostHog
+
+**This is a fundamentally different mechanism than PostHog's, and it is
+stronger.** PostHog's read-only posture depends on the *customer*
+voluntarily scoping their personal API key to read-only `resource:action`
+pairs at key-creation time — an honor-system convention Conduit cannot
+verify. NetSuite's read-only posture instead rests on **NetSuite's own
+native RBAC**, enforced by the NetSuite platform itself, not by this
+plugin or by Conduit:
+
+- The custom role created in step 3 above (commonly named something like
+  "MCP Server Connection" role) can be granted **view-only** permissions on
+  every record type it touches, with no create/update/delete grants at
+  all.
+- If the connecting integration role has no write permission on a record
+  type, NetSuite itself refuses `ns_createRecord` / `ns_updateRecord` calls
+  against that type **at the platform level** — the SuiteApp's own docs
+  state it "uses the same access controls as the NetSuite UI, so you can
+  only see data and take actions allowed by your assigned roles." That
+  refusal happens inside NetSuite, before any response reaches Conduit or
+  this plugin.
+- `ns_runCustomSuiteQL` is documented by Oracle as accepting **read-only
+  queries only** — it is not a general SQL-execution tool, so it cannot be
+  used to work around the role's write restriction even by an operator who
+  wanted to.
+
+**This plugin does not verify that the connecting admin actually
+provisioned a view-only role — that is a setup instruction, not something
+Conduit or this plugin inspects after the fact.** Say this plainly: if the
+client's NetSuite admin instead grants the dedicated role full CRUD
+permissions on some or all record types (a role misconfiguration, or a
+shortcut taken during setup), NetSuite itself will honor
+`ns_createRecord` / `ns_updateRecord` calls against those types, and this
+plugin's "read-only" framing becomes aspirational documentation, not an
+enforced boundary — exactly the same shape of gap PostHog's GOVERNANCE.md
+describes for its own key-scoping convention, just enforced by NetSuite
+role permissions instead of PostHog API key scopes. See *Open enforcement
+gap* below.
+
+### The read-only tool families this plugin grants
+
+| Family | Read tools |
+|---|---|
+| Records | `ns_getRecord`, `ns_getRecordTypeMetadata` (`ns_createRecord`, `ns_updateRecord` excluded — see above) |
+| Reports | `ns_listAllReports`, `ns_runReport`, plus filter-lookup helpers `ns_getAccountingBooks`, `ns_getAccountingContexts`, `ns_getNexusIds`, `ns_getSubsidiaries` |
+| Saved Searches | `ns_listSavedSearches`, `ns_runSavedSearch` |
+| SuiteQL | `ns_runCustomSuiteQL` (read-only queries only, per Oracle's own documentation), `ns_getSuiteQLMetadata` |
+
+This is the complete 12-tool read surface Oracle documents for the MCP
+Standard Tools SuiteApp as of this writing — not a subset. The full
+14-tool catalog (including the 2 excluded write tools) is documented at
+the Oracle link above.
+
+**Conduit does not enforce per-call approval.** It compares tiers and,
+where configured, checks the tool allowlist — there is no approval step,
+no per-call confirmation, and no interactive prompt anywhere in its
+enforcement path. The read-only posture above is a combination of (1) the
+connected role's NetSuite permissions and (2) the gateway allowlist;
+nothing in Conduit stops a misconfigured role or grant from reaching a
+write tool if either of those is set up wrong.
+
+## Recommended agent policy
+
+Because this plugin ships no write surface, **read tools are safe to grant
+to autonomous and scheduled agents** — record lookups, saved-search runs,
+report pulls, and SuiteQL queries are the intended unattended use. Grant
+them through the gateway allowlist naming the read families above; do not
+grant `admin` on this vendor, because `admin` reaches the full upstream
+surface including `ns_createRecord` and `ns_updateRecord`.
+
+There is no write tier to propose-then-approve here, unlike Xero or
+Freshdesk. If a future version of this plugin adds write tools, that
+version needs its own agent-policy section — do not assume the read-only
+recommendation above still holds once this document is updated to grant a
+write tier.
+
+## What it cannot reach
+
+- Only the NetSuite account the connected Integration record and role
+  belong to. NetSuite accounts are fully separate tenants; there is no
+  cross-account visibility through this plugin.
+- Only the record types, fields, reports, and saved searches the connected
+  role's NetSuite permissions actually cover — **if the role was granted
+  broader visibility than intended, this plugin surfaces whatever that role
+  can see, not a narrower plugin-defined subset.** See *How read-only is
+  actually enforced here* above.
+- No write path of any kind, in the tools this plugin grants or documents —
+  see *Tool permission tiers*.
+- No filesystem, no shell, no other vendor's data.
+- No SuiteScript execution, no workflow or script deployment, and nothing
+  outside the confirmed 12-tool read surface above — this plugin's skills
+  and commands are built only against tools Oracle documents as existing
+  today.
+
+## Data handling
+
+Responses pass through the gateway into model context for the session and
+are not persisted by this plugin.
+
+- **Financial and ERP data by definition.** NetSuite is a client's books of
+  record — customers, vendors, transactions, invoices, journal entries,
+  and financial reports are exactly the kind of commercially sensitive data
+  this plugin can surface. Treat every record, report, and SuiteQL result
+  as sensitive by default.
+- **SuiteQL query results depend entirely on what the connected role can
+  see and what the query asks for.** A broadly-scoped role plus a broad
+  query can return far more than the question needed; prefer targeted
+  queries and bounded result sets.
+- **Saved searches and reports may already carry PII** — customer contact
+  details, employee data on HR-adjacent record types, and similar —
+  depending on what the client's own NetSuite configuration exposes. This
+  plugin has no way to know in advance whether a given account's data is
+  PII-clean.
+
+Restrict the record, report, and SuiteQL tools specifically if agents run
+unattended or render output where anyone outside the client's own team
+could see it.
+
+## Open enforcement gap (tracked, not resolved by this plugin)
+
+**"Read-only" for this vendor rests on two operator-configured layers, and
+neither is enforced automatically by this plugin today:**
+
+1. The dedicated NetSuite integration role must be provisioned view-only —
+   no create/update/delete permissions on any record type it can reach
+   (see *How read-only is actually enforced here* above). This is a setup
+   instruction given to the client's NetSuite admin; this plugin has no way
+   to inspect the role's actual permission grants after the fact.
+2. The connection should also use a gateway-side `customTools` allowlist
+   naming only the read families in this document, not an `admin` grant —
+   Conduit has no `VENDOR_TOOL_CONFIG` entry for `netsuite` yet, so there
+   is no coarse `read` tier to fall back on if the allowlist is skipped or
+   misconfigured.
+
+**Neither layer is a hard boundary enforced by this plugin — layer 1 is
+enforced by NetSuite itself (which is a real, platform-level backstop
+PostHog's key-scoping convention does not have), but only if the admin
+followed the setup instructions correctly. A role provisioned with full
+CRUD permissions, connected with an `admin` grant, gives this plugin's
+"read-only" framing no teeth at all** — NetSuite will honor
+`ns_createRecord` / `ns_updateRecord` calls against anything that role can
+reach. This is a real gap between what this document calls "read-only" and
+what is verified at connect time for a fast-tracked adopt-vendor plugin —
+flagged to Aaron (2026-08-12) as the same open question raised in
+PostHog's GOVERNANCE.md: whether adopt-vendor plugins like this one need a
+default-deny `VENDOR_TOOL_CONFIG` entry (or equivalent enforced default)
+shipped alongside the plugin itself, rather than relying on setup
+instructions alone. Not resolved by this PR; tracking here so it isn't
+lost.
+
+## Known sharp edges
+
+- **This is per-tenant, vendor-hosted MCP, not a shared hosted endpoint.**
+  Every client's NetSuite account runs its own MCP Standard Tools SuiteApp
+  instance at its own account-specific URL. A connection problem for one
+  client (expired certificate, role permission change, SuiteApp not
+  updated) does not imply anything about any other client's connection —
+  each is independent.
+- **The MCP Standard Tools SuiteApp is Oracle-managed and auto-updates.**
+  Oracle's own documentation notes updates may change how tools operate.
+  The 12-tool read surface and 2-tool write surface documented here are
+  accurate as of this plugin's build (2026-08-12, against Oracle's
+  published tool list) and should be reconfirmed against a live connection
+  if Oracle ships a SuiteApp update that changes the catalog.
+- **A misconfigured role is the single biggest risk in this integration,**
+  more than for a typical API-key vendor, because the "read-only" promise
+  depends entirely on a NetSuite admin doing five setup steps correctly
+  (see *Customer-side setup* above) rather than on a single field like an
+  API key's scope. See *Open enforcement gap*.
+- **`ns_runCustomSuiteQL` is documented as read-only-queries-only by
+  Oracle**, but this plugin does not independently verify that constraint
+  — it is stated in Oracle's own documentation, not something this plugin
+  or Conduit tests against.
+- **Not yet classified means not yet safely grantable at a coarse tier.**
+  Until `netsuite` gets a `VENDOR_TOOL_CONFIG` entry, there is no `read`
+  grant that admits only the families above — it is allowlist or `admin`,
+  nothing in between. Classifying the vendor, when it happens, is what
+  turns the family table above into an actual `read` tier.

--- a/msp-claude-plugins/netsuite/netsuite/README.md
+++ b/msp-claude-plugins/netsuite/netsuite/README.md
@@ -1,0 +1,209 @@
+# NetSuite Plugin
+
+Claude Code plugin for Oracle NetSuite ERP — read-only at v1.
+
+*Internal fast-track build, 2026-08-12 — not run through the standard
+community PRD process.*
+
+## Overview
+
+This plugin gives Claude working knowledge of NetSuite so MSP technicians
+and analysts can look up a client's ERP data without leaving the chat:
+
+- **Records & Metadata** — Retrieve individual NetSuite records (customers,
+  vendors, transactions, and any other type the connected role can reach)
+  and discover a record type's available fields
+- **Reports & Saved Searches** — Run existing NetSuite reports and saved
+  searches, with the filter-lookup helpers (accounting books, accounting
+  contexts, nexuses, subsidiaries) needed to scope them
+- **SuiteQL Queries** — Run read-only SuiteQL queries against NetSuite data
+  and discover queryable fields via SuiteQL metadata
+- **API Patterns** — Auth model (OAuth 2.0 Client Credentials / JWT-bearer),
+  per-tenant endpoints, and error handling for the NetSuite MCP surface
+
+**This plugin is read-only by design.** The MCP Standard Tools SuiteApp
+exposes 14 tools total; 2 of them (`ns_createRecord`, `ns_updateRecord`)
+create or update NetSuite records. This plugin grants and documents only
+the 12 read tools. See [GOVERNANCE.md](GOVERNANCE.md) for the full
+reasoning, including how NetSuite's own role-based permissions — not just
+this plugin's documentation — back the read-only posture.
+
+## Prerequisites
+
+**NetSuite setup for this plugin is heavier than a typical API-key
+vendor.** Before Conduit can connect a client's NetSuite account, that
+client's NetSuite administrator must complete real configuration inside
+NetSuite:
+
+1. Enable **Server SuiteScript**, **REST Web Services**, and OAuth 2.0
+   (Setup > Company > Enable Features, SuiteCloud subtab)
+2. Install the **MCP Standard Tools SuiteApp** (SuiteApps tab > search
+   "MCP Standard Tools" > Install)
+3. Create a dedicated custom role with the **MCP Server Connection**
+   permission and **Log in using OAuth 2.0 Access Tokens** permission,
+   granted **view-only** — no create/update/delete permissions on any
+   record type. Do not use the Administrator role; NetSuite does not permit
+   the Administrator role to be used for this kind of connection.
+4. Create an Integration record with **Client Credentials Grant** enabled
+   to obtain a **Client ID**
+5. Generate/upload a certificate under Setup > Integration > OAuth 2.0
+   Client Credentials Setup (mapping the integration user, the role from
+   step 3, and the Integration record from step 4) to obtain a
+   **Certificate ID** — keep the matching **PKCS8 private key** (PEM)
+
+See [GOVERNANCE.md](GOVERNANCE.md), *Customer-side setup is heavier than a
+typical API-key vendor*, for full detail and why step 3's view-only grant
+is what actually makes this plugin's read-only posture hold.
+
+### Connecting through Conduit
+
+This plugin does not accept local credentials of any kind. Connect the
+four values from the setup above once in the WYRE Conduit web UI
+(**Connections → NetSuite**):
+
+- NetSuite **Account ID**
+- OAuth 2.0 **Client ID**
+- **Certificate ID**
+- **PKCS8 private key** (PEM)
+
+Conduit stores them and mints/caches bearer tokens server-side per
+organization.
+
+There are **no environment variables and no headers to configure on the
+client** — `.mcp.json` declares only the gateway URL:
+
+```json
+{
+  "mcpServers": {
+    "netsuite": {
+      "type": "http",
+      "url": "https://conduit.wyre.ai/v1/netsuite/mcp"
+    }
+  }
+}
+```
+
+## Installation
+
+```
+/plugin marketplace add wyre-technology/msp-claude-plugins
+/plugin install netsuite
+```
+
+## Available Skills
+
+| Skill | Description |
+|-------|-------------|
+| `records-and-metadata` | Retrieving individual NetSuite records and record-type field metadata |
+| `reports-and-saved-searches` | Running reports and saved searches, plus their filter-lookup helpers |
+| `suiteql-queries` | Read-only SuiteQL queries and SuiteQL field metadata |
+| `api-patterns` | Auth model, per-tenant endpoints, and error handling |
+
+## Available Commands
+
+| Command | Description |
+|---------|-------------|
+| `/get-record` | Retrieve a NetSuite record by type and internal ID |
+| `/query-records` | Run a read-only SuiteQL query |
+| `/run-saved-search` | Run a saved search by name or ID |
+| `/run-report` | List available reports, or run one by name or ID |
+
+## Quick Start
+
+### Retrieve a Record
+
+```
+/get-record customer 12345
+```
+
+### Run a SuiteQL Query
+
+```
+/query-records "SELECT id, entityid, companyname FROM customer WHERE isinactive = 'F'"
+```
+
+### Run a Saved Search
+
+```
+/run-saved-search "Open Sales Orders by Customer"
+```
+
+### Run a Report
+
+```
+/run-report "Balance Sheet"
+```
+
+## Security Considerations
+
+- **Read-only here is backed by NetSuite's own RBAC, which is stronger than
+  a client-side convention — but it is still only as good as how the
+  client's NetSuite admin configured the integration role.** See
+  [GOVERNANCE.md](GOVERNANCE.md) — this plugin does not inspect the
+  connected role's actual permission grants after the fact.
+- Never paste a NetSuite Client ID, Certificate ID, or private key into a
+  technician's local environment, a `.env` file, or this repo. All four
+  connect values are entered once, in Conduit's connect UI, and stored
+  server-side.
+- NetSuite is a client's financial system of record. Review who has access
+  to the connected NetSuite account and its integration role regularly.
+
+## Troubleshooting
+
+### Authentication Errors
+
+If a call fails with an authentication or permission error:
+1. Confirm the Integration record's Client Credentials Grant is still
+   enabled and the certificate mapped to it hasn't expired or been revoked
+   in NetSuite (Setup > Integration > OAuth 2.0 Client Credentials Setup).
+2. Confirm the connected role still carries **MCP Server Connection** and
+   **Log in using OAuth 2.0 Access Tokens** — a role permission removed
+   after initial setup breaks the connection silently from this plugin's
+   point of view until the next call.
+3. Re-connect NetSuite in Conduit (**Connections → NetSuite**) if the
+   Account ID, Client ID, Certificate ID, or private key changed.
+
+### Empty or Unexpected Results
+
+1. Confirm the connected role actually has view access to the record type,
+   report, or saved search being queried — NetSuite scopes visibility by
+   role the same way it does in the UI, so a role without access to a
+   record type returns nothing (or a permission error) rather than data
+   from a different tenant.
+2. Confirm the record, report, or saved search actually exists in that
+   NetSuite account — this plugin cannot create any of them, so a missing
+   record has to be created in the NetSuite UI first.
+
+### Rate Limiting
+
+If you see a rate-limit or throttling response:
+1. Wait before retrying — NetSuite's SuiteTalk/REST platform enforces
+   concurrency and request limits that vary by account tier; this plugin
+   does not hardcode current thresholds. Consult
+   [NetSuite's Web Services documentation](https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/) for the account's actual limits.
+2. Reduce request frequency, and prefer targeted SuiteQL queries and
+   bounded saved-search/report runs over broad unbounded pulls.
+
+## API Documentation
+
+- [MCP Standard Tools SuiteApp overview](https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/article_143403258.html)
+- [Installing the MCP Standard Tools SuiteApp](https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/article_0902023450.html)
+- [Available Tools in the MCP Standard Tools SuiteApp](https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/article_0902023508.html)
+
+## Contributing
+
+See the main [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+
+This plugin shipped as an Aaron-approved internal fast-track build and did
+not go through the standard community PRD process. Contributions that
+extend it (including any future write-tool tier) should follow the normal
+process and must update [GOVERNANCE.md](GOVERNANCE.md) accordingly.
+
+## Changelog
+
+### 0.1.0 (2026-08-12)
+
+- Initial release — read-only at v1
+- 4 skills: records-and-metadata, reports-and-saved-searches,
+  suiteql-queries, api-patterns
+- 4 commands: get-record, query-records, run-saved-search, run-report

--- a/msp-claude-plugins/netsuite/netsuite/commands/get-record.md
+++ b/msp-claude-plugins/netsuite/netsuite/commands/get-record.md
@@ -1,0 +1,58 @@
+---
+description: Retrieve a NetSuite record by type and internal ID
+argument-hint: "<record_type> <id>"
+arguments: [record_type, id]
+---
+
+# Get NetSuite Record
+
+Look up a single NetSuite record by its record type and internal ID, and
+report its fields.
+
+## Arguments
+
+- `record_type` (required) — NetSuite record type, e.g. `customer`,
+  `vendor`, `salesorder`, `invoice`
+- `id` (required) — Internal ID of the record
+
+## Prerequisites
+
+- NetSuite connected in Conduit, with the connected role granted view
+  access to the target record type (see `GOVERNANCE.md`)
+
+## Steps
+
+1. If the record type's fields aren't already known for this session, call
+   `ns_getRecordTypeMetadata` for `record_type` to confirm what's available
+   (see `skills/records-and-metadata/SKILL.md`)
+2. Call `ns_getRecord` with `record_type` and `id`
+3. Report the record's fields plainly; do not infer or fill in fields the
+   tool didn't return
+4. If the record type isn't one the connected role can see, say so — this
+   command cannot expand what the connected role is permitted to view
+
+## Examples
+
+### Retrieve a customer record
+
+```
+/get-record customer 12345
+```
+
+### Retrieve a sales order
+
+```
+/get-record salesorder 98765
+```
+
+## Error Handling
+
+| Error | Resolution |
+|-------|------------|
+| Not found | No record of that type exists with that internal ID |
+| Permission denied | The connected NetSuite role isn't granted view access to this record type — this is enforced by NetSuite itself, not by this plugin |
+| Unknown record type | Call `ns_getRecordTypeMetadata` with no type filter to list valid record types, or confirm spelling |
+
+## Related Commands
+
+- `/query-records` — Look up records by criteria instead of a known ID

--- a/msp-claude-plugins/netsuite/netsuite/commands/query-records.md
+++ b/msp-claude-plugins/netsuite/netsuite/commands/query-records.md
@@ -1,0 +1,58 @@
+---
+description: Run a read-only SuiteQL query against NetSuite
+argument-hint: "<suiteql_query>"
+arguments: [suiteql_query]
+---
+
+# Query NetSuite Records (SuiteQL)
+
+Run a read-only SuiteQL query and report the results.
+
+## Arguments
+
+- `suiteql_query` (required) — A SuiteQL `SELECT` statement
+
+## Prerequisites
+
+- NetSuite connected in Conduit, with the connected role granted view
+  access to the record types referenced in the query
+
+## Steps
+
+1. If the query references fields whose availability or joinability isn't
+   already known, call `ns_getSuiteQLMetadata` for the relevant record type
+   first (see `skills/suiteql-queries/SKILL.md`)
+2. Call `ns_runCustomSuiteQL` with `suiteql_query`
+3. Report the returned rows. If the query is unbounded and the result set
+   is large, say so and suggest narrowing with a `WHERE` clause rather than
+   dumping everything
+4. This command only ever issues read queries — `ns_runCustomSuiteQL`
+   itself is documented by NetSuite as accepting read-only queries only;
+   do not attempt `INSERT`/`UPDATE`/`DELETE` statements, they will not
+   succeed
+
+## Examples
+
+### List active customers
+
+```
+/query-records "SELECT id, entityid, companyname FROM customer WHERE isinactive = 'F'"
+```
+
+### Recent sales orders for a customer
+
+```
+/query-records "SELECT id, tranid, trandate, total FROM transaction WHERE type = 'SalesOrd' AND entity = 12345 ORDER BY trandate DESC"
+```
+
+## Error Handling
+
+| Error | Resolution |
+|-------|------------|
+| Syntax error | Check the SuiteQL statement's syntax; SuiteQL is a subset of SQL, not full ANSI SQL |
+| Permission denied on a table/field | The connected NetSuite role isn't granted view access to that record type or field |
+| Query rejected as non-read | `ns_runCustomSuiteQL` accepts read-only queries only — remove any write statement |
+
+## Related Commands
+
+- `/get-record` — Retrieve a single known record directly, without writing SuiteQL

--- a/msp-claude-plugins/netsuite/netsuite/commands/run-report.md
+++ b/msp-claude-plugins/netsuite/netsuite/commands/run-report.md
@@ -1,0 +1,58 @@
+---
+description: List available NetSuite reports, or run one by name or ID
+argument-hint: "[report]"
+arguments: [report]
+---
+
+# Run NetSuite Report
+
+List a NetSuite account's available reports, or run a specific one.
+
+## Arguments
+
+- `report` (optional) — Report name or ID to run; omit to list all
+  available reports
+
+## Prerequisites
+
+- NetSuite connected in Conduit, with the connected role granted view
+  access to the target report
+
+## Steps
+
+1. If `report` is omitted, call `ns_listAllReports` and list what's
+   available
+2. If `report` is given, confirm which filters it needs — subsidiary,
+   accounting book/context, or nexus — using `ns_getSubsidiaries`,
+   `ns_getAccountingBooks`, `ns_getAccountingContexts`, or `ns_getNexusIds`
+   as needed (see `skills/reports-and-saved-searches/SKILL.md`)
+3. Call `ns_runReport` for the matched report with the appropriate filters
+4. Report the results as returned; note the reporting period or as-of date
+   the report used rather than implying the numbers are live right now
+
+## Examples
+
+### List available reports
+
+```
+/run-report
+```
+
+### Run a specific report
+
+```
+/run-report "Balance Sheet"
+```
+
+## Error Handling
+
+| Error | Resolution |
+|-------|------------|
+| Not found | No report exists with that name or ID — run `/run-report` with no argument to list available reports |
+| Permission denied | The connected role can't view this report |
+| Missing required filter | Some reports require a subsidiary, accounting book, or nexus — use the filter-lookup tools to find a valid value |
+
+## Related Commands
+
+- `/run-saved-search` — Run a saved search instead of a standard report
+- `/query-records` — Ask a question no existing report or search already answers

--- a/msp-claude-plugins/netsuite/netsuite/commands/run-saved-search.md
+++ b/msp-claude-plugins/netsuite/netsuite/commands/run-saved-search.md
@@ -1,0 +1,55 @@
+---
+description: Run a NetSuite saved search by name or ID
+argument-hint: "<saved_search>"
+arguments: [saved_search]
+---
+
+# Run NetSuite Saved Search
+
+Run an existing saved search and report its results.
+
+## Arguments
+
+- `saved_search` (required) — Saved search name or ID to run
+
+## Prerequisites
+
+- NetSuite connected in Conduit, with the connected role granted view
+  access to the saved search and the record type it's built on
+
+## Steps
+
+1. If `saved_search` looks like an ID, run it directly; otherwise call
+   `ns_listSavedSearches` first to find the matching search by name (see
+   `skills/reports-and-saved-searches/SKILL.md`)
+2. Call `ns_runSavedSearch` for the matched search
+3. Report the results as returned by the saved search's own configured
+   columns — do not re-shape or re-aggregate them
+4. If nothing matches, say so plainly rather than guessing at a similarly
+   named search
+
+## Examples
+
+### Run by name
+
+```
+/run-saved-search "Open Sales Orders by Customer"
+```
+
+### Run by ID
+
+```
+/run-saved-search 481
+```
+
+## Error Handling
+
+| Error | Resolution |
+|-------|------------|
+| Not found | No saved search exists with that name or ID — confirm spelling or call `ns_listSavedSearches` with no filter |
+| Permission denied | The connected role can't view the saved search or its underlying record type |
+
+## Related Commands
+
+- `/run-report` — Run a standard or custom NetSuite report instead of a saved search
+- `/query-records` — Ask an ad-hoc question a saved search doesn't already answer

--- a/msp-claude-plugins/netsuite/netsuite/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/netsuite/netsuite/skills/api-patterns/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: "NetSuite API Patterns"
+description: >
+  NetSuite MCP fundamentals for this plugin: OAuth 2.0 Client Credentials
+  (JWT-bearer) machine-to-machine auth brokered through Conduit, the
+  per-tenant vendor-hosted MCP endpoint model, generic error handling, and
+  how NetSuite's own role-based permissions — not this plugin — enforce the
+  read-only posture.
+when_to_use: >-
+  When authenticating to NetSuite, reasoning about the connected role's
+  permissions, or debugging errors from the NetSuite MCP server. Use when:
+  netsuite api, netsuite auth, netsuite authentication, netsuite oauth,
+  netsuite role, netsuite permission, netsuite integration record, or
+  netsuite error.
+---
+
+# NetSuite API Patterns
+
+## Overview
+
+NetSuite is reached here through the **MCP Standard Tools SuiteApp**,
+which each NetSuite customer installs into their own account, via the
+WYRE Conduit gateway. This skill covers the mechanics that aren't
+guessable from the tool names: how auth is brokered, why this is
+per-tenant infrastructure rather than a shared endpoint, and how
+NetSuite's own permission model actually enforces this plugin's read-only
+posture.
+
+## Anti-triggers
+
+- **What a specific tool does or which record/report/search it covers** —
+  use `records-and-metadata`, `reports-and-saved-searches`, or
+  `suiteql-queries`.
+- **Why this plugin excludes `ns_createRecord` and `ns_updateRecord`** —
+  that's a governance question, not an API-mechanics one; see
+  [GOVERNANCE.md](../../GOVERNANCE.md).
+
+## Connection & Authentication
+
+This plugin does not accept a local NetSuite credential. NetSuite auth is
+**OAuth 2.0 Client Credentials Grant using a JWT-bearer client
+assertion** — machine-to-machine, with no browser redirect or user-consent
+screen at any point. The operator connects four values once, in Conduit's
+connect UI (**Connections → NetSuite**): NetSuite **Account ID**, OAuth 2.0
+**Client ID**, **Certificate ID**, and the **PKCS8 private key** (PEM).
+Conduit uses these to sign a JWT assertion and mint (and cache) a bearer
+token server-side per organization — the same `bearerTokenCache` pattern
+Conduit already uses for HaloPSA.
+
+This plugin's `.mcp.json` declares no headers and no environment
+variables — there is nothing to configure on the client:
+
+```json
+{
+  "mcpServers": {
+    "netsuite": {
+      "type": "http",
+      "url": "https://conduit.wyre.ai/v1/netsuite/mcp"
+    }
+  }
+}
+```
+
+## Per-Tenant, Vendor-Hosted MCP
+
+Unlike a shared hosted MCP server, **each NetSuite customer runs their own
+MCP endpoint**, at an account-specific URL:
+
+- MCP endpoint: `https://<accountId>.suitetalk.api.netsuite.com/services/mcp/v1/suiteapp/com.netsuite.mcpstandardtools`
+- Token endpoint: `https://<accountId>.suitetalk.api.netsuite.com/services/rest/auth/oauth2/v1/token`
+
+Both are resolved by Conduit server-side per organization; this plugin's
+`.mcp.json` still just points at Conduit's fixed gateway URL, the same
+broker pattern as every other Conduit vendor. Practically, this means a
+connection issue for one client's NetSuite account (expired certificate,
+role permission changed, SuiteApp not yet installed or updated) says
+nothing about any other client's connection.
+
+## How the Read-Only Posture Actually Holds
+
+NetSuite's own MCP Standard Tools SuiteApp "uses the same access controls
+as the NetSuite UI" — access to every tool, record type, report, and
+saved search is governed by the NetSuite role assigned to the connected
+integration user. The setup instructions for this plugin call for that
+role to be provisioned **view-only**: no create/update/delete permissions
+on any record type. If that instruction was followed, NetSuite itself
+refuses `ns_createRecord` / `ns_updateRecord` calls at the platform level
+— before the request ever reaches Conduit or this plugin.
+
+**This is a stronger mechanism than PostHog's key-scope convention**
+(PostHog's read-only posture depends on a personal API key being scoped
+to read-only resources at creation, which PostHog's own API enforces but
+which is otherwise identical in shape — an operator-configured setting
+this plugin cannot verify after the fact). See
+[GOVERNANCE.md](../../GOVERNANCE.md), *How read-only is actually enforced
+here*, for the full comparison and the honest caveat: this plugin has no
+way to confirm the connected role was actually provisioned view-only.
+
+## Error Handling
+
+| Situation | Meaning | Action |
+|------|---------|--------|
+| `invalid_client` / `invalid_grant` / `unauthorized_client` at token mint | The Client ID, Certificate ID, or private key mapping is wrong, or the certificate expired | Reconnect in Conduit with current values; confirm the Integration record's Client Credentials Grant is still enabled |
+| Permission denied on a tool or record type | The connected role doesn't have view access to that record type, report, or saved search | This is enforced by NetSuite itself — request the client's NetSuite admin grant view access on the dedicated role if the lookup is legitimately needed |
+| Tool not visible / not callable | Tools are only exposed if the connected role has all required permissions for that tool | Confirm the role carries **MCP Server Connection** and **Log in using OAuth 2.0 Access Tokens** |
+| Empty results, no error | The connected role can't see the record/report/search, or it genuinely doesn't exist | Distinguish the two — NetSuite scopes visibility by role the same way the UI does, so absence of an error doesn't mean absence of data |
+
+## Rate Limiting
+
+This plugin does not hardcode NetSuite's concurrency or request-rate
+limits — they vary by account tier and are not part of the confirmed
+facts behind this plugin. Consult
+[NetSuite's Web Services documentation](https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/) for
+the connected account's actual limits. Prefer targeted SuiteQL queries and
+bounded report/saved-search runs over broad unbounded pulls, which are the
+fastest way to hit a limit during a sweep across multiple clients.
+
+## Gotchas
+
+- **Read-only here depends on the connected role's NetSuite permissions,
+  not on anything this plugin checks.** See
+  [GOVERNANCE.md](../../GOVERNANCE.md), *Open enforcement gap*.
+- **`netsuite` is not yet classified in Conduit's `VENDOR_TOOL_CONFIG`.**
+  Until it is, there is no coarse `read` tier grant that admits only this
+  plugin's read families — access has to go through the gateway allowlist.
+  See [GOVERNANCE.md](../../GOVERNANCE.md), *Tool permission tiers*.
+- **Every client's NetSuite account is a fully separate MCP endpoint.**
+  There is no cross-account behavior to reason about — a tool call always
+  targets exactly the one account Conduit resolved for that connection.
+
+## Related Skills
+
+- [Records & Metadata](../records-and-metadata/SKILL.md) — Record retrieval and record-type field metadata
+- [Reports & Saved Searches](../reports-and-saved-searches/SKILL.md) — Report and saved-search execution
+- [SuiteQL Queries](../suiteql-queries/SKILL.md) — Ad-hoc read-only queries

--- a/msp-claude-plugins/netsuite/netsuite/skills/records-and-metadata/SKILL.md
+++ b/msp-claude-plugins/netsuite/netsuite/skills/records-and-metadata/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: "NetSuite Records & Metadata"
+description: >
+  Retrieving individual NetSuite records by type and internal ID, and
+  discovering a record type's available fields via record-type metadata.
+  Read-only — retrieving existing records, not creating or updating them.
+when_to_use: >-
+  When looking up a specific NetSuite record (customer, vendor, sales
+  order, invoice, or any other record type) by its internal ID, or when
+  you need to know what fields a NetSuite record type has before querying
+  or reading it. Use when: netsuite record, netsuite customer, netsuite
+  vendor, netsuite invoice, netsuite sales order, record type, internal
+  id, or netsuite field.
+---
+
+# NetSuite Records & Metadata
+
+## Overview
+
+NetSuite organizes almost everything as a typed record — `customer`,
+`vendor`, `salesorder`, `invoice`, `employee`, and many more, each with its
+own internal ID and field set. This skill covers looking a specific record
+up directly when you already know (or can pin down) its type and ID, and
+discovering what fields a record type actually has before you go looking
+for one.
+
+## Anti-triggers
+
+- **Finding records by criteria you don't have an ID for** — use
+  `suiteql-queries` to search, then retrieve the specific record here if
+  needed.
+- **Creating or updating a record** — this plugin is read-only. See
+  [GOVERNANCE.md](../../GOVERNANCE.md), *Tool permission tiers*:
+  `ns_createRecord` and `ns_updateRecord` are the two write tools this
+  plugin deliberately excludes. Make the change directly in the NetSuite
+  UI, with the same care you'd give any change to a client's financial
+  system of record.
+- **Reports or saved searches already built for this data** — use
+  `reports-and-saved-searches` rather than re-deriving what a report
+  already computes.
+- **Auth, role permissions, or error handling** — use `api-patterns`.
+
+## Core Concepts
+
+Every NetSuite record has a record type (a fixed string like `customer`
+or `salesorder`) and an internal ID (a number, unique within that type).
+Record-type metadata describes the fields a given type carries — names,
+data types, and (per NetSuite's `ns_getRecordTypeMetadata` tool) can be
+requested for a single type or for all types at once. What a record
+actually returns when retrieved depends entirely on the connected role's
+view permissions on that type and its fields — the same way it would if a
+human opened the record in the NetSuite UI.
+
+## API Patterns
+
+The confirmed read tool family for this domain:
+
+- `ns_getRecord` — retrieves a record in NetSuite by type and internal ID
+- `ns_getRecordTypeMetadata` — retrieves metadata (available fields and
+  data types) for all NetSuite record types, or for a specific type
+
+Both are documented by Oracle at
+[Available Tools in the MCP Standard Tools SuiteApp](https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/article_0902023508.html).
+The corresponding write tools, `ns_createRecord` and `ns_updateRecord`,
+are excluded from this plugin — see
+[GOVERNANCE.md](../../GOVERNANCE.md).
+
+**A note on record-type-specific commands:** this plugin does not ship a
+separate command per record type (e.g. no dedicated "get customer" vs.
+"get vendor" command). `ns_getRecord` is generic across record types by
+design, and this plugin's `/get-record` command is built directly against
+that generic tool rather than inventing per-type wrappers that don't
+correspond to anything the underlying MCP surface exposes.
+
+## Common Workflows
+
+### Looking up a customer before an escalation
+
+A support ticket references a customer by name, not ID:
+
+1. If the internal ID isn't known, use `suiteql-queries` to find it (e.g.
+   `SELECT id, companyname FROM customer WHERE companyname LIKE '...'`)
+2. Call `ns_getRecord` with type `customer` and the resolved ID
+3. Report the fields relevant to the escalation — don't dump the entire
+   record if only a few fields matter
+
+### Confirming a record type's fields before writing a SuiteQL query
+
+Before querying an unfamiliar record type:
+
+1. Call `ns_getRecordTypeMetadata` for that type
+2. Use the returned field names and types to write an accurate SuiteQL
+   query in `suiteql-queries`, rather than guessing at field names
+
+## Gotchas
+
+- **Retrieval respects the connected role's field-level permissions, not
+  just record-level.** A role with view access to a record type can still
+  have specific fields withheld — a retrieved record missing an expected
+  field may be a permission boundary, not a data gap.
+- **Internal IDs are per-type, not global.** Customer 12345 and sales
+  order 12345 are unrelated records; always pair an ID with its record
+  type.
+- **This is a read-only lookup, with no exceptions.** Even a trivial
+  correction (fixing an obviously wrong field) is outside this plugin —
+  escalate to a human with direct NetSuite access.
+
+## Related Skills
+
+- [Reports & Saved Searches](../reports-and-saved-searches/SKILL.md) — Pre-built aggregations and lookups
+- [SuiteQL Queries](../suiteql-queries/SKILL.md) — Finding records by criteria
+- [API Patterns](../api-patterns/SKILL.md) — Auth, roles, and error handling

--- a/msp-claude-plugins/netsuite/netsuite/skills/reports-and-saved-searches/SKILL.md
+++ b/msp-claude-plugins/netsuite/netsuite/skills/reports-and-saved-searches/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: "NetSuite Reports & Saved Searches"
+description: >
+  Running NetSuite's standard and custom reports and saved searches, plus
+  the filter-lookup helpers (accounting books, accounting contexts,
+  nexuses, subsidiaries) many of them need. Read-only — running existing
+  reports and searches, not building or editing them.
+when_to_use: >-
+  When running a NetSuite financial report, a saved search, or looking up
+  the subsidiary/nexus/accounting-book values a report needs to be scoped
+  correctly. Use when: netsuite report, netsuite saved search, balance
+  sheet, income statement, subsidiary, nexus, accounting book, accounting
+  context, or financial report.
+---
+
+# NetSuite Reports & Saved Searches
+
+## Overview
+
+NetSuite reports (standard financial reports like a Balance Sheet, plus
+any custom reports the client has built) and saved searches (reusable,
+criteria-based lookups defined in the NetSuite UI) are both pre-built
+views over the account's data. This skill covers running them and
+retrieving their results — not authoring or editing either.
+
+## Anti-triggers
+
+- **Ad-hoc questions no existing report or search answers** — use
+  `suiteql-queries` instead of trying to force a report to answer
+  something it wasn't built for.
+- **Retrieving a single known record directly** — use
+  `records-and-metadata`.
+- **Building or editing a report or saved search** — this plugin is
+  read-only; there is no tool in this plugin's surface for authoring
+  either. Build or change it in the NetSuite UI directly.
+- **Auth, role permissions, or error handling** — use `api-patterns`.
+
+## Core Concepts
+
+A **report** is one of NetSuite's standard financial/operational reports
+(Balance Sheet, Income Statement, and similar) or a custom report the
+client has built; many require filter context — which subsidiary, which
+accounting book, which nexus — to run correctly in a multi-entity or
+multi-book NetSuite account. A **saved search** is a reusable,
+criteria-based lookup defined once in the NetSuite UI and re-run on
+demand, returning whatever columns it was configured with.
+
+## API Patterns
+
+The confirmed read tool family for this domain:
+
+- `ns_listAllReports` — lists all standard and custom reports in the account
+- `ns_runReport` — runs a report and returns its results
+- `ns_getSubsidiaries` — lists subsidiaries, for scoping a report
+- `ns_getAccountingBooks` — lists accounting books, for scoping a report
+- `ns_getAccountingContexts` — lists accounting contexts, for scoping a report
+- `ns_getNexusIds` — lists nexuses, for scoping a report
+- `ns_listSavedSearches` — lists all saved searches in the account
+- `ns_runSavedSearch` — runs an existing saved search
+
+All eight are documented by Oracle at
+[Available Tools in the MCP Standard Tools SuiteApp](https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/article_0902023508.html).
+This plugin exposes only these read tools — there is no report- or
+saved-search-authoring tool in this plugin's surface.
+
+## Common Workflows
+
+### Running a standard financial report for a QBR
+
+1. `ns_listAllReports` to confirm the report's exact name if not already
+   known
+2. If the account has multiple subsidiaries or accounting books, call
+   `ns_getSubsidiaries` / `ns_getAccountingBooks` / `ns_getAccountingContexts`
+   to find the correct filter value
+3. `ns_runReport` with the resolved filters
+4. Report the numbers with the reporting period the report actually used
+
+### Running a saved search a client already relies on
+
+1. `ns_listSavedSearches` to find the search by name if the ID isn't known
+2. `ns_runSavedSearch` for the matched search
+3. Report results using the search's own configured columns — don't
+   re-aggregate or re-shape what the saved search already defines
+
+## Gotchas
+
+- **Many reports require filter context to run correctly.** A multi-
+  subsidiary or multi-book NetSuite account can return misleading or
+  incomplete results if a report is run without the right subsidiary,
+  accounting book, or nexus — use the filter-lookup tools rather than
+  guessing.
+- **A report or saved search reflects only what the connected role can
+  see.** The same role-based visibility that governs direct record access
+  governs report and saved-search results too.
+- **Report results reflect a point in time, not necessarily "right now."**
+  Note the reporting period or as-of date a report used rather than
+  presenting the numbers as live.
+
+## Related Skills
+
+- [Records & Metadata](../records-and-metadata/SKILL.md) — Single-record lookups
+- [SuiteQL Queries](../suiteql-queries/SKILL.md) — Ad-hoc questions no report or search covers
+- [API Patterns](../api-patterns/SKILL.md) — Auth, roles, and error handling

--- a/msp-claude-plugins/netsuite/netsuite/skills/suiteql-queries/SKILL.md
+++ b/msp-claude-plugins/netsuite/netsuite/skills/suiteql-queries/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: "NetSuite SuiteQL Queries"
+description: >
+  Running read-only SuiteQL queries against NetSuite data and discovering
+  queryable fields and joins via SuiteQL metadata. The flexible ad-hoc
+  query surface for questions no existing report or saved search already
+  answers.
+when_to_use: >-
+  When you need to query NetSuite data with custom criteria that no
+  existing report or saved search covers, or when you need to know what
+  fields and joins a record type supports for SuiteQL. Use when: suiteql,
+  netsuite query, netsuite sql, ad hoc query, netsuite join, or netsuite
+  field metadata.
+---
+
+# NetSuite SuiteQL Queries
+
+## Overview
+
+SuiteQL is NetSuite's SQL-like query language over its record data —
+`SELECT` statements with `WHERE`, `JOIN`, `ORDER BY`, and similar clauses,
+scoped to whatever the connected role can see. It's the right tool when a
+question needs custom filtering or joins that no existing report or saved
+search already provides.
+
+## Anti-triggers
+
+- **A question an existing report or saved search already answers** — use
+  `reports-and-saved-searches` instead of re-deriving something NetSuite
+  has already computed.
+- **Retrieving one specific, already-known record** — use
+  `records-and-metadata`; `ns_getRecord` is simpler than a SuiteQL query
+  for a single record by ID.
+- **Creating, updating, or deleting data** — SuiteQL here is read-only.
+  `ns_runCustomSuiteQL` is documented by Oracle as accepting **read-only
+  queries only** — write statements are not a workaround this skill
+  supports, or one NetSuite will honor.
+- **Auth, role permissions, or error handling** — use `api-patterns`.
+
+## Core Concepts
+
+SuiteQL queries NetSuite's underlying record tables (which broadly mirror
+record types like `customer`, `transaction`, `item`) using SQL syntax.
+It's a subset of SQL, not full ANSI SQL — some familiar constructs may not
+be supported. Query results respect the connected role's view permissions
+the same way direct record retrieval and reports do.
+
+## API Patterns
+
+The confirmed read tool family for this domain:
+
+- `ns_runCustomSuiteQL` — runs a custom SuiteQL query (Oracle's
+  documentation states explicitly: read-only queries only)
+- `ns_getSuiteQLMetadata` — retrieves metadata for records queryable via
+  SuiteQL, including available fields, data types, and joinable fields;
+  can be scoped to a specific record type
+
+Both are documented by Oracle at
+[Available Tools in the MCP Standard Tools SuiteApp](https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/article_0902023508.html).
+
+## Common Workflows
+
+### Finding a record's internal ID before a direct lookup
+
+1. `ns_runCustomSuiteQL` with a targeted `SELECT id, ... FROM <type> WHERE ...`
+2. Take the resolved ID to `records-and-metadata`'s `ns_getRecord` if a
+   full record retrieval is needed next
+
+### Building a query against an unfamiliar record type
+
+1. `ns_getSuiteQLMetadata` for the record type in question, to confirm
+   real field names and available joins
+2. Write the SuiteQL query against the confirmed fields, rather than
+   guessing at column names from the NetSuite UI's field labels (which
+   don't always match the underlying SuiteQL field name)
+
+### Answering a cross-record question a report doesn't cover
+
+1. Confirm no existing report or saved search already answers it (check
+   `reports-and-saved-searches` first — don't re-derive what NetSuite
+   already computes)
+2. Write a targeted, bounded SuiteQL query — filter by date range or
+   specific criteria rather than pulling an entire table
+3. Report results plainly, noting if the result set was truncated or if
+   the query should be narrowed further
+
+## Gotchas
+
+- **SuiteQL is a subset of SQL.** Not every construct from full ANSI SQL
+  is guaranteed to work — if a query fails unexpectedly, simplify it
+  before assuming the data doesn't exist.
+- **Bound queries.** An unbounded `SELECT *` against a large table (e.g.
+  `transaction`) is a way to exhaust rate limits and return far more data
+  than the question needs — prefer explicit columns and a `WHERE` clause.
+- **Field names in SuiteQL don't always match NetSuite UI labels.** Use
+  `ns_getSuiteQLMetadata` rather than guessing from what a field is called
+  on screen.
+- **Read-only is enforced by NetSuite here, not just by this plugin's
+  documentation.** `ns_runCustomSuiteQL` itself is documented as
+  read-only-queries-only — but this plugin does not independently verify
+  that constraint; it is Oracle's own stated behavior. See
+  [GOVERNANCE.md](../../GOVERNANCE.md).
+
+## Related Skills
+
+- [Records & Metadata](../records-and-metadata/SKILL.md) — Direct record retrieval by ID
+- [Reports & Saved Searches](../reports-and-saved-searches/SKILL.md) — Pre-built views to check before writing a custom query
+- [API Patterns](../api-patterns/SKILL.md) — Auth, roles, and error handling


### PR DESCRIPTION
## Summary
- Adds a Claude Code plugin for Oracle NetSuite, connected through Conduit (`wyre-technology/conduit#1355` — the NetSuite vendor wiring, itself stacked on `conduit#1354`).
- **Read-only at v1** (Aaron/founder sign-off, 2026-08-12 — same review as PostHog's `#214`).
- Same broker model as PostHog: this plugin holds zero credentials. `.mcp.json` points only at Conduit's gateway URL; the four connect values (Account ID, Client ID, Certificate ID, PKCS8 private key) are entered once in Conduit's connect UI.

## Tool surface (Oracle-documented, not fabricated)
Oracle's own doc — [Available Tools in the MCP Standard Tools SuiteApp](https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/article_0902023508.html) — lists a confirmed 14-tool catalog: 12 read tools (this plugin's full grant) + 2 write tools (`ns_createRecord`, `ns_updateRecord`, deliberately excluded, not documented or shipped).

## How read-only differs from PostHog — the interesting design note
PostHog's read-only posture depends on the *customer* voluntarily scoping their personal API key at creation — an honor-system convention Conduit can't verify. NetSuite's rests on **NetSuite's own native RBAC**: the customer's admin provisions a dedicated integration role that can be granted view-only permissions, and NetSuite itself refuses write calls at the platform level if that role has no write grant — a real backstop PostHog's mechanism doesn't have. GOVERNANCE.md documents this honestly, including the same class of "Open enforcement gap" PostHog's plugin flags: this plugin still can't verify after the fact that the admin actually provisioned the role view-only.

## Category correction
Registered under the existing `"accounting"` category (matching `quickbooks-online`'s precedent) — **not** `"erp"`, which isn't a valid category in this repo's marketplace schema (confirmed against `docs/scripts/generate-plugins.ts`'s `VALID_CATEGORIES` set). An earlier same-day scoping note assumed an `"erp"` category + an IQMS precedent that doesn't actually exist here; corrected in this PR.

## Test plan
- [x] `claude plugin validate .` (root manifest) — passes
- [x] `claude plugin validate msp-claude-plugins/netsuite/netsuite` — passes
- [x] `node scripts/check-marketplace-drift.mjs --base origin/main` — passes (77 entries)
- [x] `node scripts/check-doc-references.mjs` — passes (1526 references resolve)
- [x] `node scripts/check-tool-anchoring.mjs` — passes; confirmed independently that `netsuite` adds **zero** new entries to `scripts/unanchored-docs.json` (every skill/command names a real `ns_*` tool)
- [ ] Live verification against a real NetSuite sandbox — blocked on the same live-verify gate as `conduit#1355`/`#1353`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/msp-claude-plugins/pr/215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->