### PR TITLE
fix(posthog): correct GOVERNANCE.md's fictional gateway-allowlist layer

### DIFF
--- a/msp-claude-plugins/posthog/posthog/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/posthog/posthog/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "posthog",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Claude plugin for PostHog product analytics — insights, dashboards, feature flags, cohorts, events (read-only)",
   "author": {
     "name": "MSP Claude Plugins Community"

--- a/msp-claude-plugins/posthog/posthog/GOVERNANCE.md
+++ b/msp-claude-plugins/posthog/posthog/GOVERNANCE.md
@@ -47,13 +47,14 @@ That control lives entirely on the customer's side of the connection.
 Conduit stores whatever key it is given; it does not inspect, mint, or
 verify the key's scopes. **If whoever connects PostHog to Conduit pastes in
 a key that was minted with full read/write access — the PostHog default
-when scopes aren't explicitly narrowed — this plugin's read-only posture
-depends entirely on the second layer below, not on the key.** Setup
-instructions for this plugin must tell the connecting operator, explicitly,
-to scope the key to read-only resources before pasting it into Conduit.
-Verifying that instruction was followed is a manual step today; PostHog
-does not expose a way to introspect a key's granted scopes after the fact
-from outside its own settings UI.
+when scopes aren't explicitly narrowed — this plugin's read-only posture is
+not enforced at all.** There is no gateway-side fallback for this vendor —
+see *Tool permission tiers* below for why. Setup instructions for this
+plugin must tell the connecting operator, explicitly, to scope the key to
+read-only resources before pasting it into Conduit. Verifying that
+instruction was followed is a manual step today; PostHog does not expose a
+way to introspect a key's granted scopes after the fact from outside its
+own settings UI.
 
 ## Tool permission tiers
 
@@ -70,12 +71,18 @@ from outside its own settings UI.
 > *Fail-closed, and the vendors Conduit has not classified*. Classifying a
 > vendor is always a privilege *reduction*, never an expansion.
 >
-> Because tiering does nothing for this vendor yet, the operational
-> enforcement for "read-only at v1" is a **gateway-side tool allowlist**
-> (a `customTools` grant naming only the read-tool families below), not a
-> tier grant. Configure that allowlist when connecting this plugin — an
-> `admin` grant with no allowlist restores the full upstream surface,
-> including every tool this document excludes.
+> Because tiering does nothing for this vendor yet, and because PostHog's
+> MCP server exposes exactly **one** tool (`exec`, taking a free-text
+> `command` string — confirmed live via `tools/list`, not inferred), a
+> gateway-side `customTools` allowlist CANNOT express the read-tool-family
+> split below. There is no per-family tool name to allow or deny: `exec`
+> either reaches the connection (the entire upstream command surface,
+> reads and writes alike) or it doesn't. Naming `exec` in the allowlist is
+> operationally identical to granting `admin` with no allowlist at all —
+> both admit every command PostHog's `exec` accepts, including every
+> write tool this document excludes. The family table below documents
+> PostHog's own command vocabulary for this plugin's skills to use
+> responsibly; it is not a Conduit-enforceable boundary.
 
 PostHog's own MCP server exposes a very large tool surface — north of 200
 tools spanning nearly every product area, with substantial create/update/
@@ -131,13 +138,17 @@ are built against.
 | Alerts | get, list (**not** `alert-simulate`) |
 | Business Knowledge | search, retrieve |
 
-**Conduit does not enforce per-call approval.** It compares tiers and, where
-configured, checks the tool allowlist — there is no approval step, no
-per-call confirmation, and no interactive prompt anywhere in its enforcement
-path. The read-only posture above is a combination of (1) the key's own
-scopes and (2) the gateway allowlist; nothing in Conduit stops a
-misconfigured grant from reaching a write tool if either of those is set up
-wrong.
+**Conduit does not enforce per-call approval.** It compares tiers and,
+where configured, checks the tool allowlist against the MCP tool NAME —
+there is no approval step, no per-call confirmation, no command-content
+inspection, and no interactive prompt anywhere in its enforcement path.
+For this vendor the allowlist has exactly one name to check against
+(`exec`), so it collapses to a binary reachable/not-reachable decision.
+**The read-only posture above rests entirely on (1) the key's own
+`resource:action` scopes.** There is no (2) — the gateway allowlist adds
+no granularity beyond "can this grantee reach PostHog through Conduit at
+all," and nothing in Conduit stops a full-scope key from reaching every
+write tool once that coarse gate is open.
 
 ## Recommended agent policy
 
@@ -161,9 +172,10 @@ write or destructive tier.
   the wrong PostHog organization returns another team's analytics, not an
   error.
 - Only the `resource:action` scopes the key was minted with — **if the key
-  was over-scoped at creation, this plugin's read-only posture is not a
-  hard boundary, it is a documentation and allowlist convention.** See
-  *The scope decision happens outside Conduit* above.
+  was over-scoped at creation, this plugin's read-only posture is not
+  enforced at all; there is no gateway-side fallback for this vendor.** See
+  *The scope decision happens outside Conduit* above and *Tool permission
+  tiers* below.
 - No write path of any kind, in the tools this plugin grants or documents —
   see *Tool permission tiers*.
 - No filesystem, no shell, no other vendor's data.
@@ -199,36 +211,48 @@ own team could see it.
 
 ## Open enforcement gap (tracked, not resolved by this plugin)
 
-**"Read-only" for this vendor rests on two operator-configured layers, and
-neither is enforced automatically today:**
+**"Read-only" for this vendor rests on exactly ONE real control, and
+Conduit does not enforce it:**
 
-1. The PostHog personal API key must be scoped to read-only `resource:action`
-   pairs at creation (see *The scope decision happens outside Conduit*
-   above) — Conduit does not inspect or verify this.
-2. The connection must use a gateway-side `customTools` allowlist naming
-   only the read families in this document, not an `admin` grant — Conduit
-   has no `VENDOR_TOOL_CONFIG` entry for `posthog` yet, so there is no
-   coarse `read` tier to fall back on if the allowlist is skipped or
-   misconfigured.
+1. The PostHog personal API key must be scoped to read-only
+   `resource:action` pairs at creation (see *The scope decision happens
+   outside Conduit* above) — Conduit does not inspect or verify this.
+   PostHog's own API rejects a write call against a properly-scoped key
+   before it reaches Conduit or this plugin, so a correctly-scoped key IS
+   a hard boundary — but nothing checks that the connecting operator
+   actually scoped it that way.
 
-**Neither layer is a hard boundary — both are instructions the connecting
-operator has to follow correctly.** An operator who pastes in a
-full-access key AND grants `admin` gets the complete, unrestricted
-upstream PostHog tool surface, including every write tool this document
-excludes, with nothing in Conduit stopping it. This is a real gap between
-what this document calls "read-only" and what Conduit actually enforces
-for a first adopt-vendor plugin — flagged to Aaron (2026-08-12) as an open
-question: whether adopt-vendor plugins like this one need a default-deny
-`VENDOR_TOOL_CONFIG` entry (or equivalent enforced default) shipped
-alongside the plugin itself, rather than relying on setup instructions
-alone. Not resolved by this PR; tracking here so it isn't lost.
+**There is no second, gateway-side layer for this vendor — not
+"unenforced if misconfigured," but structurally absent.** PostHog's MCP
+server exposes a single tool, `exec` (confirmed live via `tools/list`:
+one entry, schema `{command, context}`), that dispatches every operation
+— read and write alike — through a free-text `command` string. Conduit's
+`customTools` allowlist gates on the MCP tool NAME; with only one name to
+gate on, it can only ever choose between "this grantee can reach PostHog
+through Conduit" (the full upstream command surface) or "cannot" (nothing,
+not even reads). No allowlist configuration, correct or otherwise, can
+admit `dashboard-get` while excluding `conversations-tickets-reply-create`
+— Conduit cannot see inside the `command` string to tell them apart. An
+operator who pastes in a full-access key gets the complete, unrestricted
+upstream PostHog tool surface the moment ANY grant reaches `exec` at all —
+`admin` and a "read-family" allowlist are operationally identical for this
+vendor today. This is a real gap between what this document calls
+"read-only" and what Conduit actually enforces for a first adopt-vendor
+plugin of this shape — flagged to Aaron (2026-08-12), who has since
+directed Conduit-side engineering (command-argument sub-tool inspection
+for exec-dispatch vendors as a class; warden security review pending) to
+close it. Not resolved by this PR; tracking here so it isn't lost. Until
+that ships, treat PostHog as key-scope-only enforcement: if you cannot
+verify the connecting operator scoped the key read-only, assume this
+connection can write.
 
 ## Known sharp edges
 
 - **The tool surface is bigger than this document, on purpose.** This
