### PR TITLE
feat(3cx): add 3CX PBX plugin — native MCP server skills, commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,12 +2,27 @@
   "$schema": "https://www.schemastore.org/claude-code-marketplace.json",
   "name": "msp-claude-plugins",
   "description": "Community-driven Claude Code plugins for Managed Service Providers. Integrates with PSA, RMM, and documentation tools.",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "owner": {
     "name": "WYRE Technology",
     "email": "aaron@sachshaus.net"
   },
   "plugins": [
+    {
+      "name": "3cx",
+      "displayName": "3CX",
+      "source": "./msp-claude-plugins/3cx/3cx",
+      "description": "3CX - native PBX MCP server: directory/contacts, calls, queues, profiles, and PBX admin/diagnostics (V20 Update 10, Alpha)",
+      "category": "productivity",
+      "tags": [
+        "3cx",
+        "pbx",
+        "voip",
+        "telephony",
+        "unified-communications",
+        "msp"
+      ]
+    },
     {
       "name": "abnormal-security",
       "source": "./msp-claude-plugins/abnormal/abnormal-security",

--- a/msp-claude-plugins/3cx/3cx/.claude-plugin/plugin.json
+++ b/msp-claude-plugins/3cx/3cx/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "3cx",
+  "version": "0.1.0",
+  "description": "Claude plugins for 3CX's native PBX MCP server - directory and contacts, calls/recordings/voicemail, queues and profiles, and PBX admin/diagnostics",
+  "author": {
+    "name": "MSP Claude Plugins Community"
+  },
+  "homepage": "https://github.com/wyre-technology/msp-claude-plugins",
+  "repository": "https://github.com/wyre-technology/msp-claude-plugins",
+  "license": "Apache-2.0"
+}

--- a/msp-claude-plugins/3cx/3cx/GOVERNANCE.md
+++ b/msp-claude-plugins/3cx/3cx/GOVERNANCE.md
@@ -1,0 +1,186 @@
+# 3CX plugin — governance and safety model
+
+Unofficial. Community-built plugin for 3CX's native PBX MCP server. Not
+affiliated with, endorsed by, or sponsored by 3CX.
+
+## What it connects as
+
+3CX doesn't fit this marketplace's usual shape. Every other "reaches
+through the WYRE Conduit gateway" plugin points at one vendor-config entry
+and one fixed proxy URL. 3CX can't: every PBX is its own origin
+(`https://yourpbx.3cx.eu/mcp`, or whatever FQDN that customer's PBX
+actually uses) with its own OAuth authorization server, so there is no
+single endpoint for a `VENDOR_TOOL_CONFIG` entry to describe — and none
+exists. `src/credentials/vendor-config.ts` carries no `3cx` entry.
+
+Two real connection paths exist instead, and this plugin's `api-patterns`
+skill documents both:
+
+1. **Direct, standalone** (no gateway) — `claude mcp add --transport http`
+   pointed straight at that PBX's own MCP URL, with the technician
+   completing 3CX's own OAuth flow in the browser. Nothing brokers this:
+   the technician's Claude session holds a token scoped to that one PBX by
+   that PBX's own authorization server, and 3CX's own Admin Console
+   (**Admin → Integrations → MCP Clients**) is the audit and revocation
+   surface for it — not Conduit.
+2. **Through Conduit's BYO MCP feature** (`/connect/byo`), for an MSP who
+   wants this PBX's tools alongside their other Conduit-brokered vendors.
+   This is generic, vendor-agnostic code (`src/byo/*`), not anything
+   3CX-specific: Conduit discovers the PBX's own authorization server at
+   request time — RFC 9728 protected-resource metadata, then RFC 8414
+   authorization-server metadata (`src/byo/byo-oauth.ts:8-11`) — registers
+   a client dynamically (RFC 7591 DCR), and validates the callback's `iss`
+   against the discovered issuer before persisting tokens (RFC 9207,
+   `byo-oauth.ts:22-25`). `src/byo/byo-registration-routes.ts` is the real
+   route table: `GET`/`POST /connect/byo`, `POST /connect/byo/:id/delete`,
+   `POST /connect/byo/:id/tools/tier`.
+
+Consequences worth stating plainly, for whichever path is used:
+
+- **Direct connection:** no credential is brokered anywhere. The OAuth
+  token lives only in that technician's local Claude Code state, scoped to
+  that one PBX, revocable from that PBX's own Admin Console. There is no
+  org-wide audit log across technicians for this path — each connection is
+  its own island.
+- **Conduit BYO connection:** the PBX's OAuth tokens are stored at Conduit
+  like any other credential (see `wyre-gateway/GOVERNANCE.md`), so an org
+  gets the usual centrally-brokered story — no per-technician secret, one
+  place to see who's connected, and Conduit's usual
+  revocation-on-org-removal behavior applies. But Conduit is standing in
+  front of a vendor it has never specifically classified, which is the
+  point of the next section.
+
+## Tool permission tiers
+
+**3CX has no `VENDOR_TOOL_CONFIG` entry, and structurally cannot get the
+normal kind** — that table is keyed by a fixed vendor slug pointing at a
+fixed endpoint, and 3CX has neither. That puts it in a different bucket
+than the classified-vs-unclassified catalog-vendor list in
+`wyre-gateway/GOVERNANCE.md`, *Fail-closed, and the vendors Conduit has not
+classified* — that list is catalog vendors that merely haven't been
+classified yet. 3CX isn't a catalog vendor at all.
+
+**Direct connection:** no Conduit tier gate sits in this path at all. What
+Claude can call is bounded only by the 3CX account's own role inside that
+PBX (see *Permission Model* in the `api-patterns` skill) — there is no
+read/write/admin layer on top of it.
+
+**Conduit BYO connection:** every BYO tool instead goes through
+`classifyByoTool` (`src/byo/byo-tool-classifier.ts:115`), a heuristic that
+infers a tier from the tool's name and description because there is no
+hand-curated config to read for an uncataloged vendor. It is deliberately
+conservative:
+
+| Signal | Effect | Source |
+|---|---|---|
+| Leading verb in a fixed read-shaped set (`get`, `list`, `search`, `find`, `query`, `read`, `fetch`, `describe`, `show`, `view`, `lookup`, `count`, `export`, `download`, `status`, `check`, and a few more) | tiers `read` | `byo-tool-classifier.ts:41-46` |
+| Any other leading verb, including one the heuristic has simply never seen | tiers `write` — **unrecognized verbs are never silently treated as read** | `byo-tool-classifier.ts:132-134` |
+| A secret/credential noun anywhere in the name or description (`secret`, `password`, `credential`, `token`, `apikey`, …) | escalates to `admin` regardless of verb | `byo-tool-classifier.ts:76-80, 129` |
+| A mutating verb on a privileged-account noun (`role`, `member`, `billing`, `apikey`, `org`, `setting`, …) | escalates to `admin` | `byo-tool-classifier.ts:62-69, 130` |
+
+Mapped against the tool groups this plugin's skills document:
+
+- The read-only lookups (find/search/list/get/describe-shaped capabilities —
+  contacts, calls, recordings, voicemail, queues, departments, profiles,
+  server time, event log, services, app logs, DIDs, blocklists, peers,
+  tables, SIP trunks, call flow apps) tier `read` **as long as 3CX's real
+  tool names actually lead with one of the recognized read verbs.** This
+  plugin describes them by capability, not by an exact name, precisely
+  because that hasn't been verified — see the `api-patterns` skill.
+- The write actions (drop a call, select/activate a profile, set/clear a
+  profile message, apply a temporary override, log an agent or the current
+  user in/out of queues, add/remove a blocklist or blacklist entry, assign
+  a DID) all use non-read-shaped verbs, so they tier `write` under this
+  heuristic — conservatively correct, not something this plugin had to
+  argue for.
+- **The `Query` tool is the one genuine ambiguity in this table.** 3CX
+  enforces `SELECT`-only server-side no matter what (see the `pbx-admin`
+  skill), but the BYO classifier tiers on the tool's *name*, not the PBX's
+  own enforcement. If 3CX's real tool name for it is built around a
+  generic "run" or "execute" action rather than a `get`/`list`/`query`-style
+  read verb, Conduit will tier it `write` despite it being incapable of
+  writing anything, and it would never
+  escalate to `admin` either way since no privileged/secret noun applies.
+  That is a usability gap (a `read`-tier grant might not reach it), not a
+  safety gap — the PBX's own `SELECT`-only enforcement is the real
+  backstop regardless of how Conduit tiers the name.
+
+Conduit compares tiers; it has no approval step, no per-call confirmation,
+and no interactive prompt on the BYO path any more than on the catalog
+path. Per-call approval is a workflow imposed on agent configuration, not
+something Conduit enforces.
+
+## Recommended agent policy
+
+The safe default is **read autonomously, propose writes, never
+self-approve a call-affecting action.**
+
+- Read tools (directory, calls/queue visibility, diagnostics, inventory,
+  the `Query` tool): safe to allow autonomously once connected.
+- `calls-queues` write tools (drop a call, switch a profile, log a queue
+  agent in/out): agent drafts the exact call — target extension, queue, or
+  call ID named explicitly — a human confirms, then it runs. Never grant to
+  a scheduled or unattended agent; the effect on a live caller or a queue's
+  staffing is immediate and has no undo.
+- `pbx-admin` write/delete tools (blocklist/blacklist entries, DID
+  assignment): the same discipline as any production network-ACL or
+  call-routing change — a named human approver, the exact value confirmed,
+  never unattended.
+- If connected via Conduit BYO, remember the `Query`-tool tiering gap
+  above: a `read`-tier grant may not reach it even though it can never
+  write anything. Use a `customTools` allowlist if a read-only analyst
+  needs the `Query` tool specifically without also granting `write` on
+  this PBX.
+
+## What it cannot reach
+
+- Only the one PBX the connection (direct or BYO) was set up against.
+  There is no cross-PBX aggregation anywhere in this plugin — an MSP
+  managing multiple customers' 3CX systems needs a separate connection per
+  PBX.
+- Only what the connecting 3CX account's own role permits inside 3CX.
+  Neither this plugin nor Conduit narrows that further — a broad 3CX role
+  is a broad grant here too.
+- No filesystem, no shell, no other vendor's data.
+- Nothing beyond what 3CX shipped in the V20 Update 10 Alpha tool set — no
+  extension provisioning, no license/billing surface, and no write access
+  to anything not explicitly listed in the *Write/Delete Capabilities*
+  sections of the `calls-queues` and `pbx-admin` skills.
+
+## Data handling
+
+- Responses pass into the model's context for the session; the BYO path
+  additionally passes through Conduit but is not persisted there beyond
+  the credential itself.
+- Directory and contact lookups return PII — names, emails, and (via
+  CRM-integrated search) whatever the connected CRM syncs to that PBX.
+- Recordings and voicemail lists are scoped to "available to the
+  authenticated user" per 3CX's own documentation — that is the account
+  that approved the connection, so what a technician sees through this
+  plugin can differ from what they would see logged into 3CX under their
+  own account.
+- Event log and application log search can surface configuration detail
+  and internal IP addressing — treat it as internal infrastructure data,
+  not something to paste into a customer-facing document unreviewed.
+
+## Known sharp edges
+
+- **This is Alpha software.** 3CX's own release notes describe Update 10
+  Alpha as "intended for testing and evaluation only." Tool names, the
+  permissions reference, and enforcement behavior can all change before
+  GA — re-verify against `tools/list` on the actual PBX rather than
+  trusting this document indefinitely.
+- **3CX has not published exact tool-name strings.** Every skill in this
+  plugin describes tools by capability rather than an invented snake_case
+  identifier, and the tier table above is conditioned on that rather than
+  asserted as verified fact.
+- **The direct-connection path has no cross-technician audit trail.**
+  Unlike a Conduit-brokered vendor, a directly-connected PBX only shows
+  that one technician's connection in 3CX's own Admin Console — there is
+  no org-wide "who connected which PBX" view unless every connection goes
+  through Conduit's BYO path instead.
+- **Don't conflate this with the community *3cx-mcp-server* project.**
+  Different codebase, different auth model, different tool surface —
+  including a licensing claim ("Enterprise/Enterprise Plus required") that
+  belongs to that project and is not confirmed for 3CX's native MCP
+  server.

--- a/msp-claude-plugins/3cx/3cx/README.md
+++ b/msp-claude-plugins/3cx/3cx/README.md
@@ -1,0 +1,183 @@
+# 3CX Plugin
+
+Claude Code plugin for 3CX's native PBX MCP server — directory and contact
+lookups, live call/queue/profile visibility (plus the write actions that
+change it), and PBX administration and diagnostics.
+
+## Overview
+
+3CX added an MCP server built directly into the PBX, introduced in
+**3CX V20 Update 10** (announced July 30, 2026 as an **Alpha** release — 3CX
+describes Update 10 Alpha as "intended for testing and evaluation only").
+Treat this plugin as based on that Alpha: exact tool names and behavior may
+shift before 3CX ships Update 10 GA. See the `api-patterns` skill and
+`GOVERNANCE.md` for the full detail.
+
+This plugin provides Claude with deep knowledge of that MCP server, enabling:
+
+- **Directory & Contacts** — resolve a caller by email, exact extension, phonebook, or CRM-synced contact
+- **Calls, Queues & Profiles** — see who's on a call, queue staffing, recordings, and voicemail; drop calls, switch profiles, and manage queue login state
+- **PBX Admin & Diagnostics** — server health, event/application logs, a read-only database query tool, DIDs, SIP trunks, call flow apps, and blocklist/blacklist/DID management
+
+This is **not** the same project as the community *SSIG-IT/3cx-mcp-server*
+on GitHub — that's a separate, third-party server talking to 3CX's REST
+API. Don't carry claims (including licensing requirements) between the two.
+
+## How This Is Different From Other Plugins Here
+
+Every 3CX PBX is its own endpoint with its own OAuth authorization server —
+there's no shared `mcp.3cx.com` the way there's a shared
+`mcp.pax8.com`. That means this plugin doesn't fit WYRE Conduit's usual
+single-shared-endpoint vendor catalog, and there's no `.mcp.json` shipped
+with it. Two real connection paths exist instead:
+
+1. **Direct**, standalone — connect Claude straight to a specific PBX.
+2. **Through Conduit's BYO MCP feature** (`/connect/byo`) — for MSPs who
+   want this PBX alongside their other Conduit-brokered vendors.
+
+Both are covered below and in the `api-patterns` skill.
+
+## Prerequisites
+
+- A 3CX PBX running **V20 Update 10** (Alpha or later) with the MCP server
+  feature available
+- An account on that PBX with the 3CX role appropriate for what you want
+  Claude to be able to do — tool access is entirely inherited from
+  whichever account approves the connection
+
+### Admin-side setup (once, per PBX)
+
+1. Sign into that PBX's 3CX Admin Console.
+2. **Admin → Integrations → MCP Clients → Add MCP Client**.
+3. Copy the MCP Server URL 3CX displays (pattern:
+   `https://yourpbx.3cx.eu/mcp` — the actual FQDN is specific to that PBX).
+
+## Installation
+
+### Direct Connection (Claude Code, no gateway)
+
+```bash
+claude mcp add --scope project --transport http 3CX "https://yourpbx.3cx.eu/mcp"
+claude
+```
+
+Then inside Claude:
+
+1. Run `/mcp` and select the `3CX` server.
+2. Choose **Authenticate** — Claude opens 3CX's own authorization page in
+   the browser.
+3. Sign in, review the requested access, and select **Allow**.
+
+The connection then also appears in that PBX's own
+**Admin → Integrations → MCP Clients** list.
+
+### Via WYRE Conduit's BYO MCP Feature
+
+If your organization already uses [Conduit](https://conduit.wyre.ai) for
+other vendors, paste the PBX's MCP URL from the admin step above into
+Conduit's BYO MCP registration form at `/connect/byo`. Conduit
+auto-discovers the PBX's OAuth flow and completes the authorization —
+no vendor-specific setup is needed on Conduit's side. See `GOVERNANCE.md`
+for exactly how Conduit tiers this PBX's tools once connected this way.
+
+## Available Skills
+
+| Skill | Description |
+|-------|-------------|
+| `directory` | Contact and extension lookups — email, exact extension, phonebook, CRM-synced |
+| `calls-queues` | Active calls, recordings, voicemail, queue/department/profile visibility, and the write actions that change live routing |
+| `pbx-admin` | System diagnostics, PBX inventory/database, the read-only `Query` tool, call flow apps, and blocklist/blacklist/DID writes |
+| `api-patterns` | Connection setup (direct and Conduit BYO), the inherited permission model, and how to discover the live tool surface |
+
+## Available Commands
+
+| Command | Description |
+|---------|-------------|
+| `/find-contact` | Resolve a contact or extension by email, extension, or name |
+| `/pbx-health-check` | Quick PBX liveness sweep — server time, service status, recent event log |
+| `/queue-status` | Staffing and active-call snapshot for one queue or all accessible queues |
+
+## Quick Start
+
+### Find a Contact
+
+```
+/find-contact jane@acmecorp.com
+```
+
+### Check PBX Health
+
+```
+/pbx-health-check
+```
+
+### Check Queue Staffing
+
+```
+/queue-status "Support"
+```
+
+## Security Considerations
+
+- Tool access is entirely inherited from the 3CX account that approved the
+  connection — there is no separate Claude-specific permission layer.
+- The `Query` database tool is hard-restricted server-side to read-only
+  `SELECT`, regardless of the connecting account's role.
+- The write actions in `calls-queues` and `pbx-admin` have an immediate,
+  visible effect on real calls, real callers, and real routing, with no
+  built-in undo — see the **Write Capabilities** section of each skill and
+  `GOVERNANCE.md`'s *Recommended agent policy* before granting them to any
+  automated or unattended workflow.
+- 3CX has not published exact MCP tool-name strings publicly. This plugin
+  describes tools by capability rather than inventing identifiers; always
+  confirm the live tool set with `tools/list` against the actual PBX.
+
+See `GOVERNANCE.md` for the full trust model, including how Conduit's BYO
+connector tiers this vendor's tools when there's no hand-curated
+classification to draw from.
+
+## Troubleshooting
+
+### Authentication errors
+
+1. Re-run `/mcp` → **Authenticate** for the `3CX` server.
+2. Confirm the connection still shows under that PBX's
+   **Admin → Integrations → MCP Clients**.
+3. If it was removed there, re-run the `claude mcp add` step and
+   reauthenticate.
+
+### Tool names don't match what a skill describes
+
+3CX has not published a fixed tool-name list, and this is Alpha software —
+call `tools/list` against the connected PBX for the authoritative current
+names rather than assuming this plugin's descriptions are literal
+identifiers.
+
+### No tools available after connecting
+
+Confirm the PBX is running V20 Update 10 (or later) with the MCP server
+feature enabled, and that the connecting 3CX account has a role that
+grants at least read access to the areas you're trying to use.
+
+## API Documentation
+
+- 3CX's own "MCP Tools and Permissions Reference" (via the Admin Console's
+  MCP Clients documentation) is the authoritative source for tool
+  capabilities and permission groupings.
+- [3CX V20 Update 10 release notes](https://www.3cx.com) — check for GA
+  status and any tool-surface changes since this plugin was written.
+
+## Contributing
+
+See the main [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+
+## Changelog
+
+### 0.1.0 (2026-08-21)
+
+- Initial release
+- 4 skills: api-patterns, directory, calls-queues, pbx-admin
+- 3 commands: find-contact, pbx-health-check, queue-status
+- Documents both the direct standalone connection and Conduit's BYO MCP
+  path, since 3CX has no fixed shared endpoint for a normal Conduit
+  vendor-catalog entry

--- a/msp-claude-plugins/3cx/3cx/commands/find-contact.md
+++ b/msp-claude-plugins/3cx/3cx/commands/find-contact.md
@@ -1,0 +1,67 @@
+---
+description: Resolve a 3CX contact or extension by email, extension, or name
+argument-hint: "<email, extension, or name>"
+arguments: [identifier]
+---
+
+# Find Contact
+
+Resolve who a phone identifier belongs to inside 3CX — by email address,
+exact extension, or name — checking exact-match lookups first and falling
+back to phonebook and CRM-integrated contact search.
+
+## Prerequisites
+
+- A 3CX PBX connected (directly or through Conduit's BYO connector) with a
+  valid, authenticated MCP session — see the `api-patterns` skill
+- The identifier's type known ahead of time if possible: email, extension
+  number, or name — this changes which lookup to try first
+
+## Steps
+
+1. **Try the exact-match lookup that fits the identifier**
+
+   If given an email address, use the find-contact-by-email capability. If
+   given a number that looks like an extension, use the
+   find-contact-by-exact-extension capability. Exact-match lookups don't
+   fuzzy match, so a wrong or partial extension returns nothing rather
+   than a close guess.
+
+2. **Fall back to phonebook and CRM search on a miss, or if given a name**
+
+   Search 3CX phonebooks and search CRM-integrated contacts in parallel.
+   Treat an empty CRM-integrated result as "not synced on this PBX," not
+   "doesn't exist in the CRM" — see the `directory` skill for why.
+
+3. **If still unresolved, list PBX users/extensions**
+
+   Useful when the identifier is close to a known extension but doesn't
+   match exactly, or when confirming a name against the raw user list.
+
+4. **Report what was found**
+
+   State which lookup resolved it (email match, extension match, phonebook,
+   or CRM sync) so the requester knows how current the result is — a
+   CRM-synced match is only as fresh as that PBX's CRM connector.
+
+## Examples
+
+```
+/find-contact jane@acmecorp.com
+/find-contact 1042
+/find-contact "Jane Smith"
+```
+
+## Error Handling
+
+- **No match anywhere:** Confirm the identifier's exact spelling/format
+  with the requester before concluding the contact doesn't exist — exact
+  lookups are unforgiving of typos.
+- **CRM-integrated search returns nothing but the contact should exist in
+  the CRM:** That PBX's CRM connector may not be configured or may be
+  stale — this is a sync-scope limitation, not proof the contact is
+  missing from the CRM itself.
+
+## Related Commands
+
+- `/queue-status` — check whether a resolved contact's extension is currently in a queue or on a call

--- a/msp-claude-plugins/3cx/3cx/commands/pbx-health-check.md
+++ b/msp-claude-plugins/3cx/3cx/commands/pbx-health-check.md
@@ -1,0 +1,69 @@
+---
+description: Quick health check for a connected 3CX PBX
+argument-hint: ""
+arguments: []
+---
+
+# PBX Health Check
+
+A quick read-only sweep of PBX liveness: current server time, service
+status, and a recent-window scan of the structured event log for a
+failure pattern.
+
+## Prerequisites
+
+- A 3CX PBX connected (directly or through Conduit's BYO connector) with a
+  valid, authenticated MCP session — see the `api-patterns` skill
+
+## Steps
+
+1. **Confirm connectivity**
+
+   Get the current PBX server time. A successful response confirms the
+   session is live and authenticated before spending calls on anything
+   else.
+
+2. **Check service status**
+
+   List PBX services and their state. Note any service not in a healthy
+   running state.
+
+3. **Scan the recent event log**
+
+   Search/list the structured PBX event log for a recent window (start
+   with the last few hours). Look for a *pattern* of related failures
+   rather than treating a single isolated entry as significant — PBX event
+   logs are noisy by nature.
+
+4. **Synthesize**
+
+   Report:
+   - Whether the PBX responded and server time looks correct (not wildly
+     skewed from expected)
+   - Any service not in a healthy state, named explicitly
+   - Any recurring event-log pattern in the recent window, with
+     timestamps
+
+   Do not report "PBX is healthy" as a single yes/no if any service is
+   degraded or the event log shows a repeating pattern — state each
+   finding explicitly so the reader can judge severity themselves.
+
+## Examples
+
+```
+/pbx-health-check
+```
+
+## Error Handling
+
+- **Server time call fails or times out:** The MCP session itself may have
+  expired — re-authenticate per the `api-patterns` skill before assuming
+  the PBX itself is down.
+- **Event log search returns nothing:** Confirm the queried time window is
+  correct before reporting "no events" — an empty result for an
+  unexpectedly narrow or misaligned window looks identical to a genuinely
+  quiet PBX.
+
+## Related Commands
+
+- `/queue-status` — staffing-specific check, narrower than this general health sweep

--- a/msp-claude-plugins/3cx/3cx/commands/queue-status.md
+++ b/msp-claude-plugins/3cx/3cx/commands/queue-status.md
@@ -1,0 +1,64 @@
+---
+description: Snapshot of 3CX queue staffing and active call load
+argument-hint: "[queue name or ID]"
+arguments: [queue]
+---
+
+# Queue Status
+
+A read-only staffing snapshot for one queue, or every queue the connected
+account can access if none is specified: who's logged in, and how many
+calls are active against it right now.
+
+## Prerequisites
+
+- A 3CX PBX connected (directly or through Conduit's BYO connector) with a
+  valid, authenticated MCP session — see the `api-patterns` skill
+- MCP tools available for listing queues, a queue's agents, and currently
+  active calls (see the `calls-queues` skill)
+
+## Steps
+
+1. **Resolve the queue(s) in scope**
+
+   If a queue name or ID was given, use it directly. Otherwise, list
+   queues the user can access/manage and cover all of them.
+
+2. **Pull staffing for each queue**
+
+   List each queue's agents. Note which are logged in versus logged out —
+   a queue can look adequately staffed by headcount while most agents are
+   actually logged out.
+
+3. **Cross-reference active call load**
+
+   List currently active calls and match them against the queue(s) in
+   scope, where the tool's response makes that association available.
+
+4. **Report**
+
+   For each queue: agent count, logged-in count, and active call count.
+   Flag any queue with active calls but zero logged-in agents — that's the
+   pattern that actually matters, not raw call volume.
+
+## Examples
+
+```
+/queue-status
+/queue-status "Support"
+/queue-status queue-42
+```
+
+## Error Handling
+
+- **Queue not found:** Re-list queues the user can access/manage — the
+  requested name or ID may not match, or may belong to a queue this
+  connection's account can't see.
+- **No active calls returned but the queue is known to be busy:** Confirm
+  the MCP session hasn't gone stale (see `/pbx-health-check`) before
+  reporting the queue as idle.
+
+## Related Commands
+
+- `/find-contact` — resolve who a specific agent extension belongs to
+- `/pbx-health-check` — broader PBX liveness check if queue data looks stale or missing

--- a/msp-claude-plugins/3cx/3cx/skills/api-patterns/SKILL.md
+++ b/msp-claude-plugins/3cx/3cx/skills/api-patterns/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: "3CX API Patterns"
+description: >
+  3CX's native PBX MCP server: the per-PBX endpoint shape (every PBX is its
+  own FQDN and its own OAuth authorization server — there is no shared
+  mcp.3cx.com), the Admin Console + client setup flow, the permission model
+  (fully inherited from the 3CX account that approved the connection), and
+  how to discover the live tool surface since 3CX has not published exact
+  tool-name strings.
+when_to_use: >-
+  When connecting Claude to a 3CX PBX for the first time, troubleshooting a
+  3CX MCP connection or authorization failure, or figuring out which 3CX MCP
+  tools are actually available before calling one. Use when: 3cx connect,
+  3cx mcp, 3cx setup, 3cx oauth, 3cx authenticate, 3cx admin console, 3cx
+  mcp client, 3cx byo, or 3cx pbx url.
+---
+
+# 3CX API Patterns
+
+## Overview
+
+3CX added a native MCP server built directly into the PBX, introduced in
+**3CX V20 Update 10** (announced July 30, 2026 as an **Alpha** release — 3CX's
+own release notes describe Update 10 Alpha as "intended for testing and
+evaluation only"). Treat everything in this plugin as based on that Alpha:
+exact tool names, the permissions reference, and behavior may all shift
+before 3CX ships Update 10 GA.
+
+This is a different project from the older third-party *SSIG-IT/3cx-mcp-server*
+on GitHub, a community-built MCP server that talks to 3CX's REST API rather
+than shipping inside the PBX. Do not mix the two up, and do not carry
+claims from the community project into this one — in particular, its
+"Enterprise/Enterprise Plus license required" claim is specific to that
+project and is **not** confirmed for 3CX's native MCP server.
+
+## Anti-triggers
+
+- **The community *3cx-mcp-server* project** — different codebase, different
+  tool surface, different auth model (its own API-key setup rather than
+  per-PBX OAuth). Nothing in this plugin describes it, and nothing about it
+  should be assumed here.
+- **A customer's "the phones are down" ticket** — that's ticket handling in
+  the PSA, not a 3CX MCP call. Use `halopsa-tickets`, `connectwise-psa-tickets`,
+  or `autotask-tickets` to work the ticket itself; come back to this plugin
+  once you need the PBX-side facts.
+- **WYRE's Conduit vendor catalog** — 3CX has no catalog entry there and,
+  structurally, cannot: Conduit's catalog vendors share one fixed endpoint
+  per vendor, and every 3CX PBX is its own origin with its own authorization
+  server. See *Connection & Authentication* below for the two ways this
+  plugin actually reaches a PBX.
+
+## Connection & Authentication
+
+### Every PBX is its own endpoint
+
+Unlike a hosted SaaS MCP server, there is no single 3CX MCP URL. Each PBX
+exposes its own endpoint at its own FQDN, following the pattern:
+
+```
+https://yourpbx.3cx.eu/mcp
+```
+
+(or whatever FQDN that customer's PBX actually uses). Transport is
+Streamable HTTP. A skill, command, or agent in this plugin that needs to
+call a tool always does so against whichever PBX endpoint the current
+session is already connected to — nothing here can assume a fixed URL
+across customers.
+
+### Admin-side setup (on the PBX)
+
+An admin enables the connection from inside that PBX's own console:
+
+1. Sign into the 3CX Admin Console for the target PBX.
+2. **Admin → Integrations → MCP Clients → Add MCP Client**.
+3. 3CX displays the MCP Server URL for that PBX — copy it for the client-side
+   step below.
+
+### Client-side setup — direct connection (no gateway)
+
+For a technician working standalone in Claude Code, with no MSP gateway in
+front of it:
+
+```bash
+claude mcp add --scope project --transport http 3CX "https://yourpbx.3cx.eu/mcp"
+claude
+```
+
+Then inside Claude:
+
+1. Run `/mcp` and select the `3CX` server.
+2. Choose **Authenticate**. Claude opens the 3CX authorization page in the
+   browser.
+3. Sign in, review the requested access, and select **Allow**.
+4. Claude confirms the connection succeeded.
+
+The new connection also then shows up in that PBX's own
+**Admin → Integrations → MCP Clients** list — the authorization is visible
+and revocable from both sides.
+
+### Client-side setup — through Conduit's BYO MCP feature
+
+An MSP already using WYRE's Conduit gateway for other vendors does not need
+a separate direct connection per PBX. Conduit has a generic
+**"Bring Your Own (BYO) MCP server"** feature (`/connect/byo`) built for
+exactly this shape — a vendor with no fixed shared endpoint. Paste the
+PBX's MCP URL from the admin step above into that form; Conduit then:
+
+1. Discovers the PBX's own OAuth authorization server at runtime —
+   RFC 9728 protected-resource metadata, then RFC 8414 authorization-server
+   metadata.
+2. Registers a client dynamically against that authorization server
+   (RFC 7591 DCR).
+3. Runs the normal authorization-code + PKCE flow, validating the callback's
+   `iss` against the discovered issuer (RFC 9207) before persisting tokens.
+
+No 3CX-specific code exists in Conduit for this — the same generic BYO path
+handles any MCP server shaped this way. See *Tool permission tiers under
+Conduit BYO* below for how Conduit decides what an operator may call once
+connected, and this plugin's `GOVERNANCE.md` for the full picture.
+
+## Permission Model
+
+Tool access is entirely inherited from the 3CX user account that approved
+the OAuth connection. Claude can do exactly what that account's 3CX role
+already permits inside 3CX — nothing more. There is no separate
+Claude-specific permission layer on the PBX side.
+
+One tool is restricted regardless of role: the `Query` tool (see the
+`pbx-admin` skill) is hard-restricted server-side to read-only SQL
+`SELECT` statements, no matter what the connecting account is otherwise
+allowed to do in 3CX.
+
+## Discovering the Live Tool Surface
+
+3CX's own "MCP Tools and Permissions Reference" documents these tools by
+human-readable label — find a contact by email, list active calls, drop a
+call, and so on — but does not publish the literal machine tool-name
+strings anywhere publicly accessible. The skills in this plugin describe
+the tool surface by capability for that reason, deliberately without
+inventing exact snake_case identifiers that cannot be verified against a
+real PBX.
+
+**Before calling a tool, confirm its real name and schema** by calling the
+standard MCP `tools/list` method against the connected PBX. This is also the
+only reliable way to know what changed between the Update 10 Alpha and any
+later release — the tool surface described here is a snapshot, not a
+guarantee.
+
+## Tool Permission Tiers Under Conduit BYO
+
+If a PBX is reached through Conduit's BYO path rather than a direct
+connection, Conduit still has to decide a permission tier for each tool it
+has never seen before — there is no hand-curated `VENDOR_TOOL_CONFIG` entry
+for 3CX to draw from. It does this with a name-and-description heuristic
+that is deliberately conservative:
+
+- A leading verb from a fixed read-shaped set (`get`, `list`, `search`,
+  `find`, `query`, and similar) tiers the tool `read`.
+- Any other leading verb — including one the heuristic has simply never
+  seen before — tiers the tool `write`. Unrecognized verbs are never
+  silently treated as read.
+- A secret/credential noun anywhere in the name or description escalates
+  to `admin`, and a mutating verb on a privileged-account noun (roles,
+  members, billing, API keys, org settings) does too.
+
+This matters concretely for one 3CX tool: the read-only `Query` tool is
+enforced `SELECT`-only *inside the PBX*, but Conduit's heuristic tiers
+purely on the tool's name. If that tool's real name is built around a
+generic "run" or "execute" action rather than a `get`/`list`/`query`-style
+read verb, Conduit will tier it `write` despite the PBX-side restriction.
+Don't assume `read` for it; check the tool's actual granted tier after
+connecting.
+
+## Gotchas
+
+- **This is Alpha software.** Exact tool names, the permissions reference,
+  and behavior can all change before 3CX ships Update 10 GA. Re-verify
+  against `tools/list` rather than trusting a cached mental model, especially
+  months after this was written.
+- **No shared URL.** Every other skill and command in this plugin assumes an
+  already-connected PBX; there is nothing to hardcode across customers.
+- **Don't borrow tool names from the community *3cx-mcp-server* project** —
+  it is a different codebase talking to a different API surface.
+
+## Related Skills
+
+- [Directory & Contacts](../directory/SKILL.md) — contact and extension lookups
+- [Calls, Queues & Profiles](../calls-queues/SKILL.md) — live call/queue state and the write actions that change it
+- [PBX Admin & Diagnostics](../pbx-admin/SKILL.md) — system diagnostics, PBX inventory, and configuration writes

--- a/msp-claude-plugins/3cx/3cx/skills/calls-queues/SKILL.md
+++ b/msp-claude-plugins/3cx/3cx/skills/calls-queues/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: "3CX Calls, Queues & Profiles"
+description: >
+  3CX's live-operations surface: read-only visibility into active calls,
+  recordings, voicemail, department and queue membership, and
+  forwarding/presence profiles, plus the write actions that change live
+  call routing — dropping a call, switching a profile, and logging a queue
+  agent in or out.
+when_to_use: >-
+  When checking who is on a call right now, queue staffing, recordings or
+  voicemail, or when changing a user's or queue's live call-routing state.
+  Use when: 3cx active calls, 3cx queue, 3cx voicemail, 3cx recording, 3cx
+  profile, 3cx forwarding, drop call 3cx, or log agent 3cx.
+---
+
+# 3CX Calls, Queues & Profiles
+
+## Overview
+
+This is the plugin's live-operations surface. Most of it is read-only
+visibility into what's happening on the PBX right now; a smaller set of
+tools actually change it — ending a call, switching who a person's calls
+route to, or moving a queue agent in or out of rotation.
+
+## Anti-triggers
+
+- **A customer-facing service ticket about a call quality or outage issue**
+  — that's PSA ticket handling (`halopsa-tickets`, `connectwise-psa-tickets`,
+  `autotask-tickets`), not this skill. Use this skill to gather the PBX-side
+  facts (was the queue staffed, was the call actually dropped), then work
+  the ticket in the PSA.
+- **A security incident involving the phone system** (toll fraud, a
+  compromised extension) — that's `huntress-incidents` or
+  `sentinelone-alerts` territory for the response workflow; this skill only
+  reports current call/queue state, it doesn't investigate or remediate.
+
+## Read-Only Capabilities
+
+Exact tool names are not published by 3CX — see the `api-patterns` skill
+and call `tools/list` for the authoritative names on a connected PBX.
+
+- List currently active calls
+- List recordings available to the authenticated user
+- List voicemail items available to the authenticated user
+- List a department's members
+- List departments accessible to the user
+- List forwarding/presence profiles available to the user
+- List a queue's agents
+- List queues the user can access/manage
+
+## Write Capabilities — Read This Before Calling Any of Them
+
+- Drop (end) an active call
+- Select/activate a forwarding-or-presence profile
+- Set or clear the active profile's message
+- Apply a temporary profile override
+- Log a queue agent in/out
+- Log the current user in/out of queues
+
+These change what a real person on a real call experiences immediately,
+and none of them have a built-in undo. Dropping a call ends it for the
+caller too, not just the technician's view of it. Switching someone's
+forwarding/presence profile mid-shift redirects their calls right away —
+if you get the wrong extension, someone's calls start ringing somewhere
+else with no obvious warning to either party. Logging the wrong agent out
+of a queue during business hours quietly reduces staffing for everyone
+still waiting in it. 3CX's own MCP Tools and Permissions Reference groups
+these separately from the read tools for exactly this reason; this
+plugin's `GOVERNANCE.md` covers how Conduit's BYO connector tiers them.
+
+**Confirm the target call, extension, or queue ID with the requester
+before calling any of these**, and don't let a scheduled or unattended
+agent invoke them — a mistake here is visible to the customer immediately
+and cannot be quietly corrected after the fact.
+
+## Common Workflows
+
+### Is anyone stuck on hold right now?
+
+List currently active calls alongside a queue's agents — a queue with
+active calls but no logged-in agents is the signal, not call count alone.
+
+### Cover for someone who's out
+
+1. List forwarding/presence profiles available to the user to see what
+   options exist.
+2. Confirm with the requester exactly which profile and which extension.
+3. Select/activate the profile — this is a write action; get explicit
+   confirmation first.
+
+### Shift-change staffing check
+
+1. List queues the user can access/manage, then list each queue's agents.
+2. If staffing needs to change, log the specific agent in or out — again,
+   confirm the agent and queue before calling it.
+
+## Gotchas
+
+- **Recordings and voicemail lists are scoped to "available to the
+  authenticated user."** That's the 3CX account that approved the OAuth
+  connection, not the technician driving Claude — what shows up depends on
+  whose connection this is, not who's asking.
+- **Profile and queue-login state is per-user or per-queue.** Confirm the
+  exact ID before switching anything; there's no confirmation step inside
+  the tool itself.
+
+## Related Skills
+
+- [API Patterns](../api-patterns/SKILL.md) — permission inheritance and connection setup
+- [Directory & Contacts](../directory/SKILL.md) — resolving who an extension or call belongs to
+- [PBX Admin & Diagnostics](../pbx-admin/SKILL.md) — department/queue configuration and system-level diagnostics

--- a/msp-claude-plugins/3cx/3cx/skills/directory/SKILL.md
+++ b/msp-claude-plugins/3cx/3cx/skills/directory/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: "3CX Directory & Contacts"
+description: >
+  3CX's read-only directory surface: resolving a caller by email or by exact
+  extension, searching the PBX's own phonebooks, searching contacts synced
+  from an integrated CRM, and listing PBX users/extensions.
+when_to_use: >-
+  When looking up who a phone number, extension, or email address belongs to
+  inside 3CX, or when listing the PBX's users and extensions. Use when: 3cx
+  contact, 3cx extension, 3cx phonebook, 3cx directory, find caller 3cx, who
+  is this extension, or 3cx user list.
+---
+
+# 3CX Directory & Contacts
+
+## Overview
+
+3CX exposes read-only lookups across three sources: the PBX's own
+phonebooks (company and personal entries), the PBX's user/extension list,
+and — where the PBX has a CRM connector configured — contacts synced in
+from that CRM. All of it is read-only; nothing in this skill creates or
+edits a contact or extension.
+
+## Anti-triggers
+
+- **The CRM record itself** — this skill only reads what 3CX has synced in
+  or is querying live from a connected CRM. To create or edit the actual
+  CRM contact, use `hubspot-contacts` or `salesbuildr-companies-contacts`.
+- **The client's documentation record** — extension lists and phone trees
+  that belong in runbooks live in `hudu-companies`, not here.
+
+## Capabilities
+
+Exact tool names are not published by 3CX — see the `api-patterns` skill
+for why, and call `tools/list` for the authoritative names on a connected
+PBX. The read-only capabilities this skill covers:
+
+- Find a contact by email
+- Find a contact by exact extension
+- Search CRM-integrated contacts
+- Search 3CX phonebooks
+- List PBX users/extensions
+
+## Common Workflows
+
+### Resolve a caller
+
+1. If you have an email address or an exact extension number, use the
+   matching exact-match lookup first — it's the most reliable signal.
+2. If that comes back empty, fall back to a phonebook search or a
+   CRM-integrated contact search for a partial or fuzzy match.
+3. If you only have a name, search the phonebook and the CRM-integrated
+   contacts in parallel — one may have an entry the other doesn't.
+
+### Cross-reference with the PSA or CRM
+
+A miss on CRM-integrated contact search means "not synced to this PBX,"
+not "doesn't exist in the CRM." The sync is whatever CRM connector is
+configured on that specific PBX — confirm the connector is active before
+concluding a contact genuinely doesn't exist anywhere.
+
+## Gotchas
+
+- **Extension lookup is exact-match, not fuzzy.** A partial or
+  slightly-wrong extension number won't resolve — fall back to the user
+  list or a phonebook search instead of retrying the same lookup.
+- **CRM-integrated results reflect the PBX's own sync, not a live CRM
+  query.** Staleness depends entirely on how that PBX's CRM connector is
+  configured — this skill has no visibility into that connector's refresh
+  interval.
+
+## Related Skills
+
+- [API Patterns](../api-patterns/SKILL.md) — connection setup and tool discovery
+- [Calls, Queues & Profiles](../calls-queues/SKILL.md) — what a resolved contact is doing right now (on a call, in a queue)

--- a/msp-claude-plugins/3cx/3cx/skills/pbx-admin/SKILL.md
+++ b/msp-claude-plugins/3cx/3cx/skills/pbx-admin/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: "3CX PBX Admin & Diagnostics"
+description: >
+  3CX's system-and-configuration surface: server time, PBX event log and
+  application log search, service status, database schema and the
+  read-only SELECT-only Query tool, DIDs, IP and phone blocklists, SIP
+  trunks, call flow apps, and the configuration write/delete actions that
+  change what calls the PBX accepts or how they route.
+when_to_use: >-
+  When diagnosing a PBX-level issue, auditing PBX configuration, running a
+  read-only query against PBX data, or changing blocklist, blacklist, or
+  DID assignment. Use when: 3cx diagnostics, 3cx event log, 3cx services,
+  3cx query, 3cx blocklist, 3cx blacklist, 3cx did, 3cx sip trunk, or 3cx
+  call flow.
+---
+
+# 3CX PBX Admin & Diagnostics
+
+## Overview
+
+This is the plugin's system-level surface: diagnostics, the PBX's own
+configuration inventory, a restricted database query tool, call flow app
+details, and the smaller set of write/delete actions that change what
+calls the PBX will accept or how they route.
+
+## Read-Only Capabilities
+
+Exact tool names are not published by 3CX — see the `api-patterns` skill
+and call `tools/list` for the authoritative names on a connected PBX.
+
+**System and diagnostics**
+
+- Get current PBX server time
+- Search/list structured PBX event log
+- List PBX services and their state
+- Search application logs
+
+**PBX inventory and database**
+
+- Describe a database table's schema
+- List DIDs
+- List IP blocklist entries
+- List configured PBX peers
+- List phone blacklist entries
+- List accessible database tables
+- List configured SIP trunks
+- Run a read-only SQL `SELECT` query (the `Query` tool)
+
+**Call flow tools**
+
+- Get a call flow app's details
+- Get a call flow app's files
+- Get an edit URL for a supported PBX object
+- List call flow apps
+
+### The Query tool
+
+The `Query` tool is hard-restricted server-side to read-only SQL `SELECT`
+statements, regardless of the connecting account's 3CX role — this holds
+even for an account that could otherwise change configuration. That
+restriction is enforced inside the PBX itself.
+
+It is *not* automatically safe from a Conduit-permission standpoint,
+though, if this PBX is reached through Conduit's BYO connector rather than
+a direct connection: Conduit's tiering heuristic reads the tool's *name*,
+not the PBX's server-side enforcement. See the `api-patterns` skill's
+section on BYO tool tiering — if the tool's real name doesn't start with a
+recognized read verb, Conduit will still gate it as `write`. Check the
+tool's actual granted tier rather than assuming `SELECT`-only implies
+`read`.
+
+## Write/Delete Capabilities — Read This Before Calling Any of Them
+
+- Add an IP address to the IP blocklist
+- Add a number to the phone blacklist
+- Assign a DID
+- Remove an IP blocklist entry
+- Remove a phone blacklist entry
+
+These directly change what calls and traffic the PBX accepts. An
+incorrect IP blocklist entry can cut off a legitimate SIP trunk or a
+remote worker's softphone. An incorrect DID assignment can silently
+misroute inbound calls for an entire department, and nobody notices until
+a customer calls in complaining the call never arrived. Treat these
+exactly like any other production network-ACL or routing change: confirm
+the exact value — the IP, the number, the DID — with the requester before
+calling, and don't let a scheduled or unattended agent apply them.
+
+## Common Workflows
+
+### PBX health check
+
+1. Get current PBX server time (confirms basic connectivity/liveness).
+2. List PBX services and their state.
+3. Search the structured event log for the recent window, looking for a
+   pattern rather than a single isolated entry.
+
+### Audit inbound call routing
+
+1. List DIDs.
+2. List call flow apps and get the details of any that own a DID under
+   review.
+3. Cross-reference against the queues/departments the DID should reach
+   (see the `calls-queues` skill).
+
+### "Why is this number blocked?"
+
+1. List phone blacklist entries and IP blocklist entries.
+2. If the number or IP is present and shouldn't be, remove it — confirm
+   the exact value with the requester first; this is a write action.
+
+### Ad hoc read-only report
+
+1. List accessible database tables, then describe the relevant table's
+   schema before writing a query.
+2. Run the query through the `Query` tool. It can only `SELECT` — there is
+   no path from this tool to a data change.
+
+## Gotchas
+
+- **`Query` is `SELECT`-only inside the PBX no matter what** — but don't
+  assume that guarantees a `read` tier if this PBX is reached through
+  Conduit's BYO connector (see above).
+- **The call-flow "edit URL" tool hands back a link into the PBX's own web
+  UI.** Treat it like any other admin-console link — something a human
+  reviews and clicks, not something to feed into further automation
+  unreviewed.
+- **This is Alpha software** (3CX V20 Update 10 Alpha). Configuration tool
+  behavior in particular is worth re-verifying against a real PBX rather
+  than trusting this description months after it was written.
+
+## Related Skills
+
+- [API Patterns](../api-patterns/SKILL.md) — connection setup, permission inheritance, and BYO tool tiering
+- [Calls, Queues & Profiles](../calls-queues/SKILL.md) — department/queue membership this configuration feeds into

--- a/msp-claude-plugins/docs/scripts/generate-plugins.ts
+++ b/msp-claude-plugins/docs/scripts/generate-plugins.ts
@@ -73,6 +73,7 @@ function deriveVendor(sourcePath: string): string {
     sherweb: 'Sherweb',
     'email-security': 'Email Security',
     'saas-alerts': 'SaaS Alerts',
+    '3cx': '3CX',
   };
 
   return vendorMap[topLevel] ?? capitalize(topLevel);
@@ -134,6 +135,7 @@ function deriveDisplayName(pluginJsonName: string | undefined, marketplaceName: 
     'm365': 'Microsoft 365',
     'rootly': 'Rootly',
     'cipp': 'CIPP',
+    '3cx': '3CX',
   };
 
   return nameMap[marketplaceName] ?? humanize(marketplaceName);

--- a/msp-claude-plugins/docs/src/data/plugins.ts
+++ b/msp-claude-plugins/docs/src/data/plugins.ts
@@ -45,6 +45,39 @@ export interface ApiInfo {
 
 export const plugins: Plugin[] = [
   {
+    id: '3cx',
+    name: '3CX',
+    vendor: '3CX',
+    description: '3CX - native PBX MCP server: directory/contacts, calls, queues, profiles, and PBX admin/diagnostics (V20 Update 10, Alpha)',
+    category: 'productivity',
+    maturity: 'beta',
+    features: [
+      'Calls Queues',
+      'Directory',
+      'Pbx Admin'
+    ],
+    skills: [
+      { name: 'calls-queues', description: '3CX\'s live-operations surface: read-only visibility into active calls, recordings, voicemail, department and queue membership, and forwarding/presence profiles, plus the write actions that change live call routing — dropping a call, switching a profile, and logging a queue agent in or out.' },
+      { name: 'directory', description: '3CX\'s read-only directory surface: resolving a caller by email or by exact extension, searching the PBX\'s own phonebooks, searching contacts synced from an integrated CRM, and listing PBX users/extensions.' },
+      { name: 'pbx-admin', description: '3CX\'s system-and-configuration surface: server time, PBX event log and application log search, service status, database schema and the read-only SELECT-only Query tool, DIDs, IP and phone blocklists, SIP trunks, call flow apps, and the configuration write/delete actions that change what calls the PBX accepts or how they route.' },
+      { name: 'api-patterns', description: '3CX\'s native PBX MCP server: the per-PBX endpoint shape (every PBX is its own FQDN and its own OAuth authorization server — there is no shared mcp.3cx.com), the Admin Console + client setup flow, the permission model (fully inherited from the 3CX account that approved the connection), and how to discover the live tool surface since 3CX has not published exact tool-name strings.' }
+    ],
+    agents: [],
+    commands: [
+      { name: '/find-contact', description: 'Resolve a 3CX contact or extension by email, extension, or name' },
+      { name: '/pbx-health-check', description: 'Quick health check for a connected 3CX PBX' },
+      { name: '/queue-status', description: 'Snapshot of 3CX queue staffing and active call load' }
+    ],
+    apiInfo: {
+      baseUrl: '',
+      auth: '',
+      rateLimit: '',
+      docsUrl: ''
+    },
+    path: '3cx/3cx',
+    compatibility: { claudeCode: true, claudeDesktop: true, validated: false }
+  },
+  {
     id: 'abnormal-security',
     name: 'Abnormal Security',
     vendor: 'Abnormal',

--- a/scripts/unanchored-docs.json
+++ b/scripts/unanchored-docs.json
@@ -11,6 +11,7 @@
   ],
   "_seeded": "2026-08-06, from the state left by #181/#195/#196/#202/#204/#205.",
   "units": {
+    "3cx:skills/api-patterns": "names no MCP tool; 0 HTTP endpoint(s), 1 CLI flag(s) — first at skills/api-patterns/SKILL.md:84 --scope",
     "abnormal-security:commands/search-threats.md": "names no MCP tool; 1 HTTP endpoint(s), 7 CLI flag(s) — first at commands/search-threats.md:25 GET /v1/threats",
     "abnormal-security:commands/threat-triage.md": "names no MCP tool; 1 HTTP endpoint(s), 6 CLI flag(s) — first at commands/threat-triage.md:25 GET /v1/threats",
     "atera:commands/create-monitor.md": "names no MCP tool; 4 HTTP endpoint(s), 6 CLI flag(s) — first at commands/create-monitor.md:284 GET /api/v3/agents/{agentId}",


### PR DESCRIPTION
## Summary

Adds a plugin for **3CX's native PBX MCP server**, introduced in **3CX V20 Update 10** (announced July 30, 2026 as an **Alpha** release — 3CX's own release notes describe it as "intended for testing and evaluation only"). This is a first-party server built into the PBX itself, distinct from the older third-party `SSIG-IT/3cx-mcp-server` community project on GitHub — the two are not conflated anywhere in this plugin, and no claim from the community project (including its "Enterprise/Enterprise Plus license required" note) is carried over, since it isn't confirmed for 3CX's native offering.

**Why this is a plugin now, and why it looks different from other plugins here:** every 3CX PBX exposes its own MCP endpoint at its own FQDN (`https://yourpbx.3cx.eu/mcp` pattern) with its own OAuth authorization server — there's no shared `mcp.3cx.com`. That means it doesn't fit Conduit's single-shared-endpoint vendor catalog (`src/credentials/vendor-config.ts` has no `3cx` entry, and structurally can't in the normal sense). So this plugin documents **two** real connection paths instead of shipping a `.mcp.json`:

1. **Direct, standalone** — `claude mcp add --transport http` straight at a PBX's own URL, OAuth done directly against that PBX.
2. **Through Conduit's BYO MCP feature** (`/connect/byo`) — generic, vendor-agnostic code (`src/byo/*`) that auto-discovers the PBX's OAuth flow (RFC 9728 → RFC 8414 → RFC 7591 DCR, RFC 9207 issuer validation) and auto-classifies each tool's permission tier from its name/description (`src/byo/byo-tool-classifier.ts`), since there's no hand-curated `VENDOR_TOOL_CONFIG` entry to read from.

`GOVERNANCE.md` works through what that BYO classifier heuristic actually does to 3CX's documented tool groups (verified directly against the real source in `wyre-technology/conduit`, not assumed) — including a genuine, non-obvious gap: the `Query` tool is enforced `SELECT`-only *inside the PBX* regardless of role, but Conduit's classifier tiers on the tool's *name*. If that name doesn't lead with a recognized read verb, it tiers `write` despite the PBX-side restriction — a usability gap, not a safety one, but worth knowing before assuming a `read`-tier grant reaches it.

3CX has not published exact MCP tool-name strings anywhere I could access — only human-readable capability labels in its own "MCP Tools and Permissions Reference." Every skill here describes tools by capability rather than inventing snake_case identifiers, and points at calling `tools/list` against the live PBX as the authoritative source.

## What was added

**Category:** `productivity` — no telephony/UC/voip category exists in this repo's taxonomy (checked: accounting, bcdr, crm, documentation, email-security, incident-management, infrastructure, knowledge, legal, marketplace, monitoring, network, psa, psa-rmm, rmm, sales, security, workflow-pack). `network` is specifically network-device monitoring (Auvik/Domotz/Meraki), not a fit for a phone system. `productivity` already houses Slack — another communications/collaboration platform — so 3CX mirrors that placement rather than forcing a new category.

**Directory:** `msp-claude-plugins/3cx/3cx/`

- `skills/api-patterns` — connection setup (direct + Conduit BYO), the inherited permission model, and how to discover the live tool surface
- `skills/directory` — contact/extension lookups (email, exact extension, phonebook, CRM-synced)
- `skills/calls-queues` — active calls, recordings, voicemail, queue/department/profile visibility, plus the write actions that change live routing (with explicit caution language)
- `skills/pbx-admin` — system diagnostics, PBX inventory/database, the read-only `Query` tool, call flow apps, and blocklist/blacklist/DID write actions (with explicit caution language)
- `commands/find-contact.md`, `commands/pbx-health-check.md`, `commands/queue-status.md`
- `GOVERNANCE.md`, `README.md`

No subagent — checked the closest analogues in this repo (vendors running their *own* hosted/native MCP server rather than a WYRE-built one: `pax8`, `rootly`, `runzero`; `connectwise-cpq` is WYRE-built, not a vendor-hosted analogue, so it wasn't used as a pattern source). None of those three ship a populated `agents/` directory — matching that precedent, this plugin ships skills + commands only.

No `.env.example` and no `.mcp.json` — every connection is OAuth against a PBX-specific URL with no static token or shared endpoint to template, matching the `wyre-gateway` plugin's precedent (pure OAuth, no headers/secrets) rather than the API-key `.env.example` pattern used by token-based vendors.

`plugin.json` starts at `0.1.0`, matching the actual starting-version convention of the three most recently added vendor-hosted-MCP plugins (`axcient`, `rootly`, `runzero` all shipped `0.1.0` initially, not `1.0.0`).

Also touched: `docs/scripts/generate-plugins.ts` (added a `3cx` → `3CX` display-name mapping so the docs site doesn't title-case it as "3cx"), `docs/src/data/plugins.ts` (regenerated), `scripts/unanchored-docs.json` (one new inventoried entry — see verification below).

## Verification

All commands run from the repo root in a clean worktree off `origin/main`, after committing.

**1. Docs-site regen + build** (`docs/`, using `--ignore-scripts` locally because `sharp`'s native build fails on this machine regardless of Node version 22/26 — pre-existing, unrelated to this change, and self-heals via the `deploy-docs.yml` workflow's `npm ci` on Node 20):

```
$ npx tsx scripts/generate-plugins.ts
Generated .../docs/src/data/plugins.ts with 81 plugins
Categories: accounting, bcdr, crm, documentation, email-security, incident-management, infrastructure, legal, marketplace, monitoring, network, productivity, psa, rmm, sales, security, workflow-pack
Generated .../docs/src/data/sharedSkills.ts with 5 shared skills
```

Plugin count moved 80 → 81 in the generated data (confirmed by diffing against `git show HEAD~1`). The new entry:

```
id: '3cx', name: '3CX', vendor: '3CX', category: 'productivity', maturity: 'beta'
skills: [calls-queues, directory, pbx-admin, api-patterns]  (4)
agents: []  (0)
commands: [/find-contact, /pbx-health-check, /queue-status]  (3)
```

Full `npx astro build` + `npx pagefind --site dist` (site build + search index, the parts of `npm run build` that don't need `sharp`) also completed clean: 159 pages including `/plugins/3cx/`, homepage hero shows "81 Plugins" / "365 skills" (was 80/361 before).

**2. Marketplace drift + bump gate:**

```
$ node scripts/check-marketplace-drift.mjs --base origin/main
bump gate: compared HEAD against merge base 9a557b25d135 (14 changed files, 1 plugins touched)
✔ marketplace drift check passed (82 entries)
```

**3. Doc-reference resolution:**

```
$ node scripts/check-doc-references.mjs --verbose
inventory: 82 plugins, 1302 resolvable ids, 212 skill slugs, 165 plugin aliases
scanned 1283 files, 1537 skill-shaped references
✔ reference check passed (1537 skill-shaped references across 1283 files resolve against 1302 ids from 82 plugins)
```

(Caught and fixed one real issue along the way: an early draft backtick-referenced `` `3cx-mcp-server` `` inside an Anti-triggers bullet, which this check correctly flagged as a dangling skill-id-shaped reference. Reworded to italics since it's naming an external GitHub project, not a sibling skill.)

**4. Tool anchoring:**

```
$ node scripts/check-tool-anchoring.mjs
✔ tool-anchoring check passed (835 skills/agents/commands; 158 un-anchored, all inventoried)
```

One new unit is in the inventory: `3cx:skills/api-patterns`, flagged for the `claude mcp add --scope project --transport http ...` setup command (a real CLI invocation, not a 3CX API operation — there's no MCP tool to anchor it to). This is the same class of exception the script's own design accounts for (see `pax8:commands/search-products.md`, already inventoried for the same reason — hyphenated tool names the script's snake_case regex can't see). Added via `node scripts/check-tool-anchoring.mjs --update`, which produced a clean, purely-additive one-line diff to `scripts/unanchored-docs.json`.

**5. Plugin validation:**

```
$ claude plugin validate .
Validating marketplace manifest: .../marketplace.json
✔ Validation passed

$ claude plugin validate msp-claude-plugins/3cx/3cx
Validating plugin manifest: .../3cx/3cx/.claude-plugin/plugin.json
✔ Validation passed
```

Also ran `claude plugin validate` across all 82 registered plugins (mirroring the CI loop in `validate.yml`) to confirm the `generate-plugins.ts` display-name edit didn't regress anything else: **0 failed out of 82**.

**6. Sanity checks:**

- No `.mcp.json` anywhere under `msp-claude-plugins/3cx/` (confirmed via `find`).
- No `triggers:` field in any `SKILL.md` frontmatter (confirmed via `grep`).
- No `version` field on the new marketplace entry (only `plugin.json` carries version).

Not merging — leaving this for review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/msp-claude-plugins/pr/225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->