### PR TITLE
docs(ci): clarify add-to-project pin comment (not floating @main)

### DIFF
--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   call:
-    uses: wyre-technology/.github/.github/workflows/auto-add-to-project.yml@c3314c1065f78adf905a815ad214c71266913771 # main
+    uses: wyre-technology/.github/.github/workflows/auto-add-to-project.yml@c3314c1065f78adf905a815ad214c71266913771  # pinned (not floating) -- bump manually when wyre-technology/.github's auto-add-to-project.yml changes, see .github#44
     secrets: inherit


### PR DESCRIPTION
The `# main` comment next to the SHA-pinned add-to-project reusable-workflow call was misleading -- it implied a floating ref when the call is actually pinned to a specific commit. This ambiguity is part of why a stale pin went undetected for hours after wyre-technology/.github#44 merged. Clarifies the comment to say it's pinned and needs a manual bump.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/msp-claude-plugins/pr/218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->