-  plugin covers a deliberate subset. An operator who grants `admin` instead
-  of using the allowlist gets the entire upstream catalog — including tools
-  no skill or command here was written against.
+  plugin covers a deliberate subset. Any grant that reaches `exec` at all
+  gets the entire upstream catalog — including tools no skill or command
+  here was written against — since `admin` and an allowlist naming `exec`
+  are the same reach for this vendor (see *Tool permission tiers*).
 - **A key minted without explicit read-only scopes is read-write by
   default.** PostHog does not force an operator to narrow scopes at key
   creation; the read-only posture this document describes depends on the
@@ -241,8 +265,12 @@ alone. Not resolved by this PR; tracking here so it isn't lost.
   has its own read and write tools documented at the link above. Don't
   assume every "feature flag" question routes through the early-access
   tools — check `skills/feature-flags-and-experiments/SKILL.md`.
-- **Not yet classified means not yet safely grantable at a coarse tier.**
-  Until `posthog` gets a `VENDOR_TOOL_CONFIG` entry, there is no `read`
-  grant that admits only the families above — it is allowlist or `admin`,
-  nothing in between. Classifying the vendor, when it happens, is what
-  turns the family table above into an actual `read` tier.
+- **Not yet classified means not yet safely grantable at any coarse tier
+  OR allowlist.** Until `posthog` gets sub-tool-aware enforcement (a plain
+  `VENDOR_TOOL_CONFIG` entry alone can't express a mid-command split for a
+  single-tool vendor — see *Open enforcement gap*), there is no `read`
+  grant, and no `customTools` allowlist, that admits only the families
+  above. `exec` either reaches the connection or it doesn't — that is the
+  entire granularity Conduit has today. Classifying the vendor with real
+  command-level sub-tool inspection, when it ships, is what turns the
+  family table above into an actual enforced `read` tier.

--- a/msp-claude-plugins/posthog/posthog/GOVERNANCE.md
+++ b/msp-claude-plugins/posthog/posthog/GOVERNANCE.md
@@ -152,12 +152,25 @@ write tool once that coarse gate is open.
 
 ## Recommended agent policy
 
-Because this plugin ships no write surface, **read tools are safe to grant
-to autonomous and scheduled agents** — insight review, dashboard pulls for
-QBRs, feature-flag status checks, and cohort/event lookups are the intended
-unattended use. Grant them through the gateway allowlist naming the read
-families above; do not grant `admin` on this vendor, because `admin` reaches
-the full upstream surface including everything this document excludes.
+**This section's premise no longer holds as written — read *Tool permission
+tiers* above before granting unattended access.** This plugin ships no
+*documented* write surface, but Conduit cannot actually restrict a grant to
+the read families described in this document: any grant that reaches `exec`
+at all gets PostHog's entire command surface, reads and writes alike, gated
+only by the connecting operator's own key scope. There is no "grant through
+the gateway allowlist naming the read families" action available — `exec`
+is the only name; naming it is the same as granting `admin`.
+
+Before granting an autonomous or scheduled agent access to this vendor,
+confirm independently that the connected org's PostHog key is actually
+scoped read-only (see *The scope decision happens outside Conduit*) —
+Conduit provides no backstop if it isn't. An unattended agent with a
+read-write-scoped key and any grant on this vendor has the same write reach
+an interactive admin session would, with no human in the loop to notice a
+mistaken or adversarial `call` command before it executes
+(`conversations-tickets-reply-create`, feature-flag mutations, and
+`llma-*`/`alert-simulate` spend-incurring calls all included). If the key
+scope cannot be verified, do not grant this vendor to an unattended agent.
 
 There is no write tier to propose-then-approve here, unlike Xero or
 Freshdesk. If a future version of this plugin adds write tools, that
@@ -205,9 +218,13 @@ are not persisted by this plugin.
   written into PostHog's business-knowledge store, which may include
   internal notes not meant for a support or MSP audience.
 
-Restrict the insight, dashboard, and business-knowledge tools specifically
-if agents run unattended or render output where anyone outside the client's
-own team could see it.
+**Conduit cannot restrict the insight, dashboard, or business-knowledge
+tools specifically** — see *Tool permission tiers* above; any grant
+reaching `exec` reaches all of them together, plus every write tool. If any
+of the categories above are too sensitive for an unattended agent or a
+rendering surface outside the client's own team, don't grant this vendor to
+that agent at all — the only enforcement point available today is whether
+the grant exists, not which of PostHog's commands it can reach.
 
 ## Open enforcement gap (tracked, not resolved by this plugin)
 

--- a/msp-claude-plugins/posthog/posthog/README.md
+++ b/msp-claude-plugins/posthog/posthog/README.md
@@ -177,6 +177,15 @@ process and must update [GOVERNANCE.md](GOVERNANCE.md) accordingly.
 
 ## Changelog
 
+### 0.1.1 (2026-08-12)
+
+- GOVERNANCE.md, README.md, and skills/api-patterns/SKILL.md corrected: the
+  documented "two-layer" read-only enforcement (key scope + gateway
+  allowlist) was factually wrong — PostHog's MCP server exposes a single
+  `exec` tool, so the gateway allowlist can only admit or deny it wholesale,
+  never exclude write commands within it. Read-only now documented
+  correctly as resting on the key's own scope alone. No behavior change.
+
 ### 0.1.0 (2026-08-12)
 
 - Initial release — read-only at v1

--- a/msp-claude-plugins/posthog/posthog/README.md
+++ b/msp-claude-plugins/posthog/posthog/README.md
@@ -113,12 +113,14 @@ client** — `.mcp.json` declares only the gateway URL:
 
 ## Security Considerations
 
-- **Read-only is a two-layer control, not one.** It depends on (1) the
-  PostHog personal API key being scoped to read-only resources at creation,
-  and (2) Conduit's gateway-side tool allowlist for this vendor excluding
-  write tool names. See [GOVERNANCE.md](GOVERNANCE.md) — neither layer is
-  automatic, and this document does not control Conduit's actual per-tool
-  permission-tier enforcement.
+- **Read-only rests on exactly one real control: the PostHog personal API
+  key being scoped to read-only resources at creation.** There is no
+  gateway-side second layer for this vendor — PostHog's MCP server exposes
+  a single `exec` tool, so Conduit's tool allowlist can only admit or deny
+  it wholesale, not exclude write tool names from within it. See
+  [GOVERNANCE.md](GOVERNANCE.md), *Tool permission tiers* and *Open
+  enforcement gap*, for the full detail. If you cannot verify the connecting
+  operator scoped the key read-only, assume this connection can write.
 - Never paste a PostHog personal API key into a technician's local
   environment, a `.env` file, or this repo. It is entered once, in Conduit's
   connect UI, and stored server-side.

--- a/msp-claude-plugins/posthog/posthog/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/posthog/posthog/skills/api-patterns/SKILL.md
@@ -3,8 +3,9 @@ name: "PostHog API Patterns"
 description: >
   PostHog API fundamentals for this plugin: personal API key auth brokered
   through Conduit (no local key), the resource:action scope model, generic
-  REST error handling, and why this plugin's read-only posture is a
-  two-layer control rather than a single enforced boundary.
+  REST error handling, and why this plugin's read-only posture rests on the
+  key's own scopes alone — Conduit has no gateway-side fallback for this
+  vendor.
 when_to_use: >-
   When authenticating to PostHog, reasoning about key scopes, or debugging
   errors or rate limiting from the PostHog MCP server. Use when: posthog
@@ -67,12 +68,16 @@ Conduit having scoped the key correctly — see
 [GOVERNANCE.md](../../GOVERNANCE.md), *The scope decision happens outside
 Conduit, at key creation*.
 
-The second, independent layer is Conduit's own gateway-side tool allowlist
-for this vendor, which should also exclude write/mutating tool names as
-defense-in-depth — but that allowlist is a Conduit configuration, not
-something the PostHog key itself enforces. Neither layer alone is a hard
-guarantee; both together are how this plugin's read-only claim actually
-holds.
+**There is no second, independent layer for this vendor.** PostHog's MCP
+server exposes a single tool, `exec`, that dispatches every operation
+through a free-text `command` string — Conduit's gateway-side allowlist
+gates on the MCP tool NAME, and with only one name to gate on, it can only
+admit or deny `exec` wholesale, never exclude specific write commands
+within it. The key's own scope is the entire enforcement story for this
+vendor; treat a connection as read-write unless you can confirm the
+connecting operator actually scoped the key to read-only resources. See
+[GOVERNANCE.md](../../GOVERNANCE.md), *Tool permission tiers* and *Open
+enforcement gap*.
 
 ## Error Handling
 
@@ -102,15 +107,16 @@ multiple clients.
 
 ## Gotchas
 
-- **Read-only here is a two-layer convention, not a single enforced
-  boundary.** Both the key's scopes and Conduit's tool allowlist have to be
-  configured correctly for this plugin's read-only posture to actually
-  hold. See [GOVERNANCE.md](../../GOVERNANCE.md).
-- **`posthog` is not yet classified in Conduit's `VENDOR_TOOL_CONFIG`.**
-  Until it is, there is no coarse `read` tier grant that admits only this
-  plugin's read families — access has to go through the gateway allowlist.
-  See [GOVERNANCE.md](../../GOVERNANCE.md), *Tool permission tiers*, and
-  `wyre-gateway/GOVERNANCE.md` for the mechanism this depends on.
+- **Read-only here rests on exactly one control: the key's own scopes.**
+  There is no gateway-side allowlist granularity for this vendor — `exec`
+  is reachable or it isn't, and naming it in an allowlist is the same as
+  granting `admin`. See [GOVERNANCE.md](../../GOVERNANCE.md).
+- **`posthog` is not yet classified in Conduit's `VENDOR_TOOL_CONFIG`,
+  and classifying it would not add tool-family granularity either** — it
+  would only let Conduit require a coarse tier floor before `exec` is
+  reachable at all. See [GOVERNANCE.md](../../GOVERNANCE.md), *Tool
+  permission tiers*, and `wyre-gateway/GOVERNANCE.md` for the mechanism
+  this depends on.
 - **A key from the wrong PostHog organization doesn't error — it just
   returns that org's data.** If results look implausibly empty or
   unfamiliar, check which organization the connected key actually belongs


### PR DESCRIPTION
## Summary

Corrects a live customer-facing misrepresentation in the PostHog plugin docs (found during conduit#1369's live-verify): every doc claimed a working two-layer read-only enforcement — (1) the customer's PostHog key scope, and (2) a Conduit gateway-side tool allowlist excluding write tool names. **Layer 2 is structurally impossible for this vendor.** PostHog's MCP server exposes exactly one tool, `exec`, which dispatches every operation (read and write alike) through a free-text `command` string. Conduit's `customTools` allowlist gates on the MCP tool name; with only one name to gate on, naming `exec` is operationally identical to granting `admin`. There is no way to admit reads while excluding writes within that single tool.

Read-only for this vendor now honestly rests on exactly one control: the customer's own key scope. Conduit-side command-argument sub-tool inspection (design posted at conduit#1369) is the planned real fix; this PR documents the current state accurately in the meantime.

## Checklist of every changed location (warden: verify each landed)

**GOVERNANCE.md** — Sections A/B/C/D per warden's exact wording, plus 3 additional spots that repeated the same claim and would have contradicted the fixed sections if left as-is:
- [x] Section A — "Tool permission tiers" blockquote (verbatim, warden wording)
- [x] Section B — per-call-approval paragraph (verbatim, warden wording)
- [x] Section C — "Open enforcement gap" full section (verbatim, warden wording)
- [x] Section D — "Known sharp edges" bullet (verbatim, warden wording)
- [x] "The scope decision happens outside Conduit" — "depends entirely on the second layer below" → "is not enforced at all... no gateway-side fallback"
- [x] "What it cannot reach" — "documentation and allowlist convention" → "not enforced at all; no gateway-side fallback"
- [x] "Known sharp edges" (tool-surface-is-bigger bullet) — "admin instead of using the allowlist" → "any grant that reaches exec... admin and an allowlist naming exec are the same reach"

**README.md**:
- [x] "Security Considerations" — "two-layer control" bullet rewritten to one real control (key scope), no gateway-side second layer

**skills/api-patterns/SKILL.md** — this is what Claude itself reads at use-time, so a false safeguard claim here shapes agent behavior, not just human expectations:
- [x] Frontmatter `description` — "two-layer control" → "rests on the key's own scopes alone"
- [x] "The resource:action Scope Model" — "second, independent layer" paragraph rewritten to "no second, independent layer for this vendor"
- [x] "Gotchas" — both bullets ("two-layer convention"; "not yet classified... allowlist or admin, nothing in between") rewritten to match

All extra (non-warden-authored) spots use the same "structurally absent, key-scope is the only real control" framing as the verbatim A–D sections, for internal consistency across the diff.

## Test plan
- [ ] CI green (marketplace + plugin validation)
- [ ] warden line-by-line review
- [ ] Merge tonight on green + warden approval (Aaron greenlit merging this specific doc-correction PR without waiting for his morning look, unlike the conduit#1369 code fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/msp-claude-plugins/pr/216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